### PR TITLE
Treat an empty command as `status`

### DIFF
--- a/lib/gitsh/cli.rb
+++ b/lib/gitsh/cli.rb
@@ -28,6 +28,9 @@ module Gitsh
 
     def read_command
       command = readline.readline(prompt, true)
+      if command && command.empty?
+        command = 'status'
+      end
       command != 'exit' && command
     end
 

--- a/spec/integration/default_command_spec.rb
+++ b/spec/integration/default_command_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'Entering no command' do
+  it 'runs `git status`' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type('init')
+      gitsh.type('')
+
+      expect(gitsh).to output /nothing to commit/
+    end
+  end
+end


### PR DESCRIPTION
Hitting return with no command will now show a lovely `git status` instead of a usage message.
