### PR TITLE
Add support for --version

### DIFF
--- a/lib/gitsh/cli.rb
+++ b/lib/gitsh/cli.rb
@@ -1,17 +1,36 @@
 require 'readline'
+require 'gitsh/version'
 require 'gitsh/git_driver'
 require 'gitsh/prompter'
 require 'gitsh/completer'
 
 module Gitsh
   class CLI
-    def initialize(output=$stdout, error=$stderr, readline=Readline)
+    EX_USAGE = 64
+
+    def initialize(args=ARGV, output=$stdout, error=$stderr, readline=Readline)
+      @args = args
       @output = output
       @error = error
       @readline = readline
     end
 
     def run
+      if args == %w(--version)
+        output.puts VERSION
+      elsif args.any?
+        error.puts 'usage: gitsh [--version]'
+        exit EX_USAGE
+      else
+        run_interactive
+      end
+    end
+
+    private
+
+    attr_reader :output, :error, :readline, :args
+
+    def run_interactive
       readline.completion_append_character = nil
       readline.completion_proc = Completer.new(readline)
 
@@ -21,10 +40,6 @@ module Gitsh
 
       output.print "\n"
     end
-
-    private
-
-    attr_reader :output, :error, :readline
 
     def read_command
       command = readline.readline(prompt, true)

--- a/spec/integration/arguments_spec.rb
+++ b/spec/integration/arguments_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'gitsh/cli'
+
+describe '--version' do
+  it 'outputs the version, and then exits' do
+    output = StringIO.new
+    error = StringIO.new
+
+    Gitsh::CLI.new(%w(--version), output, error).run
+
+    expect(error.string).to be_empty
+    expect(output.string.chomp).to eq Gitsh::VERSION.to_s
+  end
+end
+
+describe 'Unexpected arguments' do
+  it 'outputs a usage message, and then exits' do
+    output = StringIO.new
+    error = StringIO.new
+
+    runner = lambda { Gitsh::CLI.new(%w(--badger), output, error).run }
+
+    expect(runner).to raise_error SystemExit
+    expect(output.string).to be_empty
+    expect(error.string.chomp).to eq 'usage: gitsh [--version]'
+  end
+end

--- a/spec/support/gitsh_runner.rb
+++ b/spec/support/gitsh_runner.rb
@@ -22,7 +22,7 @@ class GitshRunner
 
       Thread.abort_on_exception = true
       runner = Thread.new do
-        Gitsh::CLI.new(output_stream, error_stream, readline).run
+        Gitsh::CLI.new([], output_stream, error_stream, readline).run
       end
 
       wait_for_prompt


### PR DESCRIPTION
- When invoked with no arguments, run as before
- When invoked with `--version`, output the version
- When invoked with any other arguments, output a usage message

The version is sent to `$stderror`, which might be controversial. Some programs go one way, some go the other.
