### PR TITLE
Use the rb-readline gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby '2.0.0'
 
 group :dist do
   gem 'parslet'
+  gem 'rb-readline'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
       metaclass (~> 0.0.1)
     parslet (1.5.0)
       blankslate (~> 2.0)
+    rb-readline (0.5.1)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -25,4 +26,5 @@ PLATFORMS
 DEPENDENCIES
   bourne
   parslet
+  rb-readline
   rspec


### PR DESCRIPTION
System Ruby on BSD-like systems (including Mac OS X) ships with libedit instead of readline. Unfortunately, libedit is buggy and lacking in features. Using a pure-Ruby implementation of readline gives a consistent experience to all users, without having to faff around upgrading system components.

I've been using this for a few days, and it is definitely better than libedit and not noticeably different to GNU readline.
