### PR TITLE
Fix homebrew install for Ruby < 2.0

### DIFF
--- a/homebrew/gitsh.rb.in
+++ b/homebrew/gitsh.rb.in
@@ -1,16 +1,23 @@
 require 'formula'
 
 class Gitsh < Formula
+  SYSTEM_RUBY_PATH = '/usr/bin/ruby'
+
   homepage 'http://thoughtbot.github.io/@PACKAGE@/'
   url 'http://thoughtbot.github.io/@PACKAGE@/@DIST_ARCHIVES@'
   sha1 '@DIST_SHA@'
 
-  system_ruby_version = `/usr/bin/ruby -e "puts RUBY_VERSION"`.chomp
-  if system_ruby_version < '2.0.0'
+  def self.old_system_ruby?
+    system_ruby_version = `#{SYSTEM_RUBY_PATH} -e "puts RUBY_VERSION"`.chomp
+    system_ruby_version < '2.0.0'
+  end
+
+  if old_system_ruby?
     depends_on 'Ruby'
   end
 
   def install
+    set_ruby_path
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
@@ -20,5 +27,15 @@ class Gitsh < Formula
 
   test do
     system "#{bin}/gitsh", "--version"
+  end
+
+  private
+
+  def set_ruby_path
+    if self.class.old_system_ruby?
+      ENV['RUBY'] = "#{HOMEBREW_PREFIX}/bin/ruby"
+    else
+      ENV['RUBY'] = SYSTEM_RUBY_PATH
+    end
   end
 end


### PR DESCRIPTION
Homebrew was detecting the system Ruby version correctly and adding a dependency on Homebrew Ruby if it was < 2.0, but the configure script was still heavily biased towards picking system Ruby.

This explicitly passed the Ruby path from the Homebrew formula to the configure script to ensure the Ruby version chosen by Homebrew is used.
