### PR TITLE
User-defined status command

### DIFF
--- a/lib/gitsh/cli.rb
+++ b/lib/gitsh/cli.rb
@@ -57,7 +57,7 @@ module Gitsh
     def read_command
       command = readline.readline(prompt, true)
       if command && command.empty?
-        'status'
+        env.fetch('gitsh.defaultCommand', 'status')
       else
         command
       end

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -139,6 +139,10 @@ section above for details.
 If this is set to
 .Ic true
 then no greeting message will be displayed when gitsh starts.
+.It Ic gitsh.defaultCommand
+The command that will be run when a user presses return without entering any
+command. By default this is
+.Ic status .
 .El
 .
 .Sh ENVIRONMENT

--- a/spec/integration/default_command_spec.rb
+++ b/spec/integration/default_command_spec.rb
@@ -9,4 +9,20 @@ describe 'Entering no command' do
       expect(gitsh).to output /nothing to commit/
     end
   end
+
+  it 'can be overriden using a git-config variable' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type('init')
+      gitsh.type('config --local gitsh.defaultCommand "show HEAD"')
+      gitsh.type('commit --allow-empty -m First')
+      gitsh.type('')
+
+      expect(gitsh).to output /First/
+
+      gitsh.type('commit --allow-empty -m Second')
+      gitsh.type('')
+
+      expect(gitsh).to output /Second/
+    end
+  end
 end


### PR DESCRIPTION
I'd really rather see `status -sb` over `status`. It would be awesome to either be able to define flags for the status command, or to be able to completely customize the command that's run when no command is entered. It could still default to status, but you could theoretically also set it up to run `git log -n 5` if you wanted to.
