### PR TITLE
ctrl+c shouldn't output the welcome message

### DIFF
--- a/lib/gitsh/cli.rb
+++ b/lib/gitsh/cli.rb
@@ -37,21 +37,26 @@ module Gitsh
 
     def run_interactive
       history.load
+      setup_readline
+      greet_user
+      interactive_loop
+    ensure
+      history.save
+    end
+
+    def setup_readline
       readline.completion_append_character = nil
       readline.completion_proc = Completer.new(readline, env)
+    end
 
-      greet_user
-
+    def interactive_loop
       while command = read_command
         interpreter.execute(command)
       end
-
       env.print "\n"
     rescue Interrupt
       env.print "\n"
       retry
-    ensure
-      history.save
     end
 
     def read_command
@@ -109,8 +114,7 @@ module Gitsh
 
     def greet_user
       unless env['gitsh.noGreeting'] == 'true'
-        env.puts "gitsh #{Gitsh::VERSION}"
-        env.puts "Type :exit to exit"
+        env.puts "gitsh #{Gitsh::VERSION}\nType :exit to exit"
       end
     end
   end

--- a/spec/units/cli_spec.rb
+++ b/spec/units/cli_spec.rb
@@ -40,5 +40,6 @@ describe Gitsh::CLI do
     expect(interpreter).to have_received(:execute).twice
     expect(interpreter).to have_received(:execute).with('a')
     expect(interpreter).to have_received(:execute).with('b')
+    expect(env).to have_received(:puts).once
   end
 end


### PR DESCRIPTION
ctrl+c cancels the current command, but also currently outputs the welcome message.
