### PR TITLE
Change `current_branch_name` to use short branch name.

### DIFF
--- a/lib/gitsh/git_repository.rb
+++ b/lib/gitsh/git_repository.rb
@@ -54,7 +54,10 @@ module Gitsh
     private
 
     def current_branch_name
-      git_output('symbolic-ref HEAD').split('/').last
+      branch_name = git_output('symbolic-ref HEAD --short')
+      unless branch_name.empty?
+        branch_name
+      end
     end
 
     def current_tag_name

--- a/spec/units/git_repository_spec.rb
+++ b/spec/units/git_repository_spec.rb
@@ -28,6 +28,15 @@ describe Gitsh::GitRepository do
       end
     end
 
+    it 'returns the name of the current git branch with a forward slash' do
+      in_a_temporary_directory do
+        repo = Gitsh::GitRepository.new
+        run 'git init'
+        run 'git checkout -b feature/foo'
+        expect(repo.current_head).to eq 'feature/foo'
+      end
+    end
+
     it 'returns the name of an annotated tag if there is no branch' do
       in_a_temporary_directory do
         repo = Gitsh::GitRepository.new


### PR DESCRIPTION
Having a branch such as `feature/full_branch_name` only reports the branch name as `full_branch_name`. This gives you the full branch name.

Honestly I didn't run the specs locally I keep getting a weird error.

```
blaineschmeisser@Blaines-MacBook-Pro [11:10:20] [~/sites/devup/apps/gitsh] [feature/full_branch_name]
-> % ./autogen.sh 
configure.ac:4: error: Autoconf version 2.69 or higher is required
configure.ac:4: the top level
autom4te: /usr/bin/gm4 failed with exit status: 63
aclocal: /usr/bin/autom4te failed with exit status: 63
blaineschmeisser@Blaines-MacBook-Pro [11:10:25] [~/sites/devup/apps/gitsh] [feature/full_branch_name]
-> % autoconf --version
autoconf (GNU Autoconf) 2.69
Copyright (C) 2012 Free Software Foundation, Inc.
License GPLv3+/Autoconf: GNU GPL version 3 or later
<http://gnu.org/licenses/gpl.html>, <http://gnu.org/licenses/exceptions.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by David J. MacKenzie and Akim Demaille.
```
