### PR TITLE
Support Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - "1.9.3"
   - "2.0.0"
 install: bundle install && ./autogen.sh && git config --global user.name 'Travis' && git config --global user.email 'travis@example.com'
 script: RUBY=$(which ruby) ./configure && make && bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '2.0.0'
-
 group :dist do
   gem 'parslet'
 end

--- a/arch/PKGBUILD.in
+++ b/arch/PKGBUILD.in
@@ -6,7 +6,7 @@ pkgdesc='An interactive shell for git'
 arch=('any')
 url="http://thoughtbot.github.io/@PACKAGE@/"
 license=('custom')
-depends=('ruby>=2.0')
+depends=('ruby>=1.9.3')
 source=("http://thoughtbot.github.io/@PACKAGE@/@DIST_ARCHIVES@")
 sha1sums=('@DIST_SHA@')
 

--- a/configure.ac
+++ b/configure.ac
@@ -19,9 +19,9 @@ if test -n $RUBY; then
 fi
 
 AX_PROG_RUBY_VERSION(
-  [2.0],
+  [1.9.3],
   [],
-  AC_MSG_ERROR(Ruby 2.0 or later is required to install gitsh)
+  AC_MSG_ERROR(Ruby 1.9.3 or later is required to install gitsh)
 )
 
 newer=$(ls -t $srcdir/Gemfile.lock $srcdir/vendor/gems/setup.rb 2>/dev/null | (read n; echo $n))

--- a/homebrew/gitsh.rb.in
+++ b/homebrew/gitsh.rb.in
@@ -10,7 +10,7 @@ class Gitsh < Formula
 
   def self.old_system_ruby?
     system_ruby_version = `#{SYSTEM_RUBY_PATH} -e "puts RUBY_VERSION"`.chomp
-    system_ruby_version < '2.0.0'
+    system_ruby_version < '1.9.3'
   end
 
   if old_system_ruby?

--- a/lib/gitsh/git_command.rb
+++ b/lib/gitsh/git_command.rb
@@ -12,7 +12,7 @@ module Gitsh
       git = Shellwords.split(env.git_command)
       config_arguments = env.config_variables.map { |k,v| ['-c', "#{k}=#{v}"] }
       cmd = [git, config_arguments, sub_command, args].flatten
-      pid = Process.spawn(*cmd, out: env.output_stream, err: env.error_stream)
+      pid = Process.spawn(*cmd, out: env.output_stream.to_i, err: env.error_stream.to_i)
       Process.wait(pid)
     end
 

--- a/spec/units/git_command_spec.rb
+++ b/spec/units/git_command_spec.rb
@@ -5,8 +5,8 @@ describe Gitsh::GitCommand do
   let(:env) do
     stub('Environment', {
       git_command: '/usr/bin/env git',
-      output_stream: stub,
-      error_stream: stub
+      output_stream: stub(to_i: 1),
+      error_stream: stub(to_i: 2)
     })
   end
 
@@ -23,8 +23,8 @@ describe Gitsh::GitCommand do
         '/usr/bin/env', 'git',
         'commit',
         '-m', 'A test commit',
-        out: env.output_stream,
-        err: env.error_stream
+        out: env.output_stream.to_i,
+        err: env.error_stream.to_i
       )
     end
 
@@ -43,8 +43,8 @@ describe Gitsh::GitCommand do
         '-c', 'foo.bar=1',
         'commit',
         '-m', 'A test commit',
-        out: env.output_stream,
-        err: env.error_stream
+        out: env.output_stream.to_i,
+        err: env.error_stream.to_i
       )
     end
   end

--- a/spec/units/history_spec.rb
+++ b/spec/units/history_spec.rb
@@ -42,7 +42,7 @@ describe Gitsh::History do
 
       described_class.new(env, readline).save
 
-      expect(@history_file.read.lines).to eq [
+      expect(history_file_lines).to eq [
         "init\n", "add .\n", "commit -m \"Initial\"\n"
       ]
     end
@@ -53,7 +53,7 @@ describe Gitsh::History do
 
       described_class.new(env, readline).save
 
-      expect(@history_file.read.lines).to eq [
+      expect(history_file_lines).to eq [
         "add .\n", "commit -m \"Initial\"\n"
       ]
     end
@@ -64,5 +64,9 @@ describe Gitsh::History do
       @history_file.write("#{command}\n")
     end
     @history_file.rewind
+  end
+
+  def history_file_lines
+    @history_file.each_line.to_a
   end
 end


### PR DESCRIPTION
Ruby 2.0 still isn't available in the central package repositories for many of the major Linux distributions. Supporting 1.9.3 would make installing on Linux significantly easier.
