### PR TITLE
Close list in manpage

### DIFF
--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -120,6 +120,8 @@ command.
 changes directory to the given path.
 .It Ic :exit
 ends the gitsh session.
+.El
+.
 .Sh CONFIGURATION
 The following
 .Xr git-config 1


### PR DESCRIPTION
`man` gave the following warning:

```
mdoc warning: A .Bl directive has no matching .El (#123)
```
