### PR TITLE
Fix 'Error: undefined method `sub' for nil:NilClass' when newline is included git alias

### DIFF
--- a/lib/gitsh/git_repository.rb
+++ b/lib/gitsh/git_repository.rb
@@ -42,6 +42,7 @@ module Gitsh
     def aliases
       git_output(%q(config --get-regexp '^alias\.')).
         lines.
+        grep(/^alias\./).
         map { |line| line.split(' ').first.sub(/^alias\./, '') }
     end
 

--- a/spec/units/git_repository_spec.rb
+++ b/spec/units/git_repository_spec.rb
@@ -129,8 +129,10 @@ describe Gitsh::GitRepository do
         repo = Gitsh::GitRepository.new(env)
         run 'git init'
         run 'git config --local alias.zecho "!echo zzz"'
+        run 'git config --local alias.zecho-with-newline "!echo z\nzz"'
         run 'git config --local aliasy.notanalias "not an alias"'
         expect(repo.aliases).to include 'zecho'
+        expect(repo.aliases).to include 'zecho-with-newline'
         expect(repo.aliases).not_to include 'aliasy.notanalias'
         expect(repo.aliases).not_to include 'notanalias'
       end


### PR DESCRIPTION
When there is at least one newline in git aliases like:

```
ln = log --pretty=format:'%C(blue bold)%h %C(yellow bold)%cd %C(magenta bold)%cn %C(red bold)%d\n\n%C(white bold)%s\n%Creset%b'
```

tab completion fails with 'Error: undefined method `sub' for nil:NilClass'.

This commit fixes the issue.
