### PR TITLE
Fix ReadlineBlankFilter when readline returns nil

### DIFF
--- a/lib/gitsh/readline_blank_filter.rb
+++ b/lib/gitsh/readline_blank_filter.rb
@@ -3,7 +3,7 @@ require 'gitsh/module_delegator'
 class ReadlineBlankFilter < ModuleDelegator
   def readline(prompt, add_hist = false)
     module_delegator_target.readline(prompt, add_hist).tap do |result|
-      if add_hist && result.strip.empty?
+      if add_hist && result && result.strip.empty?
         module_delegator_target::HISTORY.pop
       end
     end

--- a/spec/support/fake_readline.rb
+++ b/spec/support/fake_readline.rb
@@ -20,6 +20,10 @@ class FakeReadline < ModuleDelegator
     input_write << "#{string}\n"
   end
 
+  def send_eof
+    input_write.close
+  end
+
   def prompt
     prompt_queue.pop
   end

--- a/spec/units/readline_blank_filter_spec.rb
+++ b/spec/units/readline_blank_filter_spec.rb
@@ -33,6 +33,15 @@ describe ReadlineBlankFilter do
       expect(readline_blank_filter::HISTORY.to_a).to be_empty
     end
 
+    it 'does not enter nil lines into the history' do
+      readline_blank_filter = ReadlineBlankFilter.new(fake_readline)
+
+      fake_readline.send_eof
+      readline_blank_filter.readline('>', true)
+
+      expect(readline_blank_filter::HISTORY.to_a).to be_empty
+    end
+
     it 'does not #pop the last entry to history if add_hist is false' do
       readline_blank_filter = ReadlineBlankFilter.new(fake_readline)
 


### PR DESCRIPTION
When readline receives an EOF it returns nil. This was causing a crash when a user sent an EOF to quit gitsh.

Fixes #108 
