### PR TITLE
Allow the parser to understand upper and lower case letters.

### DIFF
--- a/lib/gitsh/parser.rb
+++ b/lib/gitsh/parser.rb
@@ -85,7 +85,7 @@ module Gitsh
     end
 
     rule(:identifier) do
-      match('[a-z]') >> match('[a-z0-9.-]').repeat(0)
+      match('[A-z]') >> match('[A-z0-9.-]').repeat(0)
     end
 
     rule(:space) do

--- a/spec/units/parser_spec.rb
+++ b/spec/units/parser_spec.rb
@@ -32,6 +32,10 @@ describe Gitsh::Parser do
       expect(parser).to parse(':set').as(internal_cmd: 'set')
     end
 
+    it 'parses upper and lower case letters' do
+      expect(parser).to parse('STATUS').as(git_cmd: 'STATUS')
+    end
+
     it 'parses a shell command with no arguments' do
       expect(parser).to parse('!pwd').as(shell_cmd: 'pwd')
     end


### PR DESCRIPTION
We should pass bad commands onto git to get the standard
"git: 'X' is not a git command. See 'git --help'." message.
# 

Interestingly, git blows up if you hand it real commands with uppercases in them:

```
$ git A
git: 'A' is not a git command. See 'git --help'.

Did you mean one of these?
    am
    co
    gc
    mv
    p4
    rm
    st

$ git ADD
fatal: cannot handle ADD internally
```
