### PR TITLE
Rework specs around completing '~'.

### DIFF
--- a/spec/support/file_system.rb
+++ b/spec/support/file_system.rb
@@ -1,12 +1,25 @@
 module FileSystemHelper
   def write_file(name, contents="Some content")
-    File.open("./#{name}", 'w') { |f| f << "#{contents}\n" }
+    File.open(name, 'w') { |f| f << "#{contents}\n" }
   end
 
   def in_a_temporary_directory(&block)
     Dir.mktmpdir do |path|
       chdir_and_allow_nesting(path, &block)
     end
+  end
+
+  def with_a_temporary_home_directory(&block)
+    orginal_home = ENV['HOME']
+
+    Dir.mktmpdir do |path|
+      ENV['HOME'] = path
+      write_file("#{path}/.inputrc", 'set bell-style none')
+      block.call
+    end
+
+  ensure
+    ENV['HOME'] = orginal_home
   end
 
   def chdir_and_allow_nesting(path)


### PR DESCRIPTION
This is because if there were no files in '~', the previous test would fail.
So instead, check for directories (which are more likely).

Also adds a test ensuring directory completion functions.
# 

This was failing for me locally. There's still the edge case that there's no directories in ~, but that seems pretty unlikely to me.
