### PR TITLE
Add an :echo

### DIFF
--- a/lib/gitsh/internal_command.rb
+++ b/lib/gitsh/internal_command.rb
@@ -45,6 +45,13 @@ module Gitsh
       end
     end
 
+    class Echo < Base
+      def execute
+        env.puts args.join(' ')
+        true
+      end
+    end
+
     class Chdir < Base
       def execute
         if valid_arguments?
@@ -92,7 +99,8 @@ module Gitsh
     COMMAND_CLASSES = {
       set: Set,
       cd: Chdir,
-      exit: Exit
+      exit: Exit,
+      echo: Echo,
     }.freeze
   end
 end

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -76,7 +76,6 @@ execute
 and then
 .Ic right.
 .El
-
 .
 .Sh PROMPT
 The prompt changes based on the status of the repository. By default it consist
@@ -123,7 +122,6 @@ would produce prompts like
 and
 .Ic (uninitialized)/home/me!!
 .Sh BUILT-IN COMMANDS
-.Pp
 Built-in commands are used to give instructions to the shell. To distinguish
 them from git commands, and to avoid collisions with git aliases and
 extensions, they are prefixed with a
@@ -157,6 +155,18 @@ variables, whether or not they were set using the
 command.
 .Bd -literal -offset indent
 @ commit -m "Commited by $user.name"
+.Ed
+.It Ic :echo string ...
+prints the given strings to standard output, followed by a newline. All
+whitespace is collapsed into one space. This can be useful for viewing
+the value of a variable:
+.Bd -literal -offset indent
+@ :echo $user.name
+.Ed
+.Pp
+Or for a mix of variables and arbitrary strings:
+.Bd -literal -offset indent
+@ :echo "This is ${user.name}'s work"
 .Ed
 .It Ic :cd path
 changes directory to the given path.

--- a/spec/integration/variables_spec.rb
+++ b/spec/integration/variables_spec.rb
@@ -58,4 +58,14 @@ describe 'Gitsh variables' do
       expect(gitsh).to output_error /usage: :set variable value/
     end
   end
+
+  it 'allows echoing of set variables' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type(':set greeting hello')
+      gitsh.type(':echo $greeting')
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to output /hello/
+    end
+  end
 end

--- a/spec/units/internal_command_spec.rb
+++ b/spec/units/internal_command_spec.rb
@@ -26,7 +26,7 @@ describe Gitsh::InternalCommand do
 
   describe '.commands' do
     it 'returns a list of recognised commands' do
-      expect(described_class.commands).to eq %w( :set :cd :exit )
+      expect(described_class.commands).to eq %w( :set :cd :exit :echo )
     end
   end
 
@@ -71,6 +71,26 @@ describe Gitsh::InternalCommand do
         command = Gitsh::InternalCommand::Set.new(env, 'set', %w(foo))
 
         expect(command.execute).to be_false
+      end
+    end
+  end
+
+  describe Gitsh::InternalCommand::Echo do
+    describe '#execute' do
+      it 'prints all arguments to the environment joined with a space' do
+        env = stub('env', puts: nil)
+        command = Gitsh::InternalCommand::Echo.new(env, 'echo', %w(foo bar))
+
+        expect(command.execute).to be_true
+        expect(env).to have_received(:puts).with('foo bar')
+      end
+
+      it 'prints a newline when no arguments are passed' do
+        env = stub('env', puts: nil)
+        command = Gitsh::InternalCommand::Echo.new(env, 'echo', [])
+
+        expect(command.execute).to be_true
+        expect(env).to have_received(:puts).with('')
       end
     end
   end


### PR DESCRIPTION
This `:echo` is much like the shell `echo`: it takes a bunch of strings
and outputs them, separated by spaces, followed by a newline.

Fixes #44.
