### PR TITLE
Don't distribute version.rb

### DIFF
--- a/lib/gitsh/Makefile.am
+++ b/lib/gitsh/Makefile.am
@@ -1,4 +1,5 @@
-dist_pkgruby_DATA = $(libfiles) version.rb
+pkgruby_DATA = version.rb
+dist_pkgruby_DATA = $(libfiles)
 CLEANFILES = version.rb
 EXTRA_DIST = version.rb.in
 


### PR DESCRIPTION
version.rb is built from version.rb.in by `make`, so it shouldn't be distributed, but it should be installed.

Should fix #133. Assuming it does, I'll release this as v1.5.1.

@mike-burns, @pbrisbin, @cippaciong: Could one of your build a tarball from this branch (`make distclean && ./autogen.sh && ./configure && make distcheck`) and the try installing from that tarball?
