### PR TITLE
Use sequence for args, as it will always be an array.

### DIFF
--- a/lib/gitsh/transformer.rb
+++ b/lib/gitsh/transformer.rb
@@ -10,7 +10,7 @@ module Gitsh
         command_class.new(context[:env], context[:cmd])
       end
 
-      rule(type => simple(:cmd), args: subtree(:args)) do |context|
+      rule(type => simple(:cmd), args: sequence(:args)) do |context|
         command_class.new(context[:env], context[:cmd], context[:args])
       end
     end


### PR DESCRIPTION
This isn't particularly important, but I think it's useful to communicate a bit better what form `args` takes.
