### PR TITLE
Add gitconfig to temporary home directory.

### DIFF
--- a/spec/support/file_system.rb
+++ b/spec/support/file_system.rb
@@ -1,4 +1,7 @@
 module FileSystemHelper
+  DEFAULT_READLINE_CONFIG = 'set bell-style none'
+  DEFAULT_GIT_CONFIG = "[user]\n  name = Test\n  email = test@example.com"
+
   def write_file(name, contents="Some content")
     File.open(name, 'w') { |f| f << "#{contents}\n" }
   end
@@ -14,7 +17,8 @@ module FileSystemHelper
 
     Dir.mktmpdir do |path|
       ENV['HOME'] = path
-      write_file("#{path}/.inputrc", 'set bell-style none')
+      write_file("#{path}/.inputrc", DEFAULT_READLINE_CONFIG)
+      write_file("#{path}/.gitconfig", DEFAULT_GIT_CONFIG)
       block.call
     end
 


### PR DESCRIPTION
Builds have been failing on Travis CI because of the temporary home directory: there was no gitconfig, and therefore no `user.name` or `user.email` settings, which prevent commits from being created under some Git versions.
