### PR TITLE
--version prints what readline lib gitsh is using

### DIFF
--- a/lib/gitsh/cli.rb
+++ b/lib/gitsh/cli.rb
@@ -104,7 +104,7 @@ module Gitsh
         end
 
         opts.on_tail('--version', 'Display the version and exit') do
-          env.puts VERSION
+          env.puts "#{VERSION} (using #{env.readline_version})"
           exit EX_OK
         end
 

--- a/lib/gitsh/environment.rb
+++ b/lib/gitsh/environment.rb
@@ -88,6 +88,13 @@ module Gitsh
       (repo.aliases + local_aliases).sort
     end
 
+    def readline_version
+      Readline.emacs_editing_mode
+      'GNU Readline'
+    rescue NotImplementedError
+      'libedit'
+    end
+
     private
 
     attr_reader :variables, :repo

--- a/spec/integration/arguments_spec.rb
+++ b/spec/integration/arguments_spec.rb
@@ -14,7 +14,8 @@ describe '--version' do
 
     expect(runner).to raise_error SystemExit
     expect(error.string).to be_empty
-    expect(output.string.chomp).to eq Gitsh::VERSION.to_s
+    expect(output.string.chomp).
+      to eq "#{Gitsh::VERSION} (using #{env.readline_version})"
   end
 end
 

--- a/spec/units/environment_spec.rb
+++ b/spec/units/environment_spec.rb
@@ -163,6 +163,22 @@ describe Gitsh::Environment do
     end
   end
 
+  describe '#readline_version' do
+    it 'returns libedit if Readline.emacs_editing_mode is not implemented' do
+      Readline.stubs(:emacs_editing_mode).raises(NotImplementedError)
+      env = described_class.new
+
+      expect(env.readline_version).to eq('libedit')
+    end
+
+    it 'returns GNU Readline if Readline.emacs_editing_mode is implemented' do
+      Readline.stubs(:emacs_editing_mode).returns(nil)
+      env = described_class.new
+
+      expect(env.readline_version).to eq('GNU Readline')
+    end
+  end
+
   context 'delegated methods' do
     let(:repo) { stub }
     let(:repo_factory) { stub(new: repo) }


### PR DESCRIPTION
This uses the hack described by @georgebrock in #144 to determine whether gitsh is using GNU Readline or libedit.
