### PR TITLE
Parse empty string arguments correctly.

### DIFF
--- a/lib/gitsh/parser.rb
+++ b/lib/gitsh/parser.rb
@@ -52,11 +52,15 @@ module Gitsh
     end
 
     rule(:argument) do
-      (soft_string | hard_string | unquoted_string).repeat(1).as(:arg)
+      (empty_string | soft_string | hard_string | unquoted_string).repeat(1).as(:arg)
     end
 
     rule(:unquoted_string) do
       (variable | match(%q([^\s'"&|;])).as(:literal)).repeat(1)
+    end
+
+    rule(:empty_string) do
+      (str('""') | str("''")).as(:empty_string)
     end
 
     rule(:soft_string) do

--- a/lib/gitsh/transformer.rb
+++ b/lib/gitsh/transformer.rb
@@ -19,6 +19,10 @@ module Gitsh
       literal
     end
 
+    rule(empty_string: simple(:empty_string)) do
+      ''
+    end
+
     rule(var: simple(:var)) do |context|
       key = context[:var]
       context[:env][key]

--- a/spec/integration/command_arguments_spec.rb
+++ b/spec/integration/command_arguments_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'Command arguments' do
+  it 'supports empty strings' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type ':echo Hello "" World'
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to output "Hello  World\n"
+    end
+  end
+end

--- a/spec/units/parser_spec.rb
+++ b/spec/units/parser_spec.rb
@@ -59,6 +59,16 @@ describe Gitsh::Parser do
       )
     end
 
+    it 'parses a command with empty string arguments' do
+      expect(parser).to parse(%q(commit '' "")).as(
+        git_cmd: 'commit',
+        args: [
+          { arg: [{ empty_string: "''" }] },
+          { arg: [{ empty_string: '""' }] }
+        ]
+      )
+    end
+
     it 'parses a command with unquoted arguments' do
       expect(parser).to parse(':set author').as(
         internal_cmd: 'set',

--- a/spec/units/transformer_spec.rb
+++ b/spec/units/transformer_spec.rb
@@ -61,6 +61,11 @@ describe Gitsh::Transformer do
       expect(output).to eq 'Jane Doe'
     end
 
+    it 'transforms empty string arguments' do
+      output = transformer.apply({ arg: [{ empty_string: "''" }] }, env: env)
+      expect(output).to eq ''
+    end
+
     it 'transforms multi commands' do
       output = transformer.apply(multi: { left: 1, right: 2 })
       expect(output).to be_a Gitsh::Tree::Multi


### PR DESCRIPTION
When the parser encountered an empty string (e.g. `""`) it was matching the `soft_string` or `hard_string` rule, but didn't include any named matches (i.e. any `literal` characters) so it returned the whole matched string instead.

After experimenting with various ways of matching the opening and closing quotes, it ended up being a smaller and more understandable change to just add a rule to explicitly match empty strings.

Fixes #139
