### PR TITLE
Fix window size bugs

### DIFF
--- a/lib/gitsh/prompter.rb
+++ b/lib/gitsh/prompter.rb
@@ -6,7 +6,7 @@ module Gitsh
 
     def initialize(options={})
       @env = options.fetch(:env)
-      @options = options
+      @use_color = options.fetch(:color, true)
     end
 
     def prompt
@@ -75,7 +75,7 @@ module Gitsh
     end
 
     def use_color?
-      @options.fetch(:color, true)
+      @use_color
     end
   end
 end

--- a/lib/gitsh/term_info.rb
+++ b/lib/gitsh/term_info.rb
@@ -1,0 +1,29 @@
+require 'singleton'
+require 'open3'
+
+module Gitsh
+  class TermInfo
+    include Singleton
+
+    def color_support?
+      tput('colors').to_i > 0
+    end
+
+    def lines
+      tput('lines').to_i
+    end
+
+    def cols
+      tput('cols').to_i
+    end
+
+    private
+
+    def tput(property)
+      output, error, exit_status = Open3.capture3("tput #{property}")
+      if exit_status.success?
+        output.chomp
+      end
+    end
+  end
+end

--- a/spec/support/gitsh_runner.rb
+++ b/spec/support/gitsh_runner.rb
@@ -3,6 +3,7 @@ require 'tempfile'
 require 'tmpdir'
 require 'gitsh/cli'
 require 'gitsh/environment'
+require 'gitsh/readline_blank_filter'
 require File.expand_path('../file_system', __FILE__)
 
 class GitshRunner
@@ -19,7 +20,7 @@ class GitshRunner
     @input_stream = stub('STDIN', tty?: true)
     @output_stream = Tempfile.new('stdout')
     @error_stream = Tempfile.new('stderr')
-    @readline = FakeReadline.new
+    @readline = ReadlineBlankFilter.new(FakeReadline.new)
     @position_before_command = 0
     @error_position_before_command = 0
     @options = options

--- a/spec/support/signalling_readline.rb
+++ b/spec/support/signalling_readline.rb
@@ -1,0 +1,17 @@
+class SignallingReadline
+  def initialize(signal)
+    @signal = signal
+  end
+
+  def readline(*args, &block)
+    Process.kill(signal, Process.pid)
+    nil
+  end
+
+  def method_missing(name, *args, &block)
+  end
+
+  private
+
+  attr_reader :signal
+end

--- a/spec/units/term_info_spec.rb
+++ b/spec/units/term_info_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+require 'gitsh/term_info'
+
+describe Gitsh::TermInfo do
+  describe '#color_support?' do
+    context 'on a 256 color terminal' do
+      it 'returns true' do
+        stub_tput_invocation output: "256\n"
+
+        result = Gitsh::TermInfo.instance.color_support?
+
+        expect(result).to be_true
+      end
+    end
+
+    context 'on a black and white terminal' do
+      it 'returns false' do
+        stub_tput_invocation output: "-1\n"
+
+        result = Gitsh::TermInfo.instance.color_support?
+
+        expect(result).to be_false
+      end
+    end
+
+    context 'when tput fails' do
+      it 'returns false' do
+        stub_tput_invocation error: "unknonwn capability\n", success: false
+
+        result = Gitsh::TermInfo.instance.color_support?
+
+        expect(result).to be_false
+      end
+    end
+  end
+
+  context '#lines' do
+    it 'returns the number of lines the terminal has' do
+      stub_tput_invocation output: "24\n"
+
+      result = Gitsh::TermInfo.instance.lines
+
+      expect(result).to eq 24
+    end
+  end
+
+  context '#cols' do
+    it 'returns the number of columns the terminal has' do
+      stub_tput_invocation output: "80\n"
+
+      result = Gitsh::TermInfo.instance.cols
+
+      expect(result).to eq 80
+    end
+  end
+
+  def stub_tput_invocation(options = {})
+    Open3.stubs(:capture3).returns [
+      options.fetch(:output, ''),
+      options.fetch(:error, ''),
+      stub('exit_status', success?: options.fetch(:success, true))
+    ]
+  end
+end


### PR DESCRIPTION
When gitsh was started in a terminal emulator window, and that window is resized, then there can be strange problems. Most commonly, when the command reaches the point where it would have needed to wrap to a new line on the original window size, it goes back to the start of the line and starts overwriting the prompt and the start of the command. If you use IRB a lot you might have seen this there too.

It's a little tricky to reproduce, but I'm pretty sure this is the solution.

Fixes #144 
