### PR TITLE
Mimic sh(1) when handling unset variables.

### DIFF
--- a/lib/gitsh/transformer.rb
+++ b/lib/gitsh/transformer.rb
@@ -12,7 +12,7 @@ module Gitsh
       end
 
       rule(type => simple(:cmd), args: sequence(:args)) do |context|
-        command_class.new(context[:env], context[:cmd], context[:args])
+        command_class.new(context[:env], context[:cmd], context[:args].compact)
       end
     end
 
@@ -29,8 +29,11 @@ module Gitsh
       context[:env][key]
     end
 
-    rule(arg: subtree(:parts)) do
-      Array(parts).join('')
+    rule(arg: subtree(:parts)) do |context|
+      parts = Array(context[:parts]).compact
+      if parts.any?
+        parts.join('')
+      end
     end
 
     rule(comment: simple(:comment)) do |context|

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -163,6 +163,14 @@ command.
 .Bd -literal -offset indent
 @ commit -m "Commited by $user.name"
 .Ed
+.Pp
+Unset variables will be ignored, as then are in
+.Xr sh 1 .
+For example, the commit message produced by the following command will be
+.Ic "a commit" :
+.Bd -literal -offset indent
+@ commit -m $unset "a commit"
+.Ed
 .It Ic :echo string ...
 prints the given strings to standard output, followed by a newline. All
 whitespace is collapsed into one space. This can be useful for viewing

--- a/spec/integration/variables_spec.rb
+++ b/spec/integration/variables_spec.rb
@@ -68,4 +68,18 @@ describe 'Gitsh variables' do
       expect(gitsh).to output /hello/
     end
   end
+
+  it 'does not pass unset variables on to commands' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type(':echo "hello $unset world"')
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to output /hello  world/
+
+      gitsh.type(':echo hello $unset world')
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to output /hello world/
+    end
+  end
 end

--- a/spec/units/transformer_spec.rb
+++ b/spec/units/transformer_spec.rb
@@ -63,8 +63,14 @@ describe Gitsh::Transformer do
 
     it 'transforms variable arguments' do
       env = { 'author' => 'Jane Doe' }
-      output = transformer.apply({ var: 'author' }, env: env)
+      output = transformer.apply({ arg: [{ var: 'author' }] }, env: env)
       expect(output).to eq 'Jane Doe'
+    end
+
+    it 'transforms unknown variables arguments to nil' do
+      env = {}
+      output = transformer.apply({ arg: [{ var: 'author' }] }, env: env)
+      expect(output).to be_nil
     end
 
     it 'transforms empty string arguments' do
@@ -86,6 +92,5 @@ describe Gitsh::Transformer do
       output = transformer.apply(and: { left: 1, right: 2 })
       expect(output).to be_a Gitsh::Tree::And
     end
-
   end
 end


### PR DESCRIPTION
If an unset variable is used as an argument, it is dropped from the argument list.

For example:

```
& commit -m $foo
error: switch `m' requires a value
...
& :set foo "This is a commit"
& commit -m $foo
(a commit is created)
```

This is one possible solution to #136, but @calleerlandsson or @mike-burns might have a better idea.
