### PR TITLE
Prevent blank lines from causing a parse error.

### DIFF
--- a/lib/gitsh/interactive_runner.rb
+++ b/lib/gitsh/interactive_runner.rb
@@ -7,6 +7,8 @@ require 'gitsh/readline_blank_filter'
 
 module Gitsh
   class InteractiveRunner
+    BLANK_LINE_REGEX = /^\s*$/
+
     def initialize(opts)
       @readline = ReadlineBlankFilter.new(opts.fetch(:readline, Readline))
       @env = opts[:env]
@@ -50,7 +52,7 @@ module Gitsh
 
     def read_command
       command = readline.readline(prompt, true)
-      if command && command.empty?
+      if command && command.match(BLANK_LINE_REGEX)
         env.fetch('gitsh.defaultCommand', 'status')
       else
         command

--- a/spec/integration/blank_line_spec.rb
+++ b/spec/integration/blank_line_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'Entering no command' do
+  it 'runs `git status`' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type('init')
+      gitsh.type('    ')
+
+      expect(gitsh).to output /nothing to commit/
+    end
+  end
+end


### PR DESCRIPTION
This was an issue as most commands currently can be preceded by
spaces, but there was no rule to support spaces alone.

The behaviour of a blank line is now identical to that of an empty
line; by default the `git status` command, overridden by
gitsh.defaultCommand

Fixes https://github.com/thoughtbot/gitsh/issues/163
