### PR TITLE
Flesh out installation instructions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ test-driver
 */.deps
 
 # Make targets
+INSTALL
 src/gitsh
 src/gitsh.rb
 lib/gitsh/version.rb

--- a/INSTALL.in
+++ b/INSTALL.in
@@ -1,0 +1,79 @@
+gitsh installation
+==================
+
+The ideal way to install gitsh is via your operating system's package manager.
+Currently gitsh packages are available for:
+
+* OS X (via homebrew)
+* Arch Linux
+
+On other operating systems you should install using the tarball, following the
+instructions in this guide.
+
+
+Prerequisites
+-------------
+
+* Ruby version 1.9.3 or later
+* gcc or a similar C compiler
+
+
+gitsh and Ruby version managers
+-------------------------------
+
+The gitsh configuration script will attempt to find a system wide version of
+Ruby 1.9.3 or later. Rubies installed by Ruby version managers will usually be
+ignored to avoid problems when those binaries are moved or deleted.
+
+To force gitsh to use a specific Ruby binary, set the $RUBY environment variable
+when running the configuration script. For example, this will use the first ruby
+binary on the $PATH:
+
+        RUBY=$(which ruby) ./configure
+
+
+libedit vs. GNU Readline
+------------------------
+
+Ruby can use two different line editors: GNU Readline, which has more features
+but a more restrictive license; and libedit, which has fewer features and more
+bugs but a more permissive license. Since gitsh involves a lot of line editing,
+it may be preferable to use GNU Readline where possible.
+
+You can determine which line editor your version of Ruby is compiled against
+using the following command:
+
+        path/to/ruby -r readline -e Readline.vi_editing_mode?
+
+If the command exits silently, then your Ruby is built with GNU Readline. If it
+outputs a "NotImplementedError" message, then it is built with libedit. Note
+that gitsh will try to use a system-wide Ruby version, so you should make sure
+you're not running this line editor version check against a Ruby installed by a
+Ruby version manager.
+
+Once gitsh is installed, it will indicate which line editor is in used when
+executed with the --version option:
+
+        $ gitsh --version
+        @PACKAGE_VERSION@ (using GNU Readline)
+
+
+Installation
+------------
+
+1. Download and extract the latest release:
+
+        curl -O https://github.com/thoughtbot/gitsh/releases/download/v@PACKAGE_VERSION@/gitsh-@PACKAGE_VERSION@.tar.gz
+        tar -zxvf gitsh-@PACKAGE_VERSION@.tar.gz
+        cd gitsh-@PACKAGE_VERSION@
+
+2. Configure the distribution. This step will determine which version of Ruby
+   should be used, which has important implications; see the notes on "gitsh and
+   Ruby version managers" and "libedit vs. GNU Readline" above.
+
+        ./configure
+
+3. Build and install gitsh:
+
+        make
+        sudo make install

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = foreign
 SUBDIRS = src man lib/gitsh vendor spec
-EXTRA_DIST = LICENSE README.md
+EXTRA_DIST = LICENSE README.md INSTALL.in
 
 .PHONY: release \
 	release_build release_push release_clean \
@@ -13,6 +13,9 @@ edit_package = sed \
 	-e 's|@PACKAGE_VERSION[@]|$(PACKAGE_VERSION)|g' \
 	-e 's|@DIST_ARCHIVES[@]|$(DIST_ARCHIVES)|g' \
 	-e 's|@DIST_SHA[@]|$(DIST_SHA)|g'
+
+INSTALL: INSTALL.in
+	$(edit_package) $@.in > $@
 
 release: release_build release_push release_clean
 

--- a/README.md
+++ b/README.md
@@ -68,14 +68,8 @@ sh$</code></pre>
 
 * On Arch Linux: https://github.com/thoughtbot/gitsh/blob/master/arch/PKGBUILD
 
-* On other operating systems:
-
-        curl -O http://thoughtbot.github.io/gitsh/gitsh-0.6.tar.gz
-        tar -zxf gitsh-0.6.tar.gz
-        cd gitsh-0.6
-        ./configure
-        make
-        sudo make install
+See the [installation guide][INSTALL] for install instructions for other
+operating systems.
 
 ## Contributing to gitsh
 
@@ -97,6 +91,7 @@ free software, and may be redistributed under the terms specified in the
 
 [hub]: http://hub.github.com/
 [gh]: https://github.com/jingweno/gh
+[INSTALL]: https://github.com/thoughtbot/gitsh/blob/master/INSTALL.in
 [CONTRIBUTING]: https://github.com/thoughtbot/gitsh/blob/master/CONTRIBUTING.md
 [LICENSE]: https://github.com/thoughtbot/gitsh/blob/master/LICENSE
 [git-sh]: https://github.com/rtomayko/git-sh


### PR DESCRIPTION
There are two subtleties to installing gitsh by hand that have caused various problems:
1. Avoiding Ruby version manager Rubies.
2. Differences between libedit and GNU Readline.

This PR tries to document those potential problems in a single easy-to-find place.
