### PR TITLE
Script support

### DIFF
--- a/lib/gitsh/exit_statuses.rb
+++ b/lib/gitsh/exit_statuses.rb
@@ -1,0 +1,5 @@
+module Gitsh
+  EX_OK = 0
+  EX_USAGE = 64
+  EX_NOINPUT = 66
+end

--- a/lib/gitsh/noop.rb
+++ b/lib/gitsh/noop.rb
@@ -1,5 +1,5 @@
 module Gitsh
-  class Comment
+  class Noop
     def execute
     end
   end

--- a/lib/gitsh/parser.rb
+++ b/lib/gitsh/parser.rb
@@ -16,7 +16,7 @@ module Gitsh
     root(:program)
 
     rule(:program) do
-      comment | multi_command
+      comment | multi_command | blank_line
     end
 
     rule(:comment) do
@@ -29,6 +29,10 @@ module Gitsh
         semicolon_operator >>
         multi_command.as(:right)
       ).as(:multi) | or_operation
+    end
+
+    rule(:blank_line) do
+      (match('^') >> match('\s').repeat(0) >> match('$')).as(:blank)
     end
 
     rule(:or_operation) do

--- a/lib/gitsh/script_runner.rb
+++ b/lib/gitsh/script_runner.rb
@@ -1,0 +1,27 @@
+require 'gitsh/exit_statuses'
+require 'gitsh/interpreter'
+
+module Gitsh
+  class ScriptRunner
+    def initialize(opts)
+      @env = opts[:env]
+      @interpreter = opts.fetch(:interpreter) { Interpreter.new(@env) }
+    end
+
+    def run(path)
+      File.open(path) do |f|
+        f.each_line { |line| interpreter.execute(line) }
+      end
+    rescue Errno::ENOENT
+      env.puts_error "gitsh: #{path}: No such file or directory"
+      exit EX_NOINPUT
+    rescue Errno::EACCES
+      env.puts_error "gitsh: #{path}: Permission denied"
+      exit EX_NOINPUT
+    end
+
+    private
+
+    attr_reader :interpreter, :env
+  end
+end

--- a/lib/gitsh/transformer.rb
+++ b/lib/gitsh/transformer.rb
@@ -1,7 +1,7 @@
 require 'parslet'
-require 'gitsh/comment'
 require 'gitsh/git_command'
 require 'gitsh/internal_command'
+require 'gitsh/noop'
 require 'gitsh/shell_command'
 
 module Gitsh
@@ -36,8 +36,12 @@ module Gitsh
       end
     end
 
+    rule(blank: simple(:blank)) do |context|
+      Noop.new
+    end
+
     rule(comment: simple(:comment)) do |context|
-      Comment.new
+      Noop.new
     end
 
     command_rule(:git_cmd, GitCommand)

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -10,6 +10,7 @@
 .Op Fl -version
 .Op Fl h
 .Op Fl -git Ar CMD
+.Op file
 .
 .Sh DESCRIPTION
 .Nm gitsh
@@ -19,9 +20,13 @@ repository. It supports all git subcommands, custom aliases, and custom
 commands for interacting with the shell itself. Commands, path names,
 branch names, and tag names can all be completed using tab completion.
 .Pp
-Quit by either typing
+Running gitsh with no arguments will start an interactive session. Quit by
+either typing
 .Ic :exit
 or sending an EOF character.
+.Pp
+Passing the path to a file containing a series of commands will run each of
+those commands in sequence.
 .Pp
 It supports these options:
 .

--- a/spec/integration/arguments_spec.rb
+++ b/spec/integration/arguments_spec.rb
@@ -20,7 +20,7 @@ describe '--version' do
 end
 
 describe 'Unexpected arguments' do
-  %w(--badger -x foobar).each do |argument|
+  %w(--badger -x).each do |argument|
     context "with the argument #{argument.inspect}" do
       it 'outputs a usage message and exits' do
         output = StringIO.new
@@ -34,7 +34,7 @@ describe 'Unexpected arguments' do
         expect(runner).to raise_error SystemExit
         expect(output.string).to be_empty
         expect(error.string.chomp).to eq(
-          'usage: gitsh [--version] [-h | --help] [--git PATH]'
+          'usage: gitsh [--version] [-h | --help] [--git PATH] [script]'
         )
       end
     end

--- a/spec/integration/running_scripts_spec.rb
+++ b/spec/integration/running_scripts_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'Executing gitsh scripts' do
+  context 'when the path to the script is passed as an argument' do
+    it 'runs the script and exits' do
+      in_a_temporary_directory do
+        write_file('myscript.gitsh', "init\n\ncommit")
+
+        expect("#{gitsh} --git #{fake_git} myscript.gitsh").to execute.
+          successfully.
+          with_output_matching(/^Fake git: init\nFake git: commit\n$/)
+      end
+    end
+
+    context 'when the script file does not exist' do
+      it 'exits with a useful error message' do
+        expect("#{gitsh} --git #{fake_git} noscript.gitsh").to execute.
+          with_exit_status(66).
+          with_error_output_matching(/^gitsh: noscript\.gitsh: No such file or directory$/)
+      end
+    end
+  end
+
+  def gitsh
+    File.expand_path('../../../bin/gitsh', __FILE__)
+  end
+
+  def fake_git
+    File.expand_path('../../../spec/fixtures/fake_git', __FILE__)
+  end
+end

--- a/spec/support/execute_matcher.rb
+++ b/spec/support/execute_matcher.rb
@@ -1,0 +1,38 @@
+RSpec::Matchers.define :execute do
+  chain :successfully do
+    @exit_status_matcher = eq(0)
+    @error_matcher = be_empty
+  end
+
+  chain :with_exit_status do |exit_status|
+    @exit_status_matcher = eq(exit_status)
+  end
+
+  chain :with_output_matching do |output_pattern|
+    @output_matcher = match_regex(output_pattern)
+  end
+
+  chain :with_error_output_matching do |output_pattern|
+    @error_matcher = match_regex(output_pattern)
+  end
+
+  match do
+    output, error, exit_status = Open3.capture3(actual)
+
+    @output_matcher ||= be_empty
+
+    [
+      @exit_status_matcher.matches?(exit_status.exitstatus),
+      @output_matcher.matches?(output),
+      @error_matcher.matches?(error),
+    ].all?
+  end
+
+  failure_message_for_should do
+    [
+      @exit_status_matcher.failure_message_for_should,
+      @output_matcher.failure_message_for_should,
+      @error_matcher.failure_message_for_should,
+    ].join("\n")
+  end
+end

--- a/spec/support/file_system.rb
+++ b/spec/support/file_system.rb
@@ -6,6 +6,13 @@ module FileSystemHelper
     File.open(name, 'w') { |f| f << "#{contents}\n" }
   end
 
+  def temp_file(name, contents)
+    Tempfile.new(name).tap do |f|
+      f.write("#{contents}\n")
+      f.flush
+    end
+  end
+
   def in_a_temporary_directory(&block)
     Dir.mktmpdir do |path|
       chdir_and_allow_nesting(path, &block)

--- a/spec/units/cli_spec.rb
+++ b/spec/units/cli_spec.rb
@@ -3,7 +3,7 @@ require 'gitsh/cli'
 
 describe Gitsh::CLI do
   describe '#run' do
-    context 'with valid arguments' do
+    context 'with valid arguments and no script file' do
       it 'calls the interactive runner' do
         interactive_runner = stub('InteractiveRunner', run: nil)
         cli = Gitsh::CLI.new(
@@ -14,6 +14,23 @@ describe Gitsh::CLI do
         cli.run
 
         expect(interactive_runner).to have_received(:run)
+      end
+    end
+
+    context 'with a script file' do
+      it 'calls the script runner' do
+        script_runner = stub('ScriptRunner', run: nil)
+        interactive_runner = stub('InteractiveRunner', run: nil)
+        cli = Gitsh::CLI.new(
+          args: ['path/to/a/script'],
+          script_runner: script_runner,
+          interactive_runner: interactive_runner
+        )
+
+        cli.run
+
+        expect(script_runner).to have_received(:run).with('path/to/a/script')
+        expect(interactive_runner).to have_received(:run).never
       end
     end
 

--- a/spec/units/parser_spec.rb
+++ b/spec/units/parser_spec.rb
@@ -20,6 +20,14 @@ describe Gitsh::Parser do
   describe '#parse' do
     let(:parser) { described_class.new }
 
+    it 'parses a blank line' do
+      expect(parser).to parse('').as(blank: '')
+    end
+
+    it 'parses a line containing only whitespace' do
+      expect(parser).to parse('   ').as(blank: '   ')
+    end
+
     it 'parses a comment command' do
       expect(parser).to parse('#cd').as(comment: '#cd')
     end

--- a/spec/units/script_runner_spec.rb
+++ b/spec/units/script_runner_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'gitsh/script_runner'
+
+describe Gitsh::ScriptRunner do
+  describe '#run' do
+    it 'passes each command to the interpreter' do
+      script = temp_file('script', "commit -m 'Changes'\npush -f")
+      interpreter = stub('Interpreter', execute: nil)
+      runner = described_class.new(interpreter: interpreter)
+
+      runner.run script.path
+
+      expect(interpreter).to have_received(:execute).twice
+      expect(interpreter).to have_received(:execute).with("commit -m 'Changes'\n")
+      expect(interpreter).to have_received(:execute).with("push -f\n")
+    end
+
+    context 'with a file that does not exist' do
+      it 'exits' do
+        env = stub('Environment', puts_error: nil)
+        interpreter = stub('Interpreter', execute: nil)
+        runner = described_class.new(env: env, interpreter: interpreter)
+
+        expect { runner.run 'no/such/script' }.to raise_exception(SystemExit)
+        expect(env).to have_received(:puts_error)
+      end
+    end
+
+    context 'with a file that the current user cannot read' do
+      it 'exits' do
+        script = temp_file('script', "commit -m 'Changes'\npush -f")
+        File.stubs(:open).raises(Errno::EACCES)
+        env = stub('Environment', puts_error: nil)
+        interpreter = stub('Interpreter', execute: nil)
+        runner = described_class.new(env: env, interpreter: interpreter)
+
+        expect { runner.run script.path }.to raise_exception(SystemExit)
+        expect(env).to have_received(:puts_error)
+      end
+    end
+  end
+end

--- a/spec/units/transformer_spec.rb
+++ b/spec/units/transformer_spec.rb
@@ -6,10 +6,16 @@ describe Gitsh::Transformer do
     let(:env) { stub }
     let(:transformer) { described_class.new }
 
+    it 'transforms blank lines' do
+      output = transformer.apply({ blank: '' }, env: env)
+
+      expect(output).to be_a Gitsh::Noop
+    end
+
     it 'transforms comments' do
       output = transformer.apply({ comment: '#cd' }, env: env)
 
-      expect(output).to be_a Gitsh::Comment
+      expect(output).to be_a Gitsh::Noop
     end
 
     it 'transforms git commands' do


### PR DESCRIPTION
Run gitsh scripts by passing the path to a script as an argument to gitsh, or by using `#!/usr/bin/env gitsh` as a sh-bang line.
