### PR TITLE
Magic variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ sh$</code></pre>
         gitsh% :set user.email support+george+mike@thoughtbot.com
         gitsh% commit -m 'We are pair programming'
 
+* Access information about your repository with magic variables like
+  `$_rebase_base`, `$_merge_base` and `$_prior`.
+
+        gitsh% rebase master
+        CONFLICT (content): Merge conflict in db/schema.rb
+        gitsh% checkout $_rebase_base -- db/schema
+        gitsh% !rake db:schema:load db:migrate
+
 * Tab completion for git commands, aliases, and branches without modifying your
   shell settings, and without any extra setup for aliases and third party
   git commands.

--- a/lib/gitsh/git_repository.rb
+++ b/lib/gitsh/git_repository.rb
@@ -11,6 +11,10 @@ module Gitsh
       git_dir && File.exist?(git_dir)
     end
 
+    def git_dir
+      git_output('rev-parse --git-dir')
+    end
+
     def current_head
       current_branch_name || current_tag_name || abbreviated_sha
     end
@@ -63,6 +67,22 @@ module Gitsh
       end
     end
 
+    def revision_name(revision)
+      name = git_output(
+        "rev-parse --abbrev-ref --verify #{Shellwords.escape(revision)}"
+      )
+      unless name.empty?
+        name
+      end
+    end
+
+    def merge_base(commit1, commit2)
+      escaped_commits = [commit1, commit2].map do |commit|
+        Shellwords.escape(commit)
+      end
+      git_output('merge-base %s %s' % escaped_commits)
+    end
+
     private
 
     attr_reader :env
@@ -90,10 +110,6 @@ module Gitsh
 
     def status
       StatusParser.new(git_output('status --porcelain'))
-    end
-
-    def git_dir
-      git_output('rev-parse --git-dir')
     end
 
     def git_output(command)

--- a/lib/gitsh/magic_variables.rb
+++ b/lib/gitsh/magic_variables.rb
@@ -1,0 +1,35 @@
+module Gitsh
+  class MagicVariables
+    def initialize(repo)
+      @repo = repo
+    end
+
+    def [](key)
+      if available_variables.include?(key)
+        send(key)
+      end
+    end
+
+    private
+
+    attr_reader :repo
+
+    def available_variables
+      private_methods(false).grep(/^_/)
+    end
+
+    def _prior
+      repo.revision_name('@{-1}')
+    end
+
+    def _merge_base
+      repo.merge_base('HEAD', 'MERGE_HEAD')
+    end
+
+    def _rebase_base
+      File.read(File.join(repo.git_dir, 'rebase-apply', 'onto')).chomp
+    rescue Errno::ENOENT
+      nil
+    end
+  end
+end

--- a/lib/gitsh/parser.rb
+++ b/lib/gitsh/parser.rb
@@ -96,7 +96,7 @@ module Gitsh
     end
 
     rule(:variable_name) do
-      match('[A-Za-z]') >> match('[A-Za-z0-9._\-]').repeat(0)
+      match('[A-Za-z_]') >> match('[A-Za-z0-9._\-]').repeat(0)
     end
 
     rule(:identifier) do

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -143,9 +143,7 @@ character.
 The following commands are supported:
 .Bl -tag -width Ds
 .It Ic :set variable value
-sets a variable in the gitsh environment to the given value. The value
-of the variable can be used in subsequent commands using the variable
-name with a dollar prefix.
+sets a variable in the gitsh environment to the given value.
 .Bd -literal -offset indent
 @ :set george "George <george@thoughtbot.com>"
 @ commit --author $george
@@ -160,22 +158,9 @@ variables for the duration of a gitsh session.
 @ commit
 .Ed
 .Pp
-The dollar prefix can also be used to read
-.Xr git-config 1
-variables, whether or not they were set using the
-.Ic :set
-command.
-.Bd -literal -offset indent
-@ commit -m "Commited by $user.name"
-.Ed
-.Pp
-Unset variables will be ignored, as then are in
-.Xr sh 1 .
-For example, the commit message produced by the following command will be
-.Ic "a commit" :
-.Bd -literal -offset indent
-@ commit -m $unset "a commit"
-.Ed
+See the section on
+.Sx VARIABLES
+for more information.
 .It Ic :echo string ...
 prints the given strings to standard output, followed by a newline. All
 whitespace is collapsed into one space. This can be useful for viewing
@@ -194,6 +179,59 @@ changes directory to the given path.
 ends the gitsh session.
 .El
 .
+.Sh VARIABLES
+Variables can be read using the
+.Ic $
+prefix. There are three kinds of variables supported by gitsh:
+.Pp
+.Bl -enum
+.It
+Variables set using the
+.Ic :set
+command.
+.Bd -literal -offset indent
+@ :set greeting "Hello, world"
+@ :echo $greeting
+.Ed
+.It
+All
+.Xr git-config 1
+settings can be treated as variables in gitsh. For example, the following
+commands will produce the same output.
+.Bd -literal -offset indent
+@ config user.name
+@ :echo $user.name
+.Ed
+.It
+There are a number of "magic variables" which expose information about the
+current state of the repository.
+.Bl -tag -width Ds
+.It Ic $_prior
+The name of the previous branch that was checked out. This is usually
+equivalent to
+.Ic @{-1} ,
+but will also work in situations where the branch name is required.
+.It Ic $_merge_base
+When there is a merge in progress, this will be the hash of the merge's base
+commit. It is equivalent to the output of
+.Ic merge-base HEAD MERGE_HEAD .
+.It Ic $_rebase_base
+When there is a rebase in progress, this will be the hash of the commit onto
+which we are rebasing, for example after running
+.Ic rebase master
+this variable would evaluate to the hash of the commit at the head of the
+.Ic master
+branch.
+.El
+.El
+.Pp
+Unset variables will be ignored, as then are in
+.Xr sh 1 .
+For example, the commit message produced by the following command will be
+.Ic "a commit" :
+.Bd -literal -offset indent
+@ commit -m $unset "a commit"
+.Ed
 .Sh CONFIGURATION
 The following
 .Xr git-config 1

--- a/spec/integration/magic_variables_spec.rb
+++ b/spec/integration/magic_variables_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe 'Magic variables' do
+  context '$_prior' do
+    it 'evaluates to the name of the previous branch' do
+      GitshRunner.interactive do |gitsh|
+        gitsh.type('init')
+        gitsh.type('commit --allow-empty -m "Initial commit"')
+        gitsh.type('checkout -b my-feature-branch')
+        gitsh.type(':echo $_prior')
+
+        expect(gitsh).to output 'master'
+
+        gitsh.type('checkout $_prior')
+        gitsh.type(':echo $_prior')
+
+        expect(gitsh).to output 'my-feature-branch'
+      end
+    end
+  end
+
+  context '$_merge_base' do
+    it 'evaluates to the SHA1 of the base commit of an in-progress merge' do
+      in_a_repository_with_conflicting_branches do |gitsh|
+        gitsh.type('rev-parse master')
+        expected_merge_base = gitsh.output
+        gitsh.type('checkout branch-b')
+        gitsh.type('merge branch-a')
+
+        gitsh.type(':echo $_merge_base')
+
+        expect(gitsh).to output expected_merge_base
+      end
+    end
+  end
+
+  context '$_rebase_base' do
+    it 'evaluates to the branch which is the base of an in-progress rebase' do
+      in_a_repository_with_conflicting_branches do |gitsh|
+        gitsh.type('rev-parse branch-a')
+        expected_rebase_base = gitsh.output
+        gitsh.type('checkout branch-b')
+        gitsh.type('rebase branch-a')
+
+        gitsh.type(':echo $_rebase_base')
+
+        expect(gitsh).to output expected_rebase_base
+      end
+    end
+  end
+
+  def in_a_repository_with_conflicting_branches
+    GitshRunner.interactive do |gitsh|
+      gitsh.type('init')
+      gitsh.type('commit --allow-empty -m Initial')
+      write_file('file', 'a')
+      gitsh.type('add file')
+      gitsh.type('checkout -b branch-a')
+      gitsh.type('commit -m A')
+      gitsh.type('checkout -b branch-b master')
+      write_file('file', 'b')
+      gitsh.type('add file')
+      gitsh.type('commit -m B')
+
+      yield gitsh
+    end
+  end
+end

--- a/spec/units/environment_spec.rb
+++ b/spec/units/environment_spec.rb
@@ -45,6 +45,14 @@ describe Gitsh::Environment do
       expect(env['user.name']).to eq 'Jane Doe'
       expect(env[:'user.name']).to eq 'Jane Doe'
     end
+
+    it 'understands magic variables' do
+      magic_variables = stub(:magic_variables)
+      magic_variables.stubs(:[]).with(:_prior).returns('a-branch-name')
+      env = described_class.new(magic_variables: magic_variables)
+
+      expect(env[:'_prior']).to eq 'a-branch-name'
+    end
   end
 
   describe '#fetch' do

--- a/spec/units/magic_variables_spec.rb
+++ b/spec/units/magic_variables_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+require 'gitsh/magic_variables'
+
+describe Gitsh::MagicVariables do
+  describe '#[]' do
+    context 'with an unknown variable name' do
+      it 'returns nil' do
+        repo = stub('GitRepository')
+        magic_variables = described_class.new(repo)
+
+        expect(magic_variables[:_not_a_real_variable]).to be_nil
+        expect(magic_variables[:repo]).to be_nil
+      end
+    end
+
+    context 'with _prior' do
+      it 'returns the name of the previous branch' do
+        repo = stub('GitRepository', revision_name: 'a-branch-name')
+        magic_variables = described_class.new(repo)
+
+        expect(magic_variables[:_prior]).to eq 'a-branch-name'
+        expect(repo).to have_received(:revision_name).with('@{-1}')
+      end
+    end
+
+    context 'with _merge_base' do
+      it 'returns the SHA of the base commit for an in-progress merge' do
+        repo = stub('GitRepository', merge_base: 'abc124567890')
+        magic_variables = described_class.new(repo)
+
+        expect(magic_variables[:_merge_base]).to eq 'abc124567890'
+        expect(repo).to have_received(:merge_base).with('HEAD', 'MERGE_HEAD')
+      end
+    end
+
+    context 'with _rebase_base' do
+      it 'returns the value stored in the .git/rebase-apply/onto file' do
+        Dir.mktmpdir do |tmpdir_path|
+          rebase_path = Pathname.new(tmpdir_path).join('rebase-apply')
+          rebase_path.mkpath
+          write_file(rebase_path.join('onto'), 'abc123')
+          repo = stub('GitRepository', git_dir: tmpdir_path)
+          magic_variables = described_class.new(repo)
+
+          expect(magic_variables[:_rebase_base]).to eq 'abc123'
+        end
+      end
+
+      context 'when there is no rebase in progress' do
+        it 'returns nil' do
+          Dir.mktmpdir do |tmpdir_path|
+            repo = stub('GitRepository', git_dir: tmpdir_path)
+            magic_variables = described_class.new(repo)
+
+            expect(magic_variables[:_rebase_base]).to be_nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/units/parser_spec.rb
+++ b/spec/units/parser_spec.rb
@@ -97,11 +97,12 @@ describe Gitsh::Parser do
     end
 
     it 'parses a command with variable arguments' do
-      expect(parser).to parse('foo $bar $f_o-o.bar').as(
+      expect(parser).to parse('foo $bar $f_o-o.bar $_bar').as(
         git_cmd: 'foo',
         args: [
           { arg: [{ var: 'bar' }] },
-          { arg: [{ var: 'f_o-o.bar' }] }
+          { arg: [{ var: 'f_o-o.bar' }] },
+          { arg: [{ var: '_bar' }] }
         ]
       )
     end


### PR DESCRIPTION
Adds support for `$_prior`, `$_merge_base` and `$_rebase_base` variables (see updates to `man/man1/gitsh.1` for details about what they do)
