### PR TITLE
Piped scripts

### DIFF
--- a/lib/gitsh/cli.rb
+++ b/lib/gitsh/cli.rb
@@ -33,8 +33,16 @@ module Gitsh
 
     private
 
-    attr_reader :env, :unparsed_args, :script_file,
+    attr_reader :env, :unparsed_args, :script_file_argument,
       :interactive_runner, :script_runner
+
+    def script_file
+      if script_file_argument
+        script_file_argument
+      elsif !env.tty?
+        ScriptRunner::STDIN_PLACEHOLDER
+      end
+    end
 
     def exit_with_usage_message
       env.puts_error option_parser.banner
@@ -43,7 +51,7 @@ module Gitsh
 
     def parse_arguments
       option_parser.parse!(unparsed_args)
-      @script_file = unparsed_args.pop
+      @script_file_argument = unparsed_args.pop
     rescue OptionParser::InvalidOption => err
       unparsed_args.concat(err.args)
     end

--- a/lib/gitsh/environment.rb
+++ b/lib/gitsh/environment.rb
@@ -5,9 +5,10 @@ module Gitsh
   class Environment
     DEFAULT_GIT_COMMAND = '/usr/bin/env git'.freeze
 
-    attr_reader :output_stream, :error_stream
+    attr_reader :input_stream, :output_stream, :error_stream
 
     def initialize(options={})
+      @input_stream = options.fetch(:input_stream, $stdin)
       @output_stream = options.fetch(:output_stream, $stdout)
       @error_stream = options.fetch(:error_stream, $stderr)
       @repo = options.fetch(:repository_factory, GitRepository).new(self)
@@ -56,6 +57,10 @@ module Gitsh
 
     def puts_error(*args)
       error_stream.puts(*args)
+    end
+
+    def tty?
+      input_stream.tty?
     end
 
     def repo_remotes

--- a/lib/gitsh/script_runner.rb
+++ b/lib/gitsh/script_runner.rb
@@ -3,13 +3,15 @@ require 'gitsh/interpreter'
 
 module Gitsh
   class ScriptRunner
+    STDIN_PLACEHOLDER = '-'.freeze
+
     def initialize(opts)
       @env = opts[:env]
       @interpreter = opts.fetch(:interpreter) { Interpreter.new(@env) }
     end
 
     def run(path)
-      File.open(path) do |f|
+      open_file(path) do |f|
         f.each_line { |line| interpreter.execute(line) }
       end
     rescue Errno::ENOENT
@@ -23,5 +25,13 @@ module Gitsh
     private
 
     attr_reader :interpreter, :env
+
+    def open_file(path, &block)
+      if path == STDIN_PLACEHOLDER
+        block.call(env.input_stream)
+      else
+        File.open(path, &block)
+      end
+    end
   end
 end

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -25,10 +25,11 @@ either typing
 .Ic :exit
 or sending an EOF character.
 .Pp
-Passing the path to a file containing a series of commands will run each of
-those commands in sequence.
+Passing the path to a file containing a series of commands or sending a series
+of commands to gitsh's standard input will run each of those commands in
+sequence.
 .Pp
-It supports these options:
+It supports these options and arguments:
 .
 .Bl -tag
 .It Fl -git Ar CMD
@@ -42,6 +43,10 @@ configuration option
 display a help message and exit.
 .It Fl -version
 display the version number and exit.
+.It Ic file
+the path to a file of commands to be executed. If the path is
+.Ic -
+then the commands will be read from the standard input.
 .El
 .Pp
 Within the shell you can use the following types of commands:

--- a/spec/integration/running_scripts_spec.rb
+++ b/spec/integration/running_scripts_spec.rb
@@ -21,6 +21,18 @@ describe 'Executing gitsh scripts' do
     end
   end
 
+  context 'when the script is piped to standard input' do
+    it 'runs the script and exits' do
+      in_a_temporary_directory do
+        write_file('myscript.gitsh', "init\n\ncommit")
+
+        expect("cat myscript.gitsh | #{gitsh} --git #{fake_git}").to execute.
+          successfully.
+          with_output_matching(/^Fake git: init\nFake git: commit\n$/)
+      end
+    end
+  end
+
   def gitsh
     File.expand_path('../../../bin/gitsh', __FILE__)
   end

--- a/spec/support/execute_matcher.rb
+++ b/spec/support/execute_matcher.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define :execute do
   chain :successfully do
     @exit_status_matcher = eq(0)
-    @error_matcher = be_empty
+    @error_matcher = eq('')
   end
 
   chain :with_exit_status do |exit_status|

--- a/spec/support/gitsh_runner.rb
+++ b/spec/support/gitsh_runner.rb
@@ -7,6 +7,7 @@ require File.expand_path('../file_system', __FILE__)
 
 class GitshRunner
   include FileSystemHelper
+  include Mocha::API
 
   UP_ARROW = "\033[A"
 
@@ -15,6 +16,7 @@ class GitshRunner
   end
 
   def initialize(options)
+    @input_stream = stub('STDIN', tty?: true)
     @output_stream = Tempfile.new('stdout')
     @error_stream = Tempfile.new('stderr')
     @readline = FakeReadline.new
@@ -70,7 +72,7 @@ class GitshRunner
 
   private
 
-  attr_reader :output_stream, :error_stream, :readline, :options
+  attr_reader :input_stream, :output_stream, :error_stream, :readline, :options
 
   def start_runner_thread
     Thread.abort_on_exception = true
@@ -99,6 +101,7 @@ class GitshRunner
 
   def env
     @env ||= Gitsh::Environment.new(
+      input_stream: input_stream,
       output_stream: output_stream,
       error_stream: error_stream
     ).tap do |env|

--- a/spec/units/cli_spec.rb
+++ b/spec/units/cli_spec.rb
@@ -17,8 +17,26 @@ describe Gitsh::CLI do
       end
     end
 
+    context 'when STDIN is not a TTY' do
+      it 'calls the script runner with -' do
+        script_runner = stub('ScriptRunner', run: nil)
+        interactive_runner = stub('InteractiveRunner', run: nil)
+        cli = Gitsh::CLI.new(
+          args: [],
+          script_runner: script_runner,
+          interactive_runner: interactive_runner,
+          env: stub('Environment', tty?: false),
+        )
+
+        cli.run
+
+        expect(script_runner).to have_received(:run).with('-')
+        expect(interactive_runner).to have_received(:run).never
+      end
+    end
+
     context 'with a script file' do
-      it 'calls the script runner' do
+      it 'calls the script runner with the script file' do
         script_runner = stub('ScriptRunner', run: nil)
         interactive_runner = stub('InteractiveRunner', run: nil)
         cli = Gitsh::CLI.new(

--- a/spec/units/environment_spec.rb
+++ b/spec/units/environment_spec.rb
@@ -88,6 +88,21 @@ describe Gitsh::Environment do
     end
   end
 
+  describe '#input_stream' do
+    it 'returns $stdin by default' do
+      env = described_class.new
+
+      expect(env.input_stream).to eq $stdin
+    end
+
+    it 'returns the input stream passed to the constructor' do
+      stream = stub
+      env = described_class.new(input_stream: stream)
+
+      expect(env.input_stream).to eq stream
+    end
+  end
+
   describe '#output_stream' do
     it 'returns $stdout by default' do
       env = described_class.new
@@ -95,7 +110,7 @@ describe Gitsh::Environment do
       expect(env.output_stream).to eq $stdout
     end
 
-    it 'can be overridden in the constructor' do
+    it 'returns the output stream passed to the constructor' do
       stream = stub
       env = described_class.new(output_stream: stream)
 
@@ -157,6 +172,22 @@ describe Gitsh::Environment do
       env.puts_error 'Oh no!'
 
       expect(error.string).to eq "Oh no!\n"
+    end
+  end
+
+  describe '#tty?' do
+    it 'returns true when the input stream is a TTY' do
+      input = stub('STDIN', tty?: true)
+      env = described_class.new(input_stream: input)
+
+      expect(env).to be_tty
+    end
+
+    it 'returns false when the input stream is not a TTY' do
+      input = stub('STDIN', tty?: false)
+      env = described_class.new(input_stream: input)
+
+      expect(env).not_to be_tty
     end
   end
 

--- a/spec/units/script_runner_spec.rb
+++ b/spec/units/script_runner_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'stringio'
 require 'gitsh/script_runner'
 
 describe Gitsh::ScriptRunner do
@@ -13,6 +14,21 @@ describe Gitsh::ScriptRunner do
       expect(interpreter).to have_received(:execute).twice
       expect(interpreter).to have_received(:execute).with("commit -m 'Changes'\n")
       expect(interpreter).to have_received(:execute).with("push -f\n")
+    end
+
+    context 'with -' do
+      it 'reads commands from STDIN' do
+        input_stream = StringIO.new("push\npull\n")
+        env = stub('Environment', input_stream: input_stream)
+        interpreter = stub('Interpreter', execute: nil)
+        runner = described_class.new(env: env, interpreter: interpreter)
+
+        runner.run '-'
+
+        expect(interpreter).to have_received(:execute).twice
+        expect(interpreter).to have_received(:execute).with("push\n")
+        expect(interpreter).to have_received(:execute).with("pull\n")
+      end
     end
 
     context 'with a file that does not exist' do


### PR DESCRIPTION
- Accepts scripts piped to the standard input.
- Accepts `-` as a path to a script, to force reading from the standard input instead of interactive mode.
