### PR TITLE
Custom prompt colors

### DIFF
--- a/lib/gitsh/colors.rb
+++ b/lib/gitsh/colors.rb
@@ -1,14 +1,15 @@
 module Gitsh
   module Colors
+    NONE = ''
     CLEAR = "\033[00m"
-    BLACK_FG = "\033[00;30m"
-    RED_FG = "\033[00;31m"
-    GREEN_FG = "\033[00;32m"
-    ORANGE_FG = "\033[00;33m"
-    BLUE_FG = "\033[00;34m"
-    MAGENTA_FG = "\033[00;35m"
-    CYAN_FG = "\033[00;36m"
-    WHITE_FG = "\033[00;37m"
-    RED_BG = "\033[00;41m"
+    BLACK_FG = "\033[30m"
+    RED_FG = "\033[31m"
+    GREEN_FG = "\033[32m"
+    ORANGE_FG = "\033[33m"
+    BLUE_FG = "\033[34m"
+    MAGENTA_FG = "\033[35m"
+    CYAN_FG = "\033[36m"
+    WHITE_FG = "\033[37m"
+    RED_BG = "\033[41m"
   end
 end

--- a/lib/gitsh/environment.rb
+++ b/lib/gitsh/environment.rb
@@ -87,6 +87,14 @@ module Gitsh
       repo.has_untracked_files?
     end
 
+    def repo_config_color(name, default)
+      if color_override = self[name]
+        repo.color(color_override)
+      else
+        repo.config_color(name, default)
+      end
+    end
+
     def git_commands
       repo.commands
     end

--- a/lib/gitsh/git_repository.rb
+++ b/lib/gitsh/git_repository.rb
@@ -67,6 +67,16 @@ module Gitsh
       end
     end
 
+    def config_color(name, default)
+      git_output(
+        "config --get-color #{Shellwords.escape(name)} #{Shellwords.escape(default)}"
+      )
+    end
+
+    def color(description)
+      git_output("config --get-color '' #{Shellwords.escape(description)}")
+    end
+
     def revision_name(revision)
       name = git_output(
         "rev-parse --abbrev-ref --verify #{Shellwords.escape(revision)}"

--- a/lib/gitsh/prompt_color.rb
+++ b/lib/gitsh/prompt_color.rb
@@ -1,0 +1,25 @@
+require 'gitsh/colors'
+
+module Gitsh
+  class PromptColor
+    def initialize(env)
+      @env = env
+    end
+
+    def status_color
+      if !env.repo_initialized?
+        env.repo_config_color('gitsh.color.uninitialized', 'normal red')
+      elsif env.repo_has_untracked_files?
+        env.repo_config_color('gitsh.color.untracked', 'red')
+      elsif env.repo_has_modified_files?
+        env.repo_config_color('gitsh.color.modified', 'orange')
+      else
+        env.repo_config_color('gitsh.color.default', 'blue')
+      end
+    end
+
+    private
+
+    attr_reader :env
+  end
+end

--- a/lib/gitsh/prompter.rb
+++ b/lib/gitsh/prompter.rb
@@ -1,4 +1,5 @@
 require 'gitsh/colors'
+require 'gitsh/prompt_color'
 
 module Gitsh
   class Prompter
@@ -7,6 +8,8 @@ module Gitsh
     def initialize(options={})
       @env = options.fetch(:env)
       @use_color = options.fetch(:color, true)
+      @prompt_color = options.fetch(:prompt_color) { PromptColor.new(@env) }
+      @options = options
     end
 
     def prompt
@@ -22,7 +25,7 @@ module Gitsh
 
     private
 
-    attr_reader :env
+    attr_reader :env, :prompt_color
 
     def padded_prompt_format
       "#{prompt_format.chomp} "
@@ -53,16 +56,10 @@ module Gitsh
     end
 
     def status_color
-      if !use_color?
-        ''
-      elsif !env.repo_initialized?
-        Colors::RED_BG
-      elsif env.repo_has_untracked_files?
-        Colors::RED_FG
-      elsif env.repo_has_modified_files?
-        Colors::ORANGE_FG
+      if use_color?
+        prompt_color.status_color
       else
-        Colors::BLUE_FG
+        Colors::NONE
       end
     end
 
@@ -70,7 +67,7 @@ module Gitsh
       if use_color?
         Colors::CLEAR
       else
-        ''
+        Colors::NONE
       end
     end
 

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -107,12 +107,12 @@ when the present working directory is not a git repository.
 .Pp
 The state of the repository is reflected by the terminating sigil and the color
 of both the current HEAD and the sigil:
-.Bl -column "Current directory is not a git repo" ".Sy Sigil" "Orange foreground" -offset indent
-.It Sy Status                               Ta Sy Sigil     Ta Sy Color
-.It Current directory is not a git repo     Ta !!           Ta Red background
-.It Repo has untracked files                Ta !            Ta Red foreground
-.It Repo has modified files                 Ta &            Ta Orange foreground
-.It All other states                        Ta @            Ta Blue foreground
+.Bl -column "Untracked files" ".Sy Sigil" ".Ic gitsh.color.uninitialized" ".Sy Default" -offset indent
+.It Sy Status           Ta Sy Sigil     Ta Sy Color setting                Ta Sy Default
+.It Not a git repo      Ta !!           Ta Ic gitsh.color.uninitialized    Ta normal red
+.It Untracked files     Ta !            Ta Ic gitsh.color.untracked        Ta red
+.It Modified files      Ta &            Ta Ic gitsh.color.modified         Ta orange
+.It Default             Ta @            Ta Ic gitsh.color.default          Ta blue
 .El
 .Pp
 .Ss Prompt customisation
@@ -272,6 +272,14 @@ command. By default this is
 .It Ic gitsh.gitCommand
 The command that gitsh will use to run git commands. The default is
 .Ic /usr/bin/env git .
+.It Ic gitsh.color.*
+Various settings are available to customize the colors used in the prompt.
+See the
+.Sx PROMPT
+section above for a list of settings,
+and
+.Xr git-config 1
+for the values that color settings can take.
 .El
 .Pp
 In addition, some standard

--- a/spec/integration/coloring_spec.rb
+++ b/spec/integration/coloring_spec.rb
@@ -1,18 +1,38 @@
 require 'spec_helper'
 
-describe 'Colors as determinined from the environemnt' do
+describe 'Color support' do
   include Color
 
-  it 'is uncolored for old terminals' do
+  it 'is disabled for old terminals' do
     GitshRunner.interactive do |gitsh|
       expect(gitsh).to prompt_with "#{cwd_basename} uninitialized!! "
     end
   end
 
-  it 'is colored for color xterm' do
+  it 'is enabled for color xterm' do
     GitshRunner.interactive(env: { 'TERM' => 'xterm-color' }) do |gitsh|
       expect(gitsh).to prompt_with(
         "#{cwd_basename} #{red_background}uninitialized!!#{clear} "
+      )
+    end
+  end
+
+  it 'allows custom colors from git-config variables' do
+    GitshRunner.interactive(env: { 'TERM' => 'xterm-color' }) do |gitsh|
+      gitsh.type('config --global gitsh.color.uninitialized red')
+
+      expect(gitsh).to prompt_with(
+        "#{cwd_basename} #{red}uninitialized!!#{clear} "
+      )
+    end
+  end
+
+  it 'allows custom colors from gitsh environment variables' do
+    GitshRunner.interactive(env: { 'TERM' => 'xterm-color' }) do |gitsh|
+      gitsh.type(':set gitsh.color.uninitialized blue')
+
+      expect(gitsh).to prompt_with(
+        "#{cwd_basename} #{blue}uninitialized!!#{clear} "
       )
     end
   end

--- a/spec/integration/prompt_spec.rb
+++ b/spec/integration/prompt_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe 'The gitsh prompt' do
-  include Color
-
   it 'is customised by a git config variable' do
     GitshRunner.interactive do |gitsh|
       gitsh.type('init')

--- a/spec/units/environment_spec.rb
+++ b/spec/units/environment_spec.rb
@@ -260,5 +260,35 @@ describe Gitsh::Environment do
         expect(env).to delegate(:git_commands).to(repo, :commands)
       end
     end
+
+    describe '#repo_config_color' do
+      context 'when there is no environment variable set' do
+        it 'gets the color setting from the repo' do
+          expected_color = stub('color')
+          repo = stub('GitRepository', config_color: expected_color, config: nil)
+          env = described_class.new(repository_factory: stub(new: repo))
+
+          color = env.repo_config_color('test.color.foo', 'red')
+
+          expect(color).to eq expected_color
+          expect(repo).to have_received(:config_color).
+            with('test.color.foo', 'red')
+        end
+      end
+
+      context 'when there is an environment variable set' do
+        it 'gets the repo to convert the color to an ANSI escape sequence' do
+          expected_color = stub('color')
+          repo = stub('GitRepository', color: expected_color, config: nil)
+          env = described_class.new(repository_factory: stub(new: repo))
+
+          env['test.color.foo'] = 'blue'
+          color = env.repo_config_color('test.color.foo', 'red')
+
+          expect(color).to eq expected_color
+          expect(repo).to have_received(:color).with('blue')
+        end
+      end
+    end
   end
 end

--- a/spec/units/git_repository_spec.rb
+++ b/spec/units/git_repository_spec.rb
@@ -3,6 +3,8 @@ require 'open3'
 require 'gitsh/git_repository'
 
 describe Gitsh::GitRepository do
+  include Color
+
   describe '#initialized?' do
     it 'returns true when the current directory is a git repository' do
       Dir.chdir(repository_root) do
@@ -195,6 +197,52 @@ describe Gitsh::GitRepository do
           repo = Gitsh::GitRepository.new(env)
           expect(repo.config('not-a.real-variable', 'a-default')).
             to eq 'a-default'
+        end
+      end
+    end
+  end
+
+  context '#config_color' do
+    context 'when the config variable is set' do
+      it 'returns a color code for the color described by the setting' do
+        with_a_temporary_home_directory do
+          in_a_temporary_directory do
+            repo = Gitsh::GitRepository.new(env)
+            run 'git init'
+            run 'git config --local example.color red'
+
+            color = repo.config_color('example.color', 'blue')
+
+            expect(color).to eq red
+          end
+        end
+      end
+    end
+
+    context 'when the config variable is not set' do
+      it 'returns a color code for the color described by the default' do
+        with_a_temporary_home_directory do
+          in_a_temporary_directory do
+            repo = Gitsh::GitRepository.new(env)
+
+            color = repo.config_color('example.color', 'blue')
+
+            expect(color).to eq blue
+          end
+        end
+      end
+    end
+  end
+
+  context '#color' do
+    it 'returns a color code for the color described by the argument' do
+      with_a_temporary_home_directory do
+        in_a_temporary_directory do
+          repo = Gitsh::GitRepository.new(env)
+
+          color = repo.color('blue')
+
+          expect(color).to eq blue
         end
       end
     end

--- a/spec/units/interactive_runner_spec.rb
+++ b/spec/units/interactive_runner_spec.rb
@@ -85,6 +85,7 @@ describe Gitsh::InteractiveRunner do
       print: nil,
       puts: nil,
       repo_initialized?: false,
+      repo_config_color: '',
       fetch: '',
       :[] => nil
     })

--- a/spec/units/prompt_color_spec.rb
+++ b/spec/units/prompt_color_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+require 'gitsh/prompt_color'
+
+describe Gitsh::PromptColor do
+  include Color
+
+  describe '#status_color' do
+    context 'with an uninitialized repo' do
+      it 'uses the gitsh.color.uninitialized setting' do
+        color = stub('color')
+        env = stub_env(repo_initialized?: false, repo_config_color: color)
+        prompt_color = described_class.new(env)
+
+        expect(prompt_color.status_color).to eq color
+        expect(env).to have_received(:repo_config_color).
+          with('gitsh.color.uninitialized', 'normal red')
+      end
+    end
+
+    context 'with untracked files' do
+      it 'uses the gitsh.color.untracked setting' do
+        color = stub('color')
+        env = stub_env(repo_has_untracked_files?: true, repo_config_color: color)
+        prompt_color = described_class.new(env)
+
+        expect(prompt_color.status_color).to eq color
+        expect(env).to have_received(:repo_config_color).
+          with('gitsh.color.untracked', 'red')
+      end
+    end
+
+    context 'with modified files' do
+      it 'uses the gitsh.color.modified setting' do
+        color = stub('color')
+        env = stub_env(repo_has_modified_files?: true, repo_config_color: color)
+        prompt_color = described_class.new(env)
+
+        expect(prompt_color.status_color).to eq color
+        expect(env).to have_received(:repo_config_color).
+          with('gitsh.color.modified', 'orange')
+      end
+    end
+
+    context 'with a clean repo' do
+      it 'uses the gitsh.color.default setting' do
+        color = stub('color')
+        env = stub_env(repo_config_color: color)
+        prompt_color = described_class.new(env)
+
+        expect(prompt_color.status_color).to eq color
+        expect(env).to have_received(:repo_config_color).
+          with('gitsh.color.default', 'blue')
+      end
+    end
+  end
+
+  def stub_env(overrides = {})
+    defaults = {
+      repo_initialized?: true,
+      repo_has_untracked_files?: false,
+      repo_has_modified_files?: false,
+    }
+    env = stub('env', defaults.merge(overrides))
+  end
+end

--- a/spec/units/prompter_spec.rb
+++ b/spec/units/prompter_spec.rb
@@ -11,7 +11,7 @@ describe Gitsh::Prompter do
         prompter = Gitsh::Prompter.new(env: env)
 
         expect(prompter.prompt).to eq(
-          "#{cwd_basename} #{red_background}uninitialized!!#{clear} "
+          "#{cwd_basename} #{red}uninitialized!!#{clear} "
         )
       end
     end
@@ -22,7 +22,7 @@ describe Gitsh::Prompter do
         prompter = Gitsh::Prompter.new(env: env)
 
         expect(prompter.prompt).to eq(
-          "#{cwd_basename} #{blue}my-feature@#{clear} "
+          "#{cwd_basename} #{red}my-feature@#{clear} "
         )
       end
     end
@@ -44,7 +44,7 @@ describe Gitsh::Prompter do
         prompter = Gitsh::Prompter.new(env: env)
 
         expect(prompter.prompt).to eq(
-          "#{cwd_basename} #{orange}master&#{clear} "
+          "#{cwd_basename} #{red}master&#{clear} "
         )
       end
     end
@@ -67,10 +67,11 @@ describe Gitsh::Prompter do
       end
 
       it 'replaces %c with a color code based on the status' do
+        prompt_color = stub('PromptColor', status_color: blue)
         env = env_double(repo_has_modified_files?: true, format: '%c')
-        prompter = Gitsh::Prompter.new(env: env)
+        prompter = Gitsh::Prompter.new(env: env, prompt_color: prompt_color)
 
-        expect(prompter.prompt).to eq "#{orange} "
+        expect(prompter.prompt).to eq "#{blue} "
       end
 
       it 'replaces %w with the code to restore the default color' do
@@ -108,7 +109,8 @@ describe Gitsh::Prompter do
         repo_initialized?: true,
         repo_has_modified_files?: false,
         repo_has_untracked_files?: false,
-        repo_current_head: 'master'
+        repo_current_head: 'master',
+        repo_config_color: red,
       }
       stub('Environment', default_attrs.merge(attrs)) do |env|
         env.stubs(:[]).with('gitsh.prompt').returns(format)


### PR DESCRIPTION
Supports custom prompt colours, using `git config --get-color` to convert human-readable colour settings into ANSI escape sequences.
