### PR TITLE
Support .git/rebase-merge or .git/rebase-apply

### DIFF
--- a/lib/gitsh/magic_variables.rb
+++ b/lib/gitsh/magic_variables.rb
@@ -27,7 +27,11 @@ module Gitsh
     end
 
     def _rebase_base
-      File.read(File.join(repo.git_dir, 'rebase-apply', 'onto')).chomp
+      read_file(['rebase-apply', 'onto']) || read_file(['rebase-merge', 'onto'])
+    end
+
+    def read_file(path_components)
+      File.read(File.join(repo.git_dir, *path_components)).chomp
     rescue Errno::ENOENT
       nil
     end

--- a/spec/units/magic_variables_spec.rb
+++ b/spec/units/magic_variables_spec.rb
@@ -34,15 +34,31 @@ describe Gitsh::MagicVariables do
     end
 
     context 'with _rebase_base' do
-      it 'returns the value stored in the .git/rebase-apply/onto file' do
-        Dir.mktmpdir do |tmpdir_path|
-          rebase_path = Pathname.new(tmpdir_path).join('rebase-apply')
-          rebase_path.mkpath
-          write_file(rebase_path.join('onto'), 'abc123')
-          repo = stub('GitRepository', git_dir: tmpdir_path)
-          magic_variables = described_class.new(repo)
+      context 'when there is a .git/rebase-apply/onto file' do
+        it 'returns the value stored in that file' do
+          Dir.mktmpdir do |tmpdir_path|
+            rebase_path = Pathname.new(tmpdir_path).join('rebase-apply')
+            rebase_path.mkpath
+            write_file(rebase_path.join('onto'), 'abc123')
+            repo = stub('GitRepository', git_dir: tmpdir_path)
+            magic_variables = described_class.new(repo)
 
-          expect(magic_variables[:_rebase_base]).to eq 'abc123'
+            expect(magic_variables[:_rebase_base]).to eq 'abc123'
+          end
+        end
+      end
+
+      context 'when there is a .git/rebase-merge/onto file' do
+        it 'returns the value stored in that file' do
+          Dir.mktmpdir do |tmpdir_path|
+            rebase_path = Pathname.new(tmpdir_path).join('rebase-merge')
+            rebase_path.mkpath
+            write_file(rebase_path.join('onto'), 'def456')
+            repo = stub('GitRepository', git_dir: tmpdir_path)
+            magic_variables = described_class.new(repo)
+
+            expect(magic_variables[:_rebase_base]).to eq 'def456'
+          end
         end
       end
 


### PR DESCRIPTION
The `$_rebase_base` magic variable determines the base commit of a rebase by reading the metadata in the `.git` directory.

Rebase metadata is stored in different sub-directories at different times. This commit adds support for `.git/rebase-merge` in addition to the existing `.git/rebase-apply` support.

See: http://stackoverflow.com/questions/3921409
