### PR TITLE
Disable rubygems when running gitsh.

### DIFF
--- a/src/gitsh.rb.in
+++ b/src/gitsh.rb.in
@@ -1,4 +1,4 @@
-#!@RUBY@
+#!@RUBY@ --disable-gems
 
 $LOAD_PATH.unshift('@rubydir@')
 


### PR DESCRIPTION
There are currently some load errors related to an installer bug (see issue #178).

When rubygems is enabled it modifies require, which makes these bugs worse by failing more slowly and with less helpful output (e.g. on my Mac OS X system with Homebrew Ruby, it installs the Nokogiri gem before failing).
