### PR TITLE
Include lib/gitsh/*/*.rb files in installation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ fi
 
 rubydir=$datadir/$PACKAGE/ruby
 pkgrubydir=$rubydir/$PACKAGE
-libfiles="$(cd "$(dirname "$0")/lib/gitsh"; echo *.rb)"
+libfiles="$(cd "$(dirname "$0")/lib/gitsh"; echo $(find . -name \*.rb | cut -c 3-))"
 vendorfiles="$(cd "$(dirname "$0")/vendor"; echo $(find gems -type f))"
 testfiles="$(cd "$(dirname "$0")/spec"; echo $(find integration units -type f -name \*rb))"
 gemsetuppath=$datadir/$PACKAGE/gems/setup.rb

--- a/lib/gitsh/Makefile.am
+++ b/lib/gitsh/Makefile.am
@@ -1,5 +1,5 @@
 pkgruby_DATA = version.rb
-dist_pkgruby_DATA = $(libfiles)
+nobase_dist_pkgruby_DATA = $(libfiles)
 CLEANFILES = version.rb
 EXTRA_DIST = version.rb.in
 


### PR DESCRIPTION
The previous install mechanism would only install files from `lib/gitsh`; it excluded files in subdirectories. c1dc545c21a8037f47d71bf8ca01e667433f6d6e moved the command classes into a subdirectory under `lib/gitsh`, and subsequently these files weren't included by the installer.

Fixes #178
