### PR TITLE
Support ruby21

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,8 +10,8 @@ AC_ARG_VAR([RUBY],[The path of the Ruby binary to use])
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_PROG_CC
-AC_PATH_PROGS([RUBY], [ruby ruby20], [], $(getconf PATH))
-AC_PATH_PROGS([RUBY], [ruby ruby20])
+AC_PATH_PROGS([RUBY], [ruby ruby20 ruby21], [], $(getconf PATH))
+AC_PATH_PROGS([RUBY], [ruby ruby20 ruby21])
 
 if test -n $RUBY; then
   case $RUBY in $HOME/*)


### PR DESCRIPTION
Some systems (e.g. OpenBSD) name their Ruby 2.1.x as `ruby21`. This is a
supported version, so handle it.

Closes #192.
