### PR TITLE
Add OpenBSD instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,16 @@ sh$</code></pre>
 
 ## Installing gitsh
 
-* On Mac OS X, via homebrew:
+* Mac OS X, via homebrew:
 
         brew tap thoughtbot/formulae
         brew install gitsh
 
-* On Arch Linux: https://github.com/thoughtbot/gitsh/blob/master/arch/PKGBUILD
+* Arch Linux: https://github.com/thoughtbot/gitsh/blob/master/arch/PKGBUILD
+
+* OpenBSD -current:
+
+        sudo pkg_add gitsh
 
 See the [installation guide][INSTALL] for install instructions for other
 operating systems.


### PR DESCRIPTION
The gitsh port and package are in OpenBSD 5.7+, which is not yet
released, so the instructions target -current. The package mirrors are
not even caught up yet but they hopefully will be soon.

http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/devel/gitsh/

Removed the `On` prefix in the instructions to reduce redundancy.
