### PR TITLE
Subshells

### DIFF
--- a/lib/gitsh/argument_builder.rb
+++ b/lib/gitsh/argument_builder.rb
@@ -1,6 +1,8 @@
 require 'gitsh/arguments/composite_argument'
 require 'gitsh/arguments/string_argument'
+require 'gitsh/arguments/subshell'
 require 'gitsh/arguments/variable_argument'
+require 'gitsh/interpreter'
 
 module Gitsh
   class ArgumentBuilder
@@ -22,6 +24,14 @@ module Gitsh
     def add_variable(variable_name)
       collect_literals
       arguments << Arguments::VariableArgument.new(variable_name)
+    end
+
+    def add_subshell(command)
+      collect_literals
+      arguments << Arguments::Subshell.new(
+        command,
+        interpreter_factory: Interpreter,
+      )
     end
 
     def argument

--- a/lib/gitsh/arguments/subshell.rb
+++ b/lib/gitsh/arguments/subshell.rb
@@ -1,0 +1,28 @@
+require 'gitsh/capturing_environment'
+
+module Gitsh
+  module Arguments
+    class Subshell
+      def initialize(command, options = {})
+        @command = command
+        @interpreter_factory = options.fetch(:interpreter_factory)
+      end
+
+      def value(env)
+        capturing_env = CapturingEnvironment.new(env.clone)
+        interpreter_factory.new(capturing_env).execute(command)
+        strip_whitespace(capturing_env.captured_output)
+      end
+
+      private
+
+      attr_reader :command, :interpreter_factory
+
+      def strip_whitespace(output)
+        output.
+          sub(%r{\r?\n\Z}, '').
+          gsub(%r{[\n\r\s]+}, ' ')
+      end
+    end
+  end
+end

--- a/lib/gitsh/capturing_environment.rb
+++ b/lib/gitsh/capturing_environment.rb
@@ -1,0 +1,23 @@
+require 'delegate'
+
+module Gitsh
+  class CapturingEnvironment < SimpleDelegator
+    def initialize(env)
+      super
+      @reader, @writer = IO.pipe
+    end
+
+    def output_stream
+      writer
+    end
+
+    def captured_output
+      writer.close
+      reader.read
+    end
+
+    private
+
+    attr_reader :reader, :writer
+  end
+end

--- a/lib/gitsh/environment.rb
+++ b/lib/gitsh/environment.rb
@@ -17,6 +17,12 @@ module Gitsh
       @magic_variables = options.fetch(:magic_variables) { MagicVariables.new(@repo) }
     end
 
+    def initialize_copy(original)
+      super
+      @variables = variables.clone
+      self
+    end
+
     def git_command(force_default = false)
       if force_default
         DEFAULT_GIT_COMMAND

--- a/lib/gitsh/parser.rb
+++ b/lib/gitsh/parser.rb
@@ -65,7 +65,11 @@ module Gitsh
     end
 
     rule(:unquoted_string) do
-      (variable | match(%q([^\s'"&|;#])).as(:literal)).repeat(1)
+      (
+        variable |
+        subshell |
+        match(%q([^\s'"&|;#])).as(:literal)
+      ).repeat(1)
     end
 
     rule(:empty_string) do
@@ -76,6 +80,7 @@ module Gitsh
       str('"') >> (
         (str('\\') >> match('[$"\\\]').as(:literal)) |
         variable |
+        subshell |
         (str('"').absent? >> any).as(:literal)
       ).repeat(0) >> str('"')
     end
@@ -107,6 +112,10 @@ module Gitsh
 
     rule(:variable_name) do
       match('[A-Za-z_]') >> match('[A-Za-z0-9._\-]').repeat(0)
+    end
+
+    rule(:subshell) do
+      str('$(') >> (str(')').absent? >> any).repeat(0).as(:subshell) >> str(')')
     end
 
     rule(:identifier) do

--- a/lib/gitsh/transformer.rb
+++ b/lib/gitsh/transformer.rb
@@ -6,6 +6,7 @@ require 'gitsh/commands/internal_command'
 require 'gitsh/commands/noop'
 require 'gitsh/commands/shell_command'
 require 'gitsh/commands/tree'
+require 'gitsh/interpreter'
 
 module Gitsh
   class Transformer < Parslet::Transform
@@ -29,6 +30,10 @@ module Gitsh
 
     rule(var: simple(:var)) do
       lambda { |arg_builder| arg_builder.add_variable(var) }
+    end
+
+    rule(subshell: simple(:subshell)) do
+      lambda { |arg_builder| arg_builder.add_subshell(subshell.to_s) }
     end
 
     rule(arg: subtree(:parts)) do

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -258,6 +258,16 @@ Attempting to use an unset variable will cause a command to fail. This is
 different to
 .Xr sh 1 ,
 which will ignore unset variable arguments.
+.Sh SUB-SHELLS
+.Pp
+Sub-shells can be used to pass the output of any command--including Git
+commands, internal commands, and shell commands--as an argument to another
+command. A sub-shell is surrounded by
+.Ic $(...) .
+For example:
+.Bd -literal -offset indent
+@ :set directory $(!pwd)
+.Ed
 .Sh CONFIGURATION
 The following
 .Xr git-config 1

--- a/spec/integration/subshell_spec.rb
+++ b/spec/integration/subshell_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'Subshell' do
+  it 'supports empty strings' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type 'init'
+      gitsh.type ':echo prefix $(status) suffix'
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to output /prefix.*nothing to commit.*suffix/
+    end
+  end
+
+  it 'does not modify the parent environment' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type ':set x "x in parent shell"'
+      gitsh.type ':echo $(:set x "x in subshell")'
+      gitsh.type ':echo $x'
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to output /x in parent shell/
+    end
+  end
+end

--- a/spec/units/argument_builder_spec.rb
+++ b/spec/units/argument_builder_spec.rb
@@ -34,6 +34,21 @@ describe Gitsh::ArgumentBuilder do
     end
   end
 
+  describe 'building a Subshell with #add_subshell' do
+    it 'creates a subshell' do
+      subshell = stub('Subshell')
+      Gitsh::Arguments::Subshell.stubs(:new).returns(subshell)
+
+      built_argument = described_class.build do |builder|
+        builder.add_subshell('!pwd')
+      end
+
+      expect(built_argument).to be subshell
+      expect(Gitsh::Arguments::Subshell).to have_received(:new).once.
+        with('!pwd', interpreter_factory: Gitsh::Interpreter)
+    end
+  end
+
   describe 'building a CompositeArgument with multiple calls to #add_variable' do
     it 'creates a composite argument of several VariableArguments' do
       composite_argument = stub('CompositeArgument')

--- a/spec/units/arguments/subshell_spec.rb
+++ b/spec/units/arguments/subshell_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'gitsh/arguments/subshell'
+
+describe Gitsh::Arguments::Subshell do
+  class FakeInterpreter
+    def initialize(env)
+      @env = env
+    end
+
+    def execute(command)
+      @env.output_stream.puts "Begin.\n#{command}.\nEnd."
+      true
+    end
+  end
+
+  describe '#value' do
+    it 'creates a new interpreter and executes the subshell command inside of it' do
+      env = stub('env')
+      subshell_command = 'status'
+
+      output = described_class.new(
+        subshell_command,
+        interpreter_factory: FakeInterpreter,
+      ).value(env)
+
+      expect(output).to eq %Q{Begin. #{subshell_command}. End.}
+    end
+  end
+end

--- a/spec/units/capturing_environment_spec.rb
+++ b/spec/units/capturing_environment_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'gitsh/capturing_environment'
+
+describe Gitsh::CapturingEnvironment do
+  describe '#captured_output' do
+    it 'returns any output written to the output stream' do
+      env = stub('env')
+      capturing_env = described_class.new(env)
+      capturing_env.output_stream.puts 'Hello, world'
+      capturing_env.output_stream.puts 'Goodbye'
+
+      expect(capturing_env.captured_output).to eq "Hello, world\nGoodbye\n"
+    end
+  end
+
+  describe 'delegations' do
+    it 'delegates unknown methods to the wrapped environment' do
+      return_value = stub('return_value')
+      env = stub('env', foo: return_value)
+      capturing_env = described_class.new(env)
+
+      expect(capturing_env).to respond_to(:foo)
+      expect(capturing_env.foo).to eq return_value
+    end
+  end
+end

--- a/spec/units/environment_spec.rb
+++ b/spec/units/environment_spec.rb
@@ -65,6 +65,21 @@ describe Gitsh::Environment do
     end
   end
 
+  describe '#clone' do
+    it 'creates a copy with an isolated set of variables' do
+      original = described_class.new
+      original['a'] = 'A is set'
+
+      copy = original.clone
+      copy['b'] = 'B is set'
+
+      expect(original.fetch('a')).to eq 'A is set'
+      expect(copy.fetch('a')).to eq 'A is set'
+      expect { original.fetch('b') }.to raise_exception(Gitsh::Error)
+      expect(copy.fetch('b')).to eq 'B is set'
+    end
+  end
+
   describe '#config_variables' do
     it 'returns variables that have a dot in the name' do
       env = described_class.new

--- a/spec/units/parser_spec.rb
+++ b/spec/units/parser_spec.rb
@@ -133,6 +133,24 @@ describe Gitsh::Parser do
       )
     end
 
+    it 'parses a command with a subshell argument' do
+      expect(parser).to parse(':echo $(status)').as(
+        internal_cmd: 'echo',
+        args: [
+          { arg: [{ subshell: 'status' }] }
+        ]
+      )
+    end
+
+    it 'parses a command with a double-quoted argument containing a subshell' do
+      expect(parser).to parse(':echo "In $(!pwd)"').as(
+        internal_cmd: 'echo',
+        args: [
+          { arg: parser_literals('In ') + [{ subshell: '!pwd' }] }
+        ]
+      )
+    end
+
     it 'parses a command with string arguments containing escaped quotes and slashes' do
       expect(parser).to parse(%q(commit "It's \"great\"" "C:\\foo\bar")).as(
         git_cmd: 'commit',

--- a/spec/units/transformer_spec.rb
+++ b/spec/units/transformer_spec.rb
@@ -122,6 +122,14 @@ describe Gitsh::Transformer do
       expect(output).to be argument_builder.argument
     end
 
+    it 'transforms subshell arguments' do
+      argument_builder = stub_argument_builder
+      output = transformer.apply({ arg: [{ subshell: 'status' }] }, env: env)
+
+      expect(argument_builder).to have_received(:add_subshell).with('status')
+      expect(output).to be argument_builder.argument
+    end
+
     it 'transforms empty string arguments' do
       output = transformer.apply({ arg: [{ empty_string: "''" }] }, env: env)
       expect(output.value(env)).to eq ''
@@ -149,6 +157,7 @@ describe Gitsh::Transformer do
       'ArgumentBuilder',
       add_literal: nil,
       add_variable: nil,
+      add_subshell: nil,
       argument: argument,
     )
     Gitsh::ArgumentBuilder.stubs(:build).yields(builder).returns(argument)


### PR DESCRIPTION
Support for subshells, e.g. `:echo "In $(!pwd)"`

The current parser rules don't support nesting, which might be a blocker (see #198), but I wanted to open a PR with this before it got too huge.

(Specs pass locally, Travis is suffering from the usual Readline segfault shenanigans)