### PR TITLE
Git doesn't support "orange"; use "yellow".

### DIFF
--- a/lib/gitsh/colors.rb
+++ b/lib/gitsh/colors.rb
@@ -5,7 +5,7 @@ module Gitsh
     BLACK_FG = "\033[30m"
     RED_FG = "\033[31m"
     GREEN_FG = "\033[32m"
-    ORANGE_FG = "\033[33m"
+    YELLOW_FG = "\033[33m"
     BLUE_FG = "\033[34m"
     MAGENTA_FG = "\033[35m"
     CYAN_FG = "\033[36m"

--- a/lib/gitsh/prompt_color.rb
+++ b/lib/gitsh/prompt_color.rb
@@ -12,7 +12,7 @@ module Gitsh
       elsif env.repo_has_untracked_files?
         env.repo_config_color('gitsh.color.untracked', 'red')
       elsif env.repo_has_modified_files?
-        env.repo_config_color('gitsh.color.modified', 'orange')
+        env.repo_config_color('gitsh.color.modified', 'yellow')
       else
         env.repo_config_color('gitsh.color.default', 'blue')
       end

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -111,7 +111,7 @@ of both the current HEAD and the sigil:
 .It Sy Status           Ta Sy Sigil     Ta Sy Color setting                Ta Sy Default
 .It Not a git repo      Ta !!           Ta Ic gitsh.color.uninitialized    Ta normal red
 .It Untracked files     Ta !            Ta Ic gitsh.color.untracked        Ta red
-.It Modified files      Ta &            Ta Ic gitsh.color.modified         Ta orange
+.It Modified files      Ta &            Ta Ic gitsh.color.modified         Ta yellow
 .It Default             Ta @            Ta Ic gitsh.color.default          Ta blue
 .El
 .Pp

--- a/spec/support/colors.rb
+++ b/spec/support/colors.rb
@@ -5,7 +5,7 @@ module Color
     other.let(:clear) { Gitsh::Colors::CLEAR }
     other.let(:red_background) { Gitsh::Colors::RED_BG }
     other.let(:red) { Gitsh::Colors::RED_FG }
-    other.let(:orange) { Gitsh::Colors::ORANGE_FG }
+    other.let(:yellow) { Gitsh::Colors::YELLOW_FG }
     other.let(:cyan) { Gitsh::Colors::CYAN_FG }
     other.let(:blue) { Gitsh::Colors::BLUE_FG }
   end

--- a/spec/units/prompt_color_spec.rb
+++ b/spec/units/prompt_color_spec.rb
@@ -37,7 +37,7 @@ describe Gitsh::PromptColor do
 
         expect(prompt_color.status_color).to eq color
         expect(env).to have_received(:repo_config_color).
-          with('gitsh.color.modified', 'orange')
+          with('gitsh.color.modified', 'yellow')
       end
     end
 


### PR DESCRIPTION
6e6508408b7ee7e595d657bba0fc30de076fae4c set the default colour for modified files to:

```
git config --get-color "gitsh.color.modified" "orange"
```

Unfortunately, there is no `orange`. The colour has always been called `yellow`, it just looks orange in preferred terminal emulator colour scheme.

Oops.
