### PR TITLE
Eliminate nils

### DIFF
--- a/lib/gitsh/git_repository.rb
+++ b/lib/gitsh/git_repository.rb
@@ -54,7 +54,7 @@ module Gitsh
       git_output('remote').lines
     end
 
-    def config(name, default = nil, force_default_git_command = false)
+    def config(name, force_default_git_command = false)
       command = git_command(
         "config --get #{Shellwords.escape(name)}",
         force_default_git_command
@@ -62,8 +62,10 @@ module Gitsh
       out, err, status = Open3.capture3(command)
       if status.success?
         out.chomp
+      elsif block_given?
+        yield
       else
-        default
+        raise KeyError, "Git configuration variable #{name} is not set"
       end
     end
 

--- a/lib/gitsh/history.rb
+++ b/lib/gitsh/history.rb
@@ -32,11 +32,11 @@ module Gitsh
     end
 
     def history_file_path
-      env['gitsh.historyFile'] || DEFAULT_HISTORY_FILE
+      env.fetch('gitsh.historyFile') { DEFAULT_HISTORY_FILE }
     end
 
     def history_size
-      (env['gitsh.historySize'] || DEFAULT_HISTORY_SIZE).to_i
+      env.fetch('gitsh.historySize') { DEFAULT_HISTORY_SIZE }.to_i
     end
   end
 end

--- a/lib/gitsh/interactive_runner.rb
+++ b/lib/gitsh/interactive_runner.rb
@@ -44,9 +44,13 @@ module Gitsh
     end
 
     def greet_user
-      unless env['gitsh.noGreeting'] == 'true'
+      if greeting_enabled?
         env.puts "gitsh #{Gitsh::VERSION}\nType :exit to exit"
       end
+    end
+
+    def greeting_enabled?
+      env.fetch('gitsh.noGreeting') { 'false' } != 'true'
     end
 
     def interactive_loop
@@ -62,7 +66,7 @@ module Gitsh
     def read_command
       command = readline.readline(prompt, true)
       if command && command.match(BLANK_LINE_REGEX)
-        env.fetch('gitsh.defaultCommand', 'status')
+        env.fetch('gitsh.defaultCommand') { 'status' }
       else
         command
       end

--- a/lib/gitsh/magic_variables.rb
+++ b/lib/gitsh/magic_variables.rb
@@ -4,9 +4,11 @@ module Gitsh
       @repo = repo
     end
 
-    def [](key)
+    def fetch(key)
       if available_variables.include?(key)
         send(key)
+      else
+        yield
       end
     end
 

--- a/lib/gitsh/parser.rb
+++ b/lib/gitsh/parser.rb
@@ -138,7 +138,7 @@ module Gitsh
     end
 
     def autocorrect_enabled?
-      env.fetch('help.autocorrect', '0') != '0'
+      env.fetch('help.autocorrect') { '0' } != '0'
     end
   end
 end

--- a/lib/gitsh/prompter.rb
+++ b/lib/gitsh/prompter.rb
@@ -32,7 +32,7 @@ module Gitsh
     end
 
     def prompt_format
-      env.fetch('gitsh.prompt', DEFAULT_FORMAT)
+      env.fetch('gitsh.prompt') { DEFAULT_FORMAT }
     end
 
     def branch_name

--- a/lib/gitsh/transformer.rb
+++ b/lib/gitsh/transformer.rb
@@ -27,7 +27,7 @@ module Gitsh
 
     rule(var: simple(:var)) do |context|
       key = context[:var]
-      context[:env][key]
+      context[:env].fetch(key) { nil }
     end
 
     rule(arg: subtree(:parts)) do |context|

--- a/spec/units/git_repository_spec.rb
+++ b/spec/units/git_repository_spec.rb
@@ -171,32 +171,44 @@ describe Gitsh::GitRepository do
   end
 
   context '#config' do
-    it 'returns a git configuration value' do
-      with_a_temporary_home_directory do
-        in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
-          run 'git init'
-          run 'git config --local alias.zecho "!echo zzz"'
-          expect(repo.config('alias.zecho')).to eq '!echo zzz'
+    context 'for a variable that is set' do
+      it 'returns a git configuration value' do
+        with_a_temporary_home_directory do
+          in_a_temporary_directory do
+            repo = Gitsh::GitRepository.new(env)
+            git_alias = '!echo zzz'
+            run 'git init'
+            run "git config --local alias.zecho '#{git_alias}'"
+
+            expect(repo.config('alias.zecho')).to eq git_alias
+          end
         end
       end
     end
 
-    it 'returns nil if the configuration variable is not set' do
-      with_a_temporary_home_directory do
-        in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
-          expect(repo.config('not-a.real-variable')).to be_nil
+    context 'for a variable that is not set with no block given' do
+      it 'raises a KeyError' do
+        with_a_temporary_home_directory do
+          in_a_temporary_directory do
+            repo = Gitsh::GitRepository.new(env)
+
+            expect {
+              repo.config('not-a.real-variable')
+            }.to raise_exception(KeyError)
+          end
         end
       end
     end
 
-    it 'returns the default value if the configuration variable is not set' do
-      with_a_temporary_home_directory do
-        in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
-          expect(repo.config('not-a.real-variable', 'a-default')).
-            to eq 'a-default'
+    context 'for a variable that is not set with a block' do
+      it 'yields to the block' do
+        with_a_temporary_home_directory do
+          in_a_temporary_directory do
+            repo = Gitsh::GitRepository.new(env)
+
+            expect(repo.config('not-a.real-variable') { 'a-default' }).
+              to eq 'a-default'
+          end
         end
       end
     end

--- a/spec/units/magic_variables_spec.rb
+++ b/spec/units/magic_variables_spec.rb
@@ -2,14 +2,15 @@ require 'spec_helper'
 require 'gitsh/magic_variables'
 
 describe Gitsh::MagicVariables do
-  describe '#[]' do
-    context 'with an unknown variable name' do
-      it 'returns nil' do
+  describe '#fetch' do
+    context 'with an unknown variable name and a block' do
+      it 'yields to the block' do
         repo = stub('GitRepository')
         magic_variables = described_class.new(repo)
 
-        expect(magic_variables[:_not_a_real_variable]).to be_nil
-        expect(magic_variables[:repo]).to be_nil
+        result = magic_variables.fetch(:_not_a_real_variable) { 'default' }
+
+        expect(result).to eq 'default'
       end
     end
 
@@ -18,7 +19,7 @@ describe Gitsh::MagicVariables do
         repo = stub('GitRepository', revision_name: 'a-branch-name')
         magic_variables = described_class.new(repo)
 
-        expect(magic_variables[:_prior]).to eq 'a-branch-name'
+        expect(magic_variables.fetch(:_prior)).to eq 'a-branch-name'
         expect(repo).to have_received(:revision_name).with('@{-1}')
       end
     end
@@ -28,7 +29,7 @@ describe Gitsh::MagicVariables do
         repo = stub('GitRepository', merge_base: 'abc124567890')
         magic_variables = described_class.new(repo)
 
-        expect(magic_variables[:_merge_base]).to eq 'abc124567890'
+        expect(magic_variables.fetch(:_merge_base)).to eq 'abc124567890'
         expect(repo).to have_received(:merge_base).with('HEAD', 'MERGE_HEAD')
       end
     end
@@ -43,7 +44,7 @@ describe Gitsh::MagicVariables do
             repo = stub('GitRepository', git_dir: tmpdir_path)
             magic_variables = described_class.new(repo)
 
-            expect(magic_variables[:_rebase_base]).to eq 'abc123'
+            expect(magic_variables.fetch(:_rebase_base)).to eq 'abc123'
           end
         end
       end
@@ -57,7 +58,7 @@ describe Gitsh::MagicVariables do
             repo = stub('GitRepository', git_dir: tmpdir_path)
             magic_variables = described_class.new(repo)
 
-            expect(magic_variables[:_rebase_base]).to eq 'def456'
+            expect(magic_variables.fetch(:_rebase_base)).to eq 'def456'
           end
         end
       end
@@ -68,7 +69,7 @@ describe Gitsh::MagicVariables do
             repo = stub('GitRepository', git_dir: tmpdir_path)
             magic_variables = described_class.new(repo)
 
-            expect(magic_variables[:_rebase_base]).to be_nil
+            expect(magic_variables.fetch(:_rebase_base)).to be_nil
           end
         end
       end

--- a/spec/units/prompter_spec.rb
+++ b/spec/units/prompter_spec.rb
@@ -114,7 +114,7 @@ describe Gitsh::Prompter do
       }
       stub('Environment', default_attrs.merge(attrs)) do |env|
         env.stubs(:[]).with('gitsh.prompt').returns(format)
-        env.stubs(:fetch).with('gitsh.prompt', Gitsh::Prompter::DEFAULT_FORMAT).returns(
+        env.stubs(:fetch).with('gitsh.prompt').returns(
           format || Gitsh::Prompter::DEFAULT_FORMAT
         )
       end


### PR DESCRIPTION
This PR paves the way for making unset variables raise an error (#136) which in turn will pave the way for lazily evaluating variables in command arguments (#197).

After attempting to implement lazy variable evaluation directly it became apparent that staying consistent with the way general purpose Unix shells handle unset variables is going to introduce a lot of complexity, far more than keeping that behaviour would justify (@mike-burns never liked it anyway—see discussion on #136—and I probably should have listened).

* Modify `Gitsh::Environment#fetch` and `Gitsh::GitRepository#config` to raise if no default value is given.
* Move default values from arguments to blocks to easily distinguish between “there is no default” and “the default is set to `nil`”.
* Remove `Gitsh::Environment#[]` and `Gitsh::MagicVariables#[]` entirely, in favour of `#fetch` methods.
* Update `Gitsh::Environment#fetch` to read from magic variables, which were previously only accessible via `#[]`.