### PR TITLE
Consider unset variables to be an error.

### DIFF
--- a/lib/gitsh/environment.rb
+++ b/lib/gitsh/environment.rb
@@ -1,3 +1,4 @@
+require 'gitsh/error'
 require 'gitsh/git_repository'
 require 'gitsh/magic_variables'
 
@@ -39,7 +40,7 @@ module Gitsh
         end
       end
     rescue KeyError
-      raise KeyError, "Variable '#{key}' is not set"
+      raise Gitsh::UnsetVariableError, "Variable '#{key}' is not set"
     end
 
     def config_variables

--- a/lib/gitsh/error.rb
+++ b/lib/gitsh/error.rb
@@ -1,0 +1,7 @@
+module Gitsh
+  class Error < StandardError
+  end
+
+  class UnsetVariableError < Error
+  end
+end

--- a/lib/gitsh/interpreter.rb
+++ b/lib/gitsh/interpreter.rb
@@ -1,3 +1,4 @@
+require 'gitsh/error'
 require 'gitsh/parser'
 
 module Gitsh
@@ -11,6 +12,8 @@ module Gitsh
       build_command(input).execute
     rescue Parslet::ParseFailed
       env.puts_error('gitsh: parse error')
+    rescue Gitsh::Error => err
+      env.puts_error("gitsh: #{err.message}")
     end
 
     private

--- a/lib/gitsh/transformer.rb
+++ b/lib/gitsh/transformer.rb
@@ -26,8 +26,7 @@ module Gitsh
     end
 
     rule(var: simple(:var)) do |context|
-      key = context[:var]
-      context[:env].fetch(key) { nil }
+      context[:env].fetch(context[:var])
     end
 
     rule(arg: subtree(:parts)) do |context|

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -239,13 +239,10 @@ branch.
 .El
 .El
 .Pp
-Unset variables will be ignored, as then are in
-.Xr sh 1 .
-For example, the commit message produced by the following command will be
-.Ic "a commit" :
-.Bd -literal -offset indent
-@ commit -m $unset "a commit"
-.Ed
+Attempting to use an unset variable will cause a command to fail. This is
+different to
+.Xr sh 1 ,
+which will ignore unset variable arguments.
 .Sh CONFIGURATION
 The following
 .Xr git-config 1

--- a/spec/integration/variables_spec.rb
+++ b/spec/integration/variables_spec.rb
@@ -69,17 +69,12 @@ describe 'Gitsh variables' do
     end
   end
 
-  it 'does not pass unset variables on to commands' do
+  it 'errors when told to read an unset variable' do
     GitshRunner.interactive do |gitsh|
       gitsh.type(':echo "hello $unset world"')
 
-      expect(gitsh).to output_no_errors
-      expect(gitsh).to output /hello  world/
-
-      gitsh.type(':echo hello $unset world')
-
-      expect(gitsh).to output_no_errors
-      expect(gitsh).to output /hello world/
+      expect(gitsh).to output_nothing
+      expect(gitsh).to output_error /unset/
     end
   end
 end

--- a/spec/units/environment_spec.rb
+++ b/spec/units/environment_spec.rb
@@ -56,10 +56,11 @@ describe Gitsh::Environment do
     end
 
     context 'for an unknown variable with no default block given' do
-      it 'raises a KeyError' do
+      it 'raises an error' do
         env = described_class.new
 
-        expect { env.fetch(:unknown) }.to raise_exception(KeyError, /unknown/)
+        expect { env.fetch(:unknown) }.
+          to raise_exception(Gitsh::UnsetVariableError, /unknown/)
       end
     end
   end

--- a/spec/units/interpreter_spec.rb
+++ b/spec/units/interpreter_spec.rb
@@ -29,5 +29,17 @@ describe Gitsh::Interpreter do
 
       expect(env).to have_received(:puts_error).with('gitsh: parse error')
     end
+
+    it 'handles gitsh errors' do
+      env = stub('env', puts_error: nil)
+      parser = stub('Parser')
+      parser.stubs(:parse_and_transform).raises(Gitsh::Error, 'An error message')
+      parser_factory = stub('ParserFactory', new: parser)
+
+      interpreter = Gitsh::Interpreter.new(env, parser_factory: parser_factory)
+      interpreter.execute('add -p')
+
+      expect(env).to have_received(:puts_error).with('gitsh: An error message')
+    end
   end
 end

--- a/spec/units/transformer_spec.rb
+++ b/spec/units/transformer_spec.rb
@@ -73,12 +73,6 @@ describe Gitsh::Transformer do
       expect(output).to eq 'Jane Doe'
     end
 
-    it 'transforms unknown variables arguments to nil' do
-      env = {}
-      output = transformer.apply({ arg: [{ var: 'author' }] }, env: env)
-      expect(output).to be_nil
-    end
-
     it 'transforms empty string arguments' do
       output = transformer.apply({ arg: [{ empty_string: "''" }] }, env: env)
       expect(output).to eq ''


### PR DESCRIPTION
If a command uses a variable that has not previously been set, the command will not be executed, and an error message will be printed identifying the unset variable.

Fixes #136