### PR TITLE
Lazily evaluate variables

### DIFF
--- a/lib/gitsh/argument_builder.rb
+++ b/lib/gitsh/argument_builder.rb
@@ -1,0 +1,52 @@
+require 'gitsh/arguments/composite_argument'
+require 'gitsh/arguments/string_argument'
+require 'gitsh/arguments/variable_argument'
+
+module Gitsh
+  class ArgumentBuilder
+    def self.build
+      builder = new
+      yield builder
+      builder.argument
+    end
+
+    def initialize
+      @arguments = []
+      @literals = []
+    end
+
+    def add_literal(literal)
+      literals << literal
+    end
+
+    def add_variable(variable_name)
+      collect_literals
+      arguments << Arguments::VariableArgument.new(variable_name)
+    end
+
+    def argument
+      collect_literals
+      combined_arguments
+    end
+
+    private
+
+    attr_accessor :literals
+    attr_reader :arguments
+
+    def collect_literals
+      if literals.any?
+        arguments << Arguments::StringArgument.new(literals.join(''))
+        self.literals = []
+      end
+    end
+
+    def combined_arguments
+      if arguments.length == 1
+        arguments.first
+      else
+        Arguments::CompositeArgument.new(arguments)
+      end
+    end
+  end
+end

--- a/lib/gitsh/argument_list.rb
+++ b/lib/gitsh/argument_list.rb
@@ -1,0 +1,21 @@
+module Gitsh
+  class ArgumentList
+    def initialize(args)
+      @args = args
+    end
+
+    def length
+      args.length
+    end
+
+    def values(env)
+      @args.map do |arg|
+        arg.value(env)
+      end
+    end
+
+    private
+
+    attr_reader :args
+  end
+end

--- a/lib/gitsh/arguments/composite_argument.rb
+++ b/lib/gitsh/arguments/composite_argument.rb
@@ -1,0 +1,13 @@
+module Gitsh
+  module Arguments
+    class CompositeArgument
+      def initialize(parts)
+        @parts = parts
+      end
+
+      def value(env)
+        @parts.map { |part| part.value(env) }.join('')
+      end
+    end
+  end
+end

--- a/lib/gitsh/arguments/string_argument.rb
+++ b/lib/gitsh/arguments/string_argument.rb
@@ -1,0 +1,13 @@
+module Gitsh
+  module Arguments
+    class StringArgument
+      def initialize(value)
+        @value = value
+      end
+
+      def value(env)
+        @value
+      end
+    end
+  end
+end

--- a/lib/gitsh/arguments/variable_argument.rb
+++ b/lib/gitsh/arguments/variable_argument.rb
@@ -1,0 +1,13 @@
+module Gitsh
+  module Arguments
+    class VariableArgument
+      def initialize(variable_name)
+        @variable_name = variable_name
+      end
+
+      def value(env)
+        env.fetch(@variable_name)
+      end
+    end
+  end
+end

--- a/lib/gitsh/commands/git_command.rb
+++ b/lib/gitsh/commands/git_command.rb
@@ -6,7 +6,7 @@ module Gitsh::Commands
     private
 
     def command_with_arguments
-      [git_command, config_arguments, command, args].flatten
+      [git_command, config_arguments, command, arg_values].flatten
     end
 
     def git_command

--- a/lib/gitsh/commands/internal_command.rb
+++ b/lib/gitsh/commands/internal_command.rb
@@ -1,6 +1,6 @@
 module Gitsh::Commands
   module InternalCommand
-    def self.new(env, command, args=[])
+    def self.new(env, command, args)
       command_class(command).new(env, command, args)
     end
 
@@ -13,7 +13,7 @@ module Gitsh::Commands
     end
 
     class Base
-      def initialize(env, command, args=[])
+      def initialize(env, command, args)
         @env = env
         @command = command
         @args = args
@@ -32,6 +32,10 @@ module Gitsh::Commands
       private
 
       attr_reader :env, :command, :args
+
+      def arg_values
+        @arg_values ||= args.values(env)
+      end
     end
 
     class Set < Base
@@ -46,7 +50,7 @@ TXT
 
       def execute
         if valid_arguments?
-          key, value = args
+          key, value = arg_values
           env[key] = value
           true
         else
@@ -73,7 +77,7 @@ TXT
       end
 
       def execute
-        env.puts args.join(' ')
+        env.puts arg_values.join(' ')
         true
       end
     end
@@ -112,7 +116,7 @@ TXT
       end
 
       def path
-        File.expand_path(args.first)
+        File.expand_path(arg_values.first)
       end
     end
 
@@ -147,7 +151,7 @@ TXT
       private
 
       def subject
-        args.first.to_s.sub(/^:/, '')
+        arg_values.first.to_s.sub(/^:/, '')
       end
     end
 

--- a/lib/gitsh/commands/shell_command.rb
+++ b/lib/gitsh/commands/shell_command.rb
@@ -1,6 +1,6 @@
 module Gitsh::Commands
   class ShellCommand
-    def initialize(env, command, args = [])
+    def initialize(env, command, args)
       @env = env
       @command = command
       @args = args
@@ -24,7 +24,11 @@ module Gitsh::Commands
     attr_reader :env, :command, :args
 
     def command_with_arguments
-      [command, args].flatten
+      [command, arg_values].flatten
+    end
+
+    def arg_values
+      args.values(env)
     end
 
     def wait_for_process(pid)

--- a/spec/integration/chaining_spec.rb
+++ b/spec/integration/chaining_spec.rb
@@ -17,9 +17,16 @@ describe 'Chaining methods' do
       end
     end
 
-    it 'sets a variable and reads it back out' do
+    it 'sets a git config variable and reads it back out' do
       GitshRunner.interactive do |gitsh|
         gitsh.type(':set test.setting hello && config test.setting')
+        expect(gitsh).to output 'hello'
+      end
+    end
+
+    it 'sets a variable and reads it back out' do
+      GitshRunner.interactive do |gitsh|
+        gitsh.type(':set test hello && :echo $test')
         expect(gitsh).to output 'hello'
       end
     end

--- a/spec/support/arguments.rb
+++ b/spec/support/arguments.rb
@@ -1,0 +1,9 @@
+module Arguments
+  def arguments(*values)
+    stub("ArgumentList", values: values, length: values.length)
+  end
+end
+
+RSpec.configure do |config|
+  config.include Arguments
+end

--- a/spec/units/argument_builder_spec.rb
+++ b/spec/units/argument_builder_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+require 'gitsh/argument_builder'
+
+describe Gitsh::ArgumentBuilder do
+  describe 'building a StringArgument with #add_literal' do
+    it 'concatenates the values passed to subsequent add_literal calls' do
+      string_argument = stub('StringArgument')
+      Gitsh::Arguments::StringArgument.stubs(:new).returns(string_argument)
+
+      built_argument = described_class.build do |builder|
+        builder.add_literal('Hello')
+        builder.add_literal(' ')
+        builder.add_literal('world')
+      end
+
+      expect(built_argument).to be string_argument
+      expect(Gitsh::Arguments::StringArgument).to have_received(:new).once.
+        with('Hello world')
+    end
+  end
+
+  describe 'building a VariableArgument with #add_variable' do
+    it 'creates a variable argument to access the variable' do
+      variable_argument = stub('VariableArgument')
+      Gitsh::Arguments::VariableArgument.stubs(:new).returns(variable_argument)
+
+      built_argument = described_class.build do |builder|
+        builder.add_variable('author')
+      end
+
+      expect(built_argument).to be variable_argument
+      expect(Gitsh::Arguments::VariableArgument).to have_received(:new).once.
+        with('author')
+    end
+  end
+
+  describe 'building a CompositeArgument with multiple calls to #add_variable' do
+    it 'creates a composite argument of several VariableArguments' do
+      composite_argument = stub('CompositeArgument')
+      variable_argument = stub('VariableArgument')
+      Gitsh::Arguments::VariableArgument.stubs(:new).returns(variable_argument)
+      Gitsh::Arguments::CompositeArgument.stubs(:new).returns(composite_argument)
+
+      built_argument = described_class.build do |builder|
+        builder.add_variable('foo')
+        builder.add_variable('bar')
+      end
+
+      expect(built_argument).to be composite_argument
+      expect(Gitsh::Arguments::CompositeArgument).to have_received(:new).once.
+        with([variable_argument, variable_argument])
+      expect(Gitsh::Arguments::VariableArgument).to have_received(:new).once.
+        with('foo')
+      expect(Gitsh::Arguments::VariableArgument).to have_received(:new).once.
+        with('bar')
+    end
+  end
+
+  describe 'building a CompositeArgument with mixed types' do
+    it 'creates a composite argument' do
+      composite_argument = stub('CompositeArgument')
+      string_argument = stub('StringArgument')
+      variable_argument = stub('VariableArgument')
+      Gitsh::Arguments::CompositeArgument.stubs(:new).returns(composite_argument)
+      Gitsh::Arguments::StringArgument.stubs(:new).returns(string_argument)
+      Gitsh::Arguments::VariableArgument.stubs(:new).returns(variable_argument)
+
+      built_argument = described_class.build do |builder|
+        builder.add_literal('pre')
+        builder.add_literal('fix')
+        builder.add_variable('foo')
+        builder.add_literal('suffix')
+      end
+
+      expect(built_argument).to be composite_argument
+      expect(Gitsh::Arguments::CompositeArgument).to have_received(:new).once.
+        with([string_argument, variable_argument, string_argument])
+      expect(Gitsh::Arguments::VariableArgument).to have_received(:new).once.
+        with('foo')
+      expect(Gitsh::Arguments::StringArgument).to have_received(:new).once.
+        with('prefix')
+      expect(Gitsh::Arguments::StringArgument).to have_received(:new).once.
+        with('suffix')
+    end
+  end
+end

--- a/spec/units/argument_list_spec.rb
+++ b/spec/units/argument_list_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'gitsh/argument_list'
+
+describe Gitsh::ArgumentList do 
+  describe '#length' do
+    it 'returns the number of arguments' do
+      argument_list = Gitsh::ArgumentList.new(['hello', 'goodbye'])
+
+      expect(argument_list.length).to eq 2
+    end
+  end
+
+  describe '#values' do
+    it 'returns the values of the arguments' do
+      env = stub('env')
+      hello_arg = stub('hello_arg', value: 'hello')
+      goodbye_arg = stub('goodbye_arg', value: 'goodbye')
+      argument_list = Gitsh::ArgumentList.new([hello_arg, goodbye_arg])
+
+      expect(argument_list.values(env)).to eq ['hello', 'goodbye']
+      expect(hello_arg).to have_received(:value).with(env)
+      expect(goodbye_arg).to have_received(:value).with(env)
+    end
+  end
+end

--- a/spec/units/arguments/composite_argument_spec.rb
+++ b/spec/units/arguments/composite_argument_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+require 'gitsh/arguments/composite_argument'
+
+describe Gitsh::Arguments::CompositeArgument do
+  describe '#value' do
+    it 'returns the concatenated values of the arguments passed to the initializer' do
+      env = stub('env')
+      first_argument = stub('first_argument', value: 'Hello')
+      second_argument = stub('second_argument', value: 'World')
+      argument = described_class.new([first_argument, second_argument])
+
+      expect(argument.value(env)).to eq 'HelloWorld'
+      expect(first_argument).to have_received(:value).with(env)
+      expect(second_argument).to have_received(:value).with(env)
+    end
+  end
+end

--- a/spec/units/arguments/string_argument_spec.rb
+++ b/spec/units/arguments/string_argument_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'gitsh/arguments/string_argument'
+
+describe Gitsh::Arguments::StringArgument do
+  describe '#value' do
+    it 'returns the string passed to the initializer' do
+      arg = described_class.new('Hello world')
+      env = stub('env')
+
+      expect(arg.value(env)).to eq 'Hello world'
+    end
+  end
+end

--- a/spec/units/arguments/variable_argument_spec.rb
+++ b/spec/units/arguments/variable_argument_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'gitsh/arguments/variable_argument'
+
+describe Gitsh::Arguments::VariableArgument do
+  describe '#value' do
+    it 'returns the value of the variable passed to the initializer' do
+      env = { 'author' => 'George' }
+      argument = described_class.new('author')
+
+      expect(argument.value(env)).to eq 'George'
+    end
+  end
+end

--- a/spec/units/commands/git_command_spec.rb
+++ b/spec/units/commands/git_command_spec.rb
@@ -15,7 +15,11 @@ describe Gitsh::Commands::GitCommand do
   describe '#execute' do
     it 'spawns a process with the sub command and arguments' do
       env.stubs(config_variables: {})
-      command = described_class.new(env, 'commit', ['-m', 'A test commit'])
+      command = described_class.new(
+        env,
+        'commit',
+        arguments('-m', 'A test commit'),
+      )
 
       command.execute
 
@@ -33,7 +37,11 @@ describe Gitsh::Commands::GitCommand do
         :'test.example' => 'This is an example',
         :'foo.bar' => '1'
       })
-      command = described_class.new(env, 'commit', ['-m', 'A test commit'])
+      command = described_class.new(
+        env,
+        'commit',
+        arguments('-m', 'A test commit'),
+      )
 
       command.execute
 

--- a/spec/units/commands/internal/chdir_spec.rb
+++ b/spec/units/commands/internal/chdir_spec.rb
@@ -7,14 +7,14 @@ describe Gitsh::Commands::InternalCommand::Chdir do
   describe '#execute' do
     it 'returns true for correct directories' do
       env = stub(:[]= => true, puts_error: true)
-      command = described_class.new(env, 'cd', ['./'])
+      command = described_class.new(env, 'cd', arguments('./'))
 
       expect(command.execute).to be_true
     end
 
     it 'returns false with invalid arguments' do
       env = stub(:[]= => true, puts_error: true)
-      command = described_class.new(env, 'cd', ['foo'])
+      command = described_class.new(env, 'cd', arguments('foo'))
 
       expect(command.execute).to be_false
     end

--- a/spec/units/commands/internal/echo_spec.rb
+++ b/spec/units/commands/internal/echo_spec.rb
@@ -7,7 +7,7 @@ describe Gitsh::Commands::InternalCommand::Echo do
   describe '#execute' do
     it 'prints all arguments to the environment joined with a space' do
       env = stub('env', puts: nil)
-      command = described_class.new(env, 'echo', %w(foo bar))
+      command = described_class.new(env, 'echo', arguments('foo', 'bar'))
 
       expect(command.execute).to be_true
       expect(env).to have_received(:puts).with('foo bar')
@@ -15,7 +15,7 @@ describe Gitsh::Commands::InternalCommand::Echo do
 
     it 'prints a newline when no arguments are passed' do
       env = stub('env', puts: nil)
-      command = described_class.new(env, 'echo', [])
+      command = described_class.new(env, 'echo', arguments())
 
       expect(command.execute).to be_true
       expect(env).to have_received(:puts).with('')

--- a/spec/units/commands/internal/exit_spec.rb
+++ b/spec/units/commands/internal/exit_spec.rb
@@ -6,7 +6,7 @@ describe Gitsh::Commands::InternalCommand::Exit do
 
   describe '#execute' do
     it 'exits the program' do
-      command = described_class.new(stub('env'), 'exit')
+      command = described_class.new(stub('env'), 'exit', arguments())
       expect { command.execute }.to raise_exception(SystemExit)
     end
   end

--- a/spec/units/commands/internal/help_spec.rb
+++ b/spec/units/commands/internal/help_spec.rb
@@ -8,7 +8,7 @@ describe Gitsh::Commands::InternalCommand::Help do
     context "with no arguments" do
       it "prints out some stuff" do
         env = stub('env', puts: nil)
-        command = described_class.new(env, 'help')
+        command = described_class.new(env, 'help', arguments())
 
         expect(command.execute).to be_true
         expect(env).to have_received(:puts).at_least_once
@@ -18,7 +18,7 @@ describe Gitsh::Commands::InternalCommand::Help do
     context "with an argument that matches an existing command" do
       it "prints out command-specific information" do
         env = stub('env', puts: nil)
-        command = described_class.new(env, 'help', ['set'])
+        command = described_class.new(env, 'help', arguments('set'))
         set_command = stub('Set', help_message: 'Sets variables')
         Gitsh::Commands::InternalCommand.stubs(:command_class).
           with('set').
@@ -32,7 +32,7 @@ describe Gitsh::Commands::InternalCommand::Help do
     context 'with a colon-prefixed argument' do
       it 'strips the colon' do
         env = stub('env', puts: nil)
-        command = described_class.new(env, 'help', [':set'])
+        command = described_class.new(env, 'help', arguments(':set'))
         set_command = stub('Set', help_message: 'Sets variables')
         Gitsh::Commands::InternalCommand.stubs(:command_class).
           with('set').
@@ -46,7 +46,11 @@ describe Gitsh::Commands::InternalCommand::Help do
     context "with arguments that don't match an existing command" do
       it "prints out some stuff" do
         env = stub('env', puts: nil)
-        command = described_class.new(env, 'help', ["we don't do this here"])
+        command = described_class.new(
+          env,
+          'help',
+          arguments("we don't do this here"),
+        )
 
         expect(command.execute).to be_true
         expect(env).to have_received(:puts).at_least_once

--- a/spec/units/commands/internal/set_spec.rb
+++ b/spec/units/commands/internal/set_spec.rb
@@ -7,7 +7,7 @@ describe Gitsh::Commands::InternalCommand::Set do
   describe '#execute' do
     it 'sets a variable on the environment' do
       env = stub('env', :[]=)
-      command = described_class.new(env, 'set', %w(foo bar))
+      command = described_class.new(env, 'set', arguments('foo', 'bar'))
 
       command.execute
 
@@ -16,14 +16,14 @@ describe Gitsh::Commands::InternalCommand::Set do
 
     it 'returns true with correct arguments' do
       env = stub(:[]= => true, puts_error: true)
-      command = described_class.new(env, 'set', %w(foo bar))
+      command = described_class.new(env, 'set', arguments('foo', 'bar'))
 
       expect(command.execute).to be_true
     end
 
     it 'returns false with invalid arguments' do
       env = stub(:[]= => true, puts_error: true)
-      command = described_class.new(env, 'set', %w(foo))
+      command = described_class.new(env, 'set', arguments('foo'))
 
       expect(command.execute).to be_false
     end

--- a/spec/units/commands/internal/unknown_spec.rb
+++ b/spec/units/commands/internal/unknown_spec.rb
@@ -7,7 +7,7 @@ describe Gitsh::Commands::InternalCommand::Unknown do
   describe '#execute' do
     it 'outputs an error message' do
       env = stub('env', puts_error: nil)
-      command = described_class.new(env, 'notacommand')
+      command = described_class.new(env, 'notacommand', arguments())
 
       command.execute
 

--- a/spec/units/commands/internal_command_spec.rb
+++ b/spec/units/commands/internal_command_spec.rb
@@ -9,12 +9,12 @@ describe Gitsh::Commands::InternalCommand do
     end
 
     it 'returns an Exit command when given the command "exit"' do
-      command = described_class.new(stub('env'), 'exit')
+      command = described_class.new(stub('env'), 'exit', arguments())
       expect(command).to be_a described_class::Exit
     end
 
     it 'returns an Exit command when given the command "q"' do
-      command = described_class.new(stub('env'), 'q')
+      command = described_class.new(stub('env'), 'q', arguments())
       expect(command).to be_a described_class::Exit
     end
 
@@ -24,7 +24,7 @@ describe Gitsh::Commands::InternalCommand do
     end
 
     it 'returns a Help command when given the command "help"' do
-      command = described_class.new(stub('env'), 'help')
+      command = described_class.new(stub('env'), 'help', arguments())
       expect(command).to be_a described_class::Help
     end
 

--- a/spec/units/commands/shell_command_spec.rb
+++ b/spec/units/commands/shell_command_spec.rb
@@ -9,7 +9,7 @@ describe Gitsh::Commands::ShellCommand do
     end
 
     it 'spawns a process with the command and arguments' do
-      command = described_class.new(env, 'echo', ['Hello world'])
+      command = described_class.new(env, 'echo', arguments('Hello world'))
 
       command.execute
 
@@ -22,21 +22,21 @@ describe Gitsh::Commands::ShellCommand do
 
     it 'returns true when the shell command succeeds' do
       $?.stubs(success?: true)
-      command = described_class.new(env, 'echo', ['Hello world'])
+      command = described_class.new(env, 'echo', arguments('Hello world'))
 
       expect(command.execute).to eq true
     end
 
     it 'returns false when the shell command fails' do
       $?.stubs(success?: false)
-      command = described_class.new(env, 'badcommand', ['Hello world'])
+      command = described_class.new(env, 'badcommand', arguments('Hello world'))
 
       expect(command.execute).to eq false
     end
 
     it 'returns false when Process.spawn raises' do
       Process.stubs(:spawn).raises(Errno::ENOENT, 'No such file')
-      command = described_class.new(env, 'badcommand', ['Hello world'])
+      command = described_class.new(env, 'badcommand', arguments('Hello world'))
 
       expect(command.execute).to eq false
     end
@@ -45,7 +45,7 @@ describe Gitsh::Commands::ShellCommand do
       pid = 12
       Process.stubs(:spawn).returns(pid)
       Process.stubs(:wait).with(pid).raises(Interrupt).then.returns(nil)
-      command = described_class.new(env, 'vim', [])
+      command = described_class.new(env, 'vim', arguments())
 
       command.execute
 


### PR DESCRIPTION
Originally, gitsh would replace a variable with its value when transforming a command's AST into a command object. This made it impossible to write and then read a variable in the same command, e.g. with `:set x 1 && :echo $x`

Fixes #197 