### PR TITLE
Abbreviate branch name

### DIFF
--- a/lib/gitsh/prompter.rb
+++ b/lib/gitsh/prompter.rb
@@ -1,9 +1,12 @@
+# encoding: utf-8
+
 require 'gitsh/colors'
 require 'gitsh/prompt_color'
 
 module Gitsh
   class Prompter
-    DEFAULT_FORMAT = "%D %c%b%#%w".freeze
+    DEFAULT_FORMAT = "%D %c%B%#%w".freeze
+    BRANCH_CHAR_LIMIT = 15
 
     def initialize(options={})
       @env = options.fetch(:env)
@@ -13,8 +16,9 @@ module Gitsh
     end
 
     def prompt
-      padded_prompt_format.gsub(/%[bcdDw#]/, {
+      padded_prompt_format.gsub(/%[bBcdDw#]/, {
         '%b' => branch_name,
+        "%B" => shortened_branch_name,
         '%c' => status_color,
         '%d' => Dir.getwd,
         '%D' => File.basename(Dir.getwd),
@@ -33,6 +37,18 @@ module Gitsh
 
     def prompt_format
       env.fetch('gitsh.prompt') { DEFAULT_FORMAT }
+    end
+
+    def shortened_branch_name
+      branch_name[0...BRANCH_CHAR_LIMIT] + ellipsis
+    end
+
+    def ellipsis
+      if branch_name.length > BRANCH_CHAR_LIMIT
+        '…'
+      else
+        ''
+      end
     end
 
     def branch_name

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -103,7 +103,8 @@ and the terminator sigil.
 .Pp
 The current HEAD is a branch name, tag name, abbreviated SHA, or the text
 .Li uninitialized
-when the present working directory is not a git repository.
+when the present working directory is not a git repository. It is limited to 15
+characters.
 .Pp
 The state of the repository is reflected by the terminating sigil and the color
 of both the current HEAD and the sigil:
@@ -125,7 +126,8 @@ command. The following placeholders can be used in the custom prompt:
 .Bl -column ".Sy Placeholder" ".Sy Meaning" -offset indent
 .It Sy Placeholder  Ta Sy Meaning
 .It %#              Ta terminating sigil (see previous table)
-.It %b              Ta current HEAD (branch name, tag name, etc.)
+.It %b              Ta current HEAD (full branch name, tag name, etc.)
+.It \&%B            Ta current HEAD, limited to 15 characters
 .It %d              Ta absolute path to current working directory
 .It \&%D            Ta basename of the current working directory
 .It %c              Ta start coloring based on status (see previous table)

--- a/spec/integration/prompt_spec.rb
+++ b/spec/integration/prompt_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 
 describe 'The gitsh prompt' do
@@ -6,6 +8,15 @@ describe 'The gitsh prompt' do
       gitsh.type('init')
 
       expect(gitsh).to prompt_with "#{cwd_basename} master@ "
+    end
+  end
+
+  it 'defaults to abbreviated branch names' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type('init')
+      gitsh.type("checkout -b best-branch-name-ever-forever")
+
+      expect(gitsh).to prompt_with "#{cwd_basename} best-branch-nam…@ "
     end
   end
 

--- a/spec/integration/prompt_spec.rb
+++ b/spec/integration/prompt_spec.rb
@@ -1,13 +1,28 @@
 require 'spec_helper'
 
 describe 'The gitsh prompt' do
-  it 'is customised by a git config variable' do
+  it 'defaults to the directory basename and the branch name' do
     GitshRunner.interactive do |gitsh|
       gitsh.type('init')
+
       expect(gitsh).to prompt_with "#{cwd_basename} master@ "
+    end
+  end
+
+  it 'can be customised with a Git config variable' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type('init')
       gitsh.type('config gitsh.prompt "on %b %#"')
+
       expect(gitsh).to prompt_with 'on master @ '
+    end
+  end
+
+  it 'can be customised with a gitsh environment variable' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type('init')
       gitsh.type(':set gitsh.prompt "%d:%b%#"')
+
       expect(gitsh).to prompt_with "#{Dir.getwd}:master@ "
     end
   end

--- a/spec/units/prompter_spec.rb
+++ b/spec/units/prompter_spec.rb
@@ -5,56 +5,58 @@ describe Gitsh::Prompter do
   include Color
 
   describe '#prompt' do
-    context 'an un-initialized git repository' do
-      it 'displays an uninitialized prompt' do
-        env = env_double(repo_initialized?: false)
-        prompter = Gitsh::Prompter.new(env: env)
+    context 'with the default prompt format' do
+      context 'an un-initialized git repository' do
+        it 'displays an uninitialized prompt' do
+          env = env_double(repo_initialized?: false)
+          prompter = Gitsh::Prompter.new(env: env)
 
-        expect(prompter.prompt).to eq(
-          "#{cwd_basename} #{red}uninitialized!!#{clear} "
-        )
+          expect(prompter.prompt).to eq(
+            "#{cwd_basename} #{red}uninitialized!!#{clear} "
+          )
+        end
       end
-    end
 
-    context 'a clean repository' do
-      it 'displays the branch name and a clean symbol' do
-        env = env_double(repo_current_head: 'my-feature')
-        prompter = Gitsh::Prompter.new(env: env)
+      context 'a clean repository' do
+        it 'displays the branch name and a clean symbol' do
+          env = env_double(repo_current_head: 'my-feature')
+          prompter = Gitsh::Prompter.new(env: env)
 
-        expect(prompter.prompt).to eq(
-          "#{cwd_basename} #{red}my-feature@#{clear} "
-        )
+          expect(prompter.prompt).to eq(
+            "#{cwd_basename} #{red}my-feature@#{clear} "
+          )
+        end
       end
-    end
 
-    context 'a repository with untracked files' do
-      it 'displays the branch name and an untracked symbol' do
-        env = env_double(repo_has_untracked_files?: true)
-        prompter = Gitsh::Prompter.new(env: env)
+      context 'a repository with untracked files' do
+        it 'displays the branch name and an untracked symbol' do
+          env = env_double(repo_has_untracked_files?: true)
+          prompter = Gitsh::Prompter.new(env: env)
 
-        expect(prompter.prompt).to eq(
-          "#{cwd_basename} #{red}master!#{clear} "
-        )
+          expect(prompter.prompt).to eq(
+            "#{cwd_basename} #{red}master!#{clear} "
+          )
+        end
       end
-    end
 
-    context 'a repository with uncommitted changes' do
-      it 'displays the branch name an a modified symbol' do
-        env = env_double(repo_has_modified_files?: true)
-        prompter = Gitsh::Prompter.new(env: env)
+      context 'a repository with uncommitted changes' do
+        it 'displays the branch name an a modified symbol' do
+          env = env_double(repo_has_modified_files?: true)
+          prompter = Gitsh::Prompter.new(env: env)
 
-        expect(prompter.prompt).to eq(
-          "#{cwd_basename} #{red}master&#{clear} "
-        )
+          expect(prompter.prompt).to eq(
+            "#{cwd_basename} #{red}master&#{clear} "
+          )
+        end
       end
-    end
 
-    context 'with color disabled' do
-      it 'displays the prompt without colors' do
-        env = env_double(repo_has_modified_files?: true)
-        prompter = Gitsh::Prompter.new(color: false, env: env)
+      context 'with color disabled' do
+        it 'displays the prompt without colors' do
+          env = env_double(repo_has_modified_files?: true)
+          prompter = Gitsh::Prompter.new(color: false, env: env)
 
-        expect(prompter.prompt).to eq "#{cwd_basename} master& "
+          expect(prompter.prompt).to eq "#{cwd_basename} master& "
+        end
       end
     end
 

--- a/spec/units/prompter_spec.rb
+++ b/spec/units/prompter_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 require 'gitsh/prompter'
 
@@ -58,6 +60,15 @@ describe Gitsh::Prompter do
           expect(prompter.prompt).to eq "#{cwd_basename} master& "
         end
       end
+
+      context 'with a long branch name' do
+        it 'displays the shortened branch name' do
+          env = env_double(repo_current_head: "best-branch-name-ever-forever")
+          prompter = Gitsh::Prompter.new(env: env)
+
+          expect(prompter.prompt).to eq "#{cwd_basename} #{red}best-branch-nam…@#{clear} "
+        end
+      end
     end
 
     context 'with a custom prompt format' do
@@ -83,11 +94,24 @@ describe Gitsh::Prompter do
         expect(prompter.prompt).to eq "#{clear} "
       end
 
-      it 'replaces %b with the current HEAD name' do
-        env = env_double(repo_current_head: 'a-branch', format: '%b')
+      it 'replaces %b with the full current HEAD name' do
+        env = env_double(
+          repo_current_head: 'a-really-long-branch-name',
+          format: '%b',
+        )
         prompter = Gitsh::Prompter.new(env: env)
 
-        expect(prompter.prompt).to eq "a-branch "
+        expect(prompter.prompt).to eq 'a-really-long-branch-name '
+      end
+
+      it 'replaces %B with the abbreviated current HEAD name' do
+        env = env_double(
+          repo_current_head: 'a-really-long-branch-name',
+          format: '%B',
+        )
+        prompter = Gitsh::Prompter.new(env: env)
+
+        expect(prompter.prompt).to eq 'a-really-long-b… '
       end
 
       it 'replaces %d with the absolute path of the current directory' do


### PR DESCRIPTION
By default, only show the first 15 characters of the branch name in the prompt.

Fixes #143