### PR TITLE
Command error handling

### DIFF
--- a/lib/gitsh/commands/error_handler.rb
+++ b/lib/gitsh/commands/error_handler.rb
@@ -1,0 +1,21 @@
+module Gitsh
+  module Commands
+    class ErrorHandler
+      def initialize(command, env)
+        @command = command
+        @env = env
+      end
+
+      def execute
+        command.execute
+      rescue Gitsh::Error => error
+        env.puts_error("gitsh: #{error.message}")
+        false
+      end
+
+      private
+
+      attr_reader :command, :env
+    end
+  end
+end

--- a/lib/gitsh/commands/factory.rb
+++ b/lib/gitsh/commands/factory.rb
@@ -1,0 +1,36 @@
+require 'gitsh/argument_list'
+
+module Gitsh
+  module Commands
+    class Factory
+      def initialize(command_class, context)
+        @command_class = command_class
+        @context = context
+      end 
+
+      def build
+        command_class.new(env, command, argument_list)
+      end
+
+      private
+
+      attr_reader :command_class, :context
+
+      def argument_list
+        ArgumentList.new(args)
+      end
+
+      def env
+        context[:env]
+      end
+
+      def command
+        context[:cmd]
+      end
+
+      def args
+        context.fetch(:args, []).compact
+      end
+    end
+  end
+end

--- a/lib/gitsh/commands/factory.rb
+++ b/lib/gitsh/commands/factory.rb
@@ -1,4 +1,5 @@
 require 'gitsh/argument_list'
+require 'gitsh/commands/error_handler'
 
 module Gitsh
   module Commands
@@ -9,12 +10,16 @@ module Gitsh
       end 
 
       def build
-        command_class.new(env, command, argument_list)
+        ErrorHandler.new(command_instance, env)
       end
 
       private
 
       attr_reader :command_class, :context
+
+      def command_instance
+        command_class.new(env, command, argument_list)
+      end
 
       def argument_list
         ArgumentList.new(args)
@@ -25,7 +30,7 @@ module Gitsh
       end
 
       def command
-        context[:cmd]
+        context[:command]
       end
 
       def args

--- a/lib/gitsh/interpreter.rb
+++ b/lib/gitsh/interpreter.rb
@@ -12,8 +12,6 @@ module Gitsh
       build_command(input).execute
     rescue Parslet::ParseFailed
       env.puts_error('gitsh: parse error')
-    rescue Gitsh::Error => err
-      env.puts_error("gitsh: #{err.message}")
     end
 
     private

--- a/lib/gitsh/transformer.rb
+++ b/lib/gitsh/transformer.rb
@@ -1,6 +1,5 @@
 require 'parslet'
 require 'gitsh/argument_builder'
-require 'gitsh/argument_list'
 require 'gitsh/commands/factory'
 require 'gitsh/commands/git_command'
 require 'gitsh/commands/internal_command'
@@ -11,11 +10,11 @@ require 'gitsh/commands/tree'
 module Gitsh
   class Transformer < Parslet::Transform
     def self.command_rule(type, command_class)
-      rule(type => simple(:cmd)) do |context|
+      rule(type => simple(:command)) do |context|
         Commands::Factory.new(command_class, context).build
       end
 
-      rule(type => simple(:cmd), args: sequence(:args)) do |context|
+      rule(type => simple(:command), args: sequence(:args)) do |context|
         Commands::Factory.new(command_class, context).build
       end
     end

--- a/lib/gitsh/transformer.rb
+++ b/lib/gitsh/transformer.rb
@@ -1,6 +1,7 @@
 require 'parslet'
 require 'gitsh/argument_builder'
 require 'gitsh/argument_list'
+require 'gitsh/commands/factory'
 require 'gitsh/commands/git_command'
 require 'gitsh/commands/internal_command'
 require 'gitsh/commands/noop'
@@ -11,11 +12,11 @@ module Gitsh
   class Transformer < Parslet::Transform
     def self.command_rule(type, command_class)
       rule(type => simple(:cmd)) do |context|
-        command_class.new(context[:env], context[:cmd], ArgumentList.new([]))
+        Commands::Factory.new(command_class, context).build
       end
 
       rule(type => simple(:cmd), args: sequence(:args)) do |context|
-        command_class.new(context[:env], context[:cmd], ArgumentList.new(context[:args].compact))
+        Commands::Factory.new(command_class, context).build
       end
     end
 

--- a/spec/integration/chaining_spec.rb
+++ b/spec/integration/chaining_spec.rb
@@ -47,6 +47,16 @@ describe 'Chaining methods' do
         expect(gitsh).to output /nothing to commit/
       end
     end
+
+    it 'executes the second command if the first encounters an error' do
+      GitshRunner.interactive do |gitsh|
+        gitsh.type(':set name George')
+        gitsh.type(':echo $user_name || :echo $name')
+
+        expect(gitsh).to output_error /user_name/
+        expect(gitsh).to output /George/
+      end
+    end
   end
 
   describe 'Multi' do

--- a/spec/units/commands/error_handler_spec.rb
+++ b/spec/units/commands/error_handler_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'gitsh/commands/error_handler'
+
+describe Gitsh::Commands::ErrorHandler do
+  describe '#execute' do
+    context 'the command executes successfully' do
+      it 'returns the same value as the command' do
+        env = stub('env')
+        successful_execution = stub('successful_execution')
+        command_instance = stub('command_instance', execute: successful_execution)
+        handler = Gitsh::Commands::ErrorHandler.new(command_instance, env)
+
+        expect(handler.execute).to be command_instance.execute
+      end
+    end
+
+    context 'the command raises an error' do
+      it 'prints the error and returns false' do
+        env = stub('env', puts_error: nil)
+        command_instance = stub('command_instance')
+        command_instance.stubs(:execute).raises(Gitsh::Error, 'Oh noes!')
+        handler = Gitsh::Commands::ErrorHandler.new(command_instance, env)
+
+        expect(handler.execute).to eq false
+        expect(env).to have_received(:puts_error).with('gitsh: Oh noes!')
+      end
+    end
+  end
+end

--- a/spec/units/commands/factory_spec.rb
+++ b/spec/units/commands/factory_spec.rb
@@ -5,14 +5,20 @@ describe Gitsh::Commands::Factory do
   describe '#build' do
     it 'returns an instance of the given command class' do
       env = stub('env')
-      instance = stub('instance')
-      command_class = stub('command_class', new: instance)
-      context = { env: env, cmd: 'status' }
+      error_handler = stub('error_handler')
+      Gitsh::Commands::ErrorHandler.stubs(:new).returns(error_handler)
+      command_instance = stub('command_instance')
+      command_class = stub('command_class', new: command_instance)
+      context = { env: env, command: 'status' }
       factory = Gitsh::Commands::Factory.new(command_class, context)
 
       built_instance = factory.build
 
-      expect(built_instance).to be instance
+      expect(built_instance).to be error_handler
+      expect(Gitsh::Commands::ErrorHandler).to have_received(:new).with(
+        command_instance,
+        env,
+      )
       expect(command_class).to have_received(:new).with(
         env,
         'status',

--- a/spec/units/commands/factory_spec.rb
+++ b/spec/units/commands/factory_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'gitsh/commands/factory'
+
+describe Gitsh::Commands::Factory do
+  describe '#build' do
+    it 'returns an instance of the given command class' do
+      env = stub('env')
+      instance = stub('instance')
+      command_class = stub('command_class', new: instance)
+      context = { env: env, cmd: 'status' }
+      factory = Gitsh::Commands::Factory.new(command_class, context)
+
+      built_instance = factory.build
+
+      expect(built_instance).to be instance
+      expect(command_class).to have_received(:new).with(
+        env,
+        'status',
+        instance_of(Gitsh::ArgumentList),
+      )
+    end
+  end
+end

--- a/spec/units/interpreter_spec.rb
+++ b/spec/units/interpreter_spec.rb
@@ -29,17 +29,5 @@ describe Gitsh::Interpreter do
 
       expect(env).to have_received(:puts_error).with('gitsh: parse error')
     end
-
-    it 'handles gitsh errors' do
-      env = stub('env', puts_error: nil)
-      parser = stub('Parser')
-      parser.stubs(:parse_and_transform).raises(Gitsh::Error, 'An error message')
-      parser_factory = stub('ParserFactory', new: parser)
-
-      interpreter = Gitsh::Interpreter.new(env, parser_factory: parser_factory)
-      interpreter.execute('add -p')
-
-      expect(env).to have_received(:puts_error).with('gitsh: An error message')
-    end
   end
 end

--- a/spec/units/transformer_spec.rb
+++ b/spec/units/transformer_spec.rb
@@ -19,42 +19,90 @@ describe Gitsh::Transformer do
     end
 
     it 'transforms git commands' do
+      command_factory = stub_command_factory
       output = transformer.apply({ git_cmd: 'status' }, env: env)
-      expect(output).to be_a Gitsh::Commands::GitCommand
+
+      expect(output).to be command_factory.build
+      expect(Gitsh::Commands::Factory).to have_received(:new).once.with(
+        Gitsh::Commands::GitCommand,
+        env: env,
+        cmd: 'status',
+      )
     end
 
     it 'transforms git commands with arguments' do
+      command_factory = stub_command_factory
+      argument_builder = stub_argument_builder
       output = transformer.apply(
         { git_cmd: 'add', args: [{ arg: parser_literals('-p') }] },
         env: env
       )
-      expect(output).to be_a Gitsh::Commands::GitCommand
+
+      expect(output).to be command_factory.build
+      expect(Gitsh::Commands::Factory).to have_received(:new).once.with(
+        Gitsh::Commands::GitCommand,
+        env: env,
+        cmd: 'add',
+        args: [argument_builder.argument],
+      )
     end
 
     it 'transforms internal commands' do
+      command_factory = stub_command_factory
       output = transformer.apply({ internal_cmd: 'set' }, env: env)
-      expect(output).to be_a Gitsh::Commands::InternalCommand::Set
+
+      expect(output).to be command_factory.build
+      expect(Gitsh::Commands::Factory).to have_received(:new).once.with(
+        Gitsh::Commands::InternalCommand,
+        env: env,
+        cmd: 'set',
+      )
     end
 
     it 'transforms internal commands with arguments' do
+      command_factory = stub_command_factory
+      argument_builder = stub_argument_builder
       output = transformer.apply(
         { internal_cmd: 'set', args: [{ arg: parser_literals('hi') }] },
         env: env
       )
-      expect(output).to be_a Gitsh::Commands::InternalCommand::Set
+
+      expect(output).to be command_factory.build
+      expect(Gitsh::Commands::Factory).to have_received(:new).once.with(
+        Gitsh::Commands::InternalCommand,
+        env: env,
+        cmd: 'set',
+        args: [argument_builder.argument],
+      )
     end
 
     it 'transforms shell commands' do
+      command_factory = stub_command_factory
       output = transformer.apply({ shell_cmd: '!pwd' }, env: env)
-      expect(output).to be_a Gitsh::Commands::ShellCommand
+
+      expect(output).to be command_factory.build
+      expect(Gitsh::Commands::Factory).to have_received(:new).once.with(
+        Gitsh::Commands::ShellCommand,
+        env: env,
+        cmd: '!pwd',
+      )
     end
 
     it 'transforms shell commands with arguments' do
+      command_factory = stub_command_factory
+      argument_builder = stub_argument_builder
       output = transformer.apply(
         { shell_cmd: '!echo', args: [{ arg: parser_literals('Hello') }] },
         env: env
       )
-      expect(output).to be_a Gitsh::Commands::ShellCommand
+
+      expect(output).to be command_factory.build
+      expect(Gitsh::Commands::Factory).to have_received(:new).once.with(
+        Gitsh::Commands::ShellCommand,
+        env: env,
+        cmd: '!echo',
+        args: [argument_builder.argument],
+      )
     end
 
     it 'transforms literal arguments' do
@@ -105,5 +153,12 @@ describe Gitsh::Transformer do
     )
     Gitsh::ArgumentBuilder.stubs(:build).yields(builder).returns(argument)
     builder
+  end
+
+  def stub_command_factory
+    command_instance = stub('command_instance')
+    factory_instance = stub('factory_instance', build: command_instance)
+    Gitsh::Commands::Factory.stubs(:new).returns(factory_instance)
+    factory_instance
   end
 end

--- a/spec/units/transformer_spec.rb
+++ b/spec/units/transformer_spec.rb
@@ -26,7 +26,7 @@ describe Gitsh::Transformer do
       expect(Gitsh::Commands::Factory).to have_received(:new).once.with(
         Gitsh::Commands::GitCommand,
         env: env,
-        cmd: 'status',
+        command: 'status',
       )
     end
 
@@ -42,7 +42,7 @@ describe Gitsh::Transformer do
       expect(Gitsh::Commands::Factory).to have_received(:new).once.with(
         Gitsh::Commands::GitCommand,
         env: env,
-        cmd: 'add',
+        command: 'add',
         args: [argument_builder.argument],
       )
     end
@@ -55,7 +55,7 @@ describe Gitsh::Transformer do
       expect(Gitsh::Commands::Factory).to have_received(:new).once.with(
         Gitsh::Commands::InternalCommand,
         env: env,
-        cmd: 'set',
+        command: 'set',
       )
     end
 
@@ -71,7 +71,7 @@ describe Gitsh::Transformer do
       expect(Gitsh::Commands::Factory).to have_received(:new).once.with(
         Gitsh::Commands::InternalCommand,
         env: env,
-        cmd: 'set',
+        command: 'set',
         args: [argument_builder.argument],
       )
     end
@@ -84,7 +84,7 @@ describe Gitsh::Transformer do
       expect(Gitsh::Commands::Factory).to have_received(:new).once.with(
         Gitsh::Commands::ShellCommand,
         env: env,
-        cmd: '!pwd',
+        command: '!pwd',
       )
     end
 
@@ -100,7 +100,7 @@ describe Gitsh::Transformer do
       expect(Gitsh::Commands::Factory).to have_received(:new).once.with(
         Gitsh::Commands::ShellCommand,
         env: env,
-        cmd: '!echo',
+        command: '!echo',
         args: [argument_builder.argument],
       )
     end


### PR DESCRIPTION
This PR moves the error handling from the `Gitsh::Interpreter` to a `Gitsh::Commands::ErrorHandler` decorator, so that a line that contains multiple commands can continue, even if one of those commands fails.

It makes it possible to do things like this:

```
% :set b "This is B"
% :echo $a || :echo $b
This is B
```

Fixes #213