### PR TITLE
Update INSTALL in the configure script.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,8 @@ gitsh is packaged and installed using GNU autotools.
         ./autogen.sh
         ./configure
 
-3. Regenerate the installation instructions:
-
-        make INSTALL
-        git commit -m "Update INSTALL"-- INSTALL
+3. Commit your changes to `configure.ac`, `INSTALL`, and any other files that
+   were modified by the version bump.
 
 4. Build and publish the release:
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = foreign
 SUBDIRS = src man lib/gitsh vendor spec
-EXTRA_DIST = LICENSE README.md INSTALL.in
+EXTRA_DIST = LICENSE README.md INSTALL
 
 .PHONY: release \
 	release_build release_push release_clean \
@@ -13,9 +13,6 @@ edit_package = sed \
 	-e 's|@PACKAGE_VERSION[@]|$(PACKAGE_VERSION)|g' \
 	-e 's|@DIST_ARCHIVES[@]|$(DIST_ARCHIVES)|g' \
 	-e 's|@DIST_SHA[@]|$(DIST_SHA)|g'
-
-INSTALL: Makefile INSTALL.in
-	$(edit_package) $@.in > $@
 
 release: release_build release_push release_clean
 

--- a/configure.ac
+++ b/configure.ac
@@ -49,5 +49,5 @@ AC_SUBST([vendorfiles])
 AC_SUBST([testfiles])
 AC_SUBST([gemsetuppath])
 
-AC_CONFIG_FILES([Makefile src/Makefile lib/gitsh/Makefile man/Makefile vendor/Makefile spec/Makefile])
+AC_CONFIG_FILES([Makefile src/Makefile lib/gitsh/Makefile man/Makefile vendor/Makefile spec/Makefile INSTALL])
 AC_OUTPUT


### PR DESCRIPTION
The way we were building the `INSTALL` instructions was causing `make distcheck` to fail: `make clean` wasn't cleaning up the `INSTALL` file, which was what we wanted for building in the source directory, but not when building from another directory.

Letting autoconf handle the `INSTALL` file fixes this problem, and simplifies the Makefile in the process.