### PR TITLE
:source command

### DIFF
--- a/lib/gitsh/cli.rb
+++ b/lib/gitsh/cli.rb
@@ -25,7 +25,7 @@ module Gitsh
       if unparsed_args.any?
         exit_with_usage_message
       elsif script_file
-        script_runner.run(script_file)
+        run_script
       else
         interactive_runner.run
       end
@@ -35,6 +35,13 @@ module Gitsh
 
     attr_reader :env, :unparsed_args, :script_file_argument,
       :interactive_runner, :script_runner
+
+    def run_script
+      script_runner.run(script_file)
+    rescue NoInputError => error
+      env.puts_error("gitsh: #{error.message}")
+      exit EX_NOINPUT
+    end
 
     def script_file
       if script_file_argument

--- a/lib/gitsh/commands/internal_command.rb
+++ b/lib/gitsh/commands/internal_command.rb
@@ -155,6 +155,37 @@ TXT
       end
     end
 
+    class Source < Base
+      USAGE_MESSAGE = 'usage: :source path'.freeze
+
+      def self.help_message
+        <<-TXT
+#{USAGE_MESSAGE}
+Runs the commands in the given file.
+TXT
+      end
+
+      def execute
+        if valid_arguments?
+          Gitsh::ScriptRunner.new(env: env).run(path)
+          true
+        else
+          env.puts_error USAGE_MESSAGE
+          false
+        end
+      end
+
+      private
+
+      def valid_arguments?
+        arg_values.length == 1
+      end
+
+      def path
+        arg_values.first
+      end
+    end
+
     class Unknown < Base
       def execute
         env.puts_error("gitsh: #{command}: command not found")
@@ -178,6 +209,7 @@ TXT
       q: Exit,
       echo: Echo,
       help: Help,
+      source: Source,
     }.freeze
   end
 end

--- a/lib/gitsh/error.rb
+++ b/lib/gitsh/error.rb
@@ -4,4 +4,7 @@ module Gitsh
 
   class UnsetVariableError < Error
   end
+
+  class NoInputError < Error
+  end
 end

--- a/lib/gitsh/script_runner.rb
+++ b/lib/gitsh/script_runner.rb
@@ -1,4 +1,4 @@
-require 'gitsh/exit_statuses'
+require 'gitsh/error'
 require 'gitsh/interpreter'
 
 module Gitsh
@@ -15,11 +15,9 @@ module Gitsh
         f.each_line { |line| interpreter.execute(line) }
       end
     rescue Errno::ENOENT
-      env.puts_error "gitsh: #{path}: No such file or directory"
-      exit EX_NOINPUT
+      raise NoInputError, "#{path}: No such file or directory"
     rescue Errno::EACCES
-      env.puts_error "gitsh: #{path}: Permission denied"
-      exit EX_NOINPUT
+      raise NoInputError, "#{path}: Permission denied"
     end
 
     private

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -188,6 +188,19 @@ changes directory to the given path.
 displays help about the given built-in command. Without an argument it outputs
 a list of all built-in commands. When given the name of a command, it outputs a
 usage message and brief description of that command.
+.It Ic :source path
+runs the commands in the given file. Variables
+.Ic :set
+in the sourced file will remain set after the
+.Ic :source
+command has finished, making it similar to the
+.Ic source
+built-in command in
+.Xr sh 1
+and other Unix shells.
+.Bd -literal -offset indent
+@ :source /home/george/.gitshrc
+.Ed
 .It Ic :exit
 ends the gitsh session.
 .It Ic :q

--- a/spec/integration/source_command_spec.rb
+++ b/spec/integration/source_command_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'The :source command' do
+  context 'a source file is given' do
+    it 'executes the commands in the sourced file' do
+      GitshRunner.interactive do |gitsh|
+        write_file('.gitshrc', ':set source_worked "Yes it did!"')
+
+        gitsh.type ':source .gitshrc'
+        gitsh.type ':echo $source_worked'
+
+        expect(gitsh).to output_no_errors
+        expect(gitsh).to output /Yes it did!/
+      end
+    end
+  end
+
+  context 'no source file is given' do
+    it 'prints an error message' do
+      GitshRunner.interactive do |gitsh|
+        gitsh.type ':source'
+
+        expect(gitsh).to output_error /usage/
+        expect(gitsh).to output_nothing
+      end
+    end
+  end
+
+  context 'a missing source file is given' do
+    it 'prints an error message' do
+      GitshRunner.interactive do |gitsh|
+        gitsh.type ':source not/a/real/file'
+
+        expect(gitsh).to output_error /No such file/
+        expect(gitsh).to output_nothing
+      end
+    end
+  end
+end

--- a/spec/units/cli_spec.rb
+++ b/spec/units/cli_spec.rb
@@ -52,6 +52,24 @@ describe Gitsh::CLI do
       end
     end
 
+    context 'with an unreadable script file' do
+      it 'exits' do
+        env = stub('env', puts_error: nil)
+        script_runner = stub('ScriptRunner')
+        script_runner.stubs(:run).raises(Gitsh::NoInputError, 'Oh no!')
+        interactive_runner = stub('InteractiveRunner')
+        cli = Gitsh::CLI.new(
+          env: env,
+          args: ['path/to/a/script'],
+          script_runner: script_runner,
+          interactive_runner: interactive_runner,
+        )
+
+        expect { cli.run }.to raise_exception(SystemExit)
+        expect(env).to have_received(:puts_error).with('gitsh: Oh no!')
+      end
+    end
+
     context 'with invalid arguments' do
       it 'exits with a usage message' do
         env = stub('Environment', puts_error: nil)

--- a/spec/units/commands/internal/source_spec.rb
+++ b/spec/units/commands/internal/source_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'gitsh/commands/internal_command'
+
+describe Gitsh::Commands::InternalCommand::Source do
+  it_behaves_like "an internal command"
+
+  describe "#execute" do
+    context "with a valid file" do
+      it "executes the script_runner and returns true" do
+        env = stub('env')
+        script_runner = stub('ScriptRunner', run: nil)
+        Gitsh::ScriptRunner.stubs(:new).returns(script_runner)
+        command = described_class.new(env, 'source', arguments('/path'))
+
+        result = command.execute
+
+        expect(Gitsh::ScriptRunner).to have_received(:new).with(env: env)
+        expect(script_runner).to have_received(:run).with('/path')
+        expect(result).to be_true
+      end
+    end
+
+    context "with no file argument" do
+      it "prints a usage message and returns false" do
+        env = stub('env', puts_error: nil)
+        command = described_class.new(env, 'source', arguments())
+
+        result = command.execute
+
+        expect(env).to have_received(:puts_error).with('usage: :source path')
+        expect(result).to be_false
+      end
+    end
+  end
+end

--- a/spec/units/commands/internal_command_spec.rb
+++ b/spec/units/commands/internal_command_spec.rb
@@ -28,6 +28,11 @@ describe Gitsh::Commands::InternalCommand do
       expect(command).to be_a described_class::Help
     end
 
+    it 'returns a Source command when given the command "source"' do
+      command = described_class.new(stub('env'), 'source', arguments('/some/path'))
+      expect(command).to be_a described_class::Source
+    end
+
     it 'returns an Unknown command when given anything else' do
       command = described_class.new(stub('env'), 'notacommand', %w(foo bar))
       expect(command).to be_a described_class::Unknown

--- a/spec/units/script_runner_spec.rb
+++ b/spec/units/script_runner_spec.rb
@@ -32,26 +32,30 @@ describe Gitsh::ScriptRunner do
     end
 
     context 'with a file that does not exist' do
-      it 'exits' do
-        env = stub('Environment', puts_error: nil)
+      it 'raises a NoInputError' do
+        env = stub('Environment')
         interpreter = stub('Interpreter', execute: nil)
         runner = described_class.new(env: env, interpreter: interpreter)
 
-        expect { runner.run 'no/such/script' }.to raise_exception(SystemExit)
-        expect(env).to have_received(:puts_error)
+        expect { runner.run 'no/such/script' }.to raise_exception(
+          Gitsh::NoInputError,
+          /No such file/,
+        )
       end
     end
 
     context 'with a file that the current user cannot read' do
-      it 'exits' do
+      it 'raises a NoInputError' do
         script = temp_file('script', "commit -m 'Changes'\npush -f")
         File.stubs(:open).raises(Errno::EACCES)
-        env = stub('Environment', puts_error: nil)
+        env = stub('Environment')
         interpreter = stub('Interpreter', execute: nil)
         runner = described_class.new(env: env, interpreter: interpreter)
 
-        expect { runner.run script.path }.to raise_exception(SystemExit)
-        expect(env).to have_received(:puts_error)
+        expect { runner.run script.path }.to raise_exception(
+          Gitsh::NoInputError,
+          /Permission denied/,
+        )
       end
     end
   end


### PR DESCRIPTION
`:source path` will run any Git and gitsh commands in the file at `path`. It can modify the environment of the gitsh session it's called from, much like the `source` command in Unix shells.