### PR TITLE
Replace `mocha` with `rspec-mocks`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,5 @@ end
 
 group :test do
   gem 'rspec'
-  gem 'bourne'
   gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     blankslate (3.1.3)
-    bourne (1.5.0)
-      mocha (>= 0.13.2, < 0.15)
     coderay (1.1.0)
     diff-lcs (1.2.5)
-    metaclass (0.0.1)
     method_source (0.8.2)
-    mocha (0.14.0)
-      metaclass (~> 0.0.1)
     parslet (1.6.2)
       blankslate (>= 2.0, <= 4.0)
     pry (0.9.12.6)
@@ -34,7 +29,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bourne
   parslet
   pry
   rspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'bourne'
 require 'parslet/rig/rspec'
 require 'pry'
 
@@ -7,7 +6,6 @@ Dir[File.expand_path('../support/**/*.rb', __FILE__)].each do |path|
 end
 
 RSpec.configure do |config|
-  config.mock_with :mocha
   config.order = 'random'
 end
 

--- a/spec/support/arguments.rb
+++ b/spec/support/arguments.rb
@@ -1,6 +1,6 @@
 module Arguments
   def arguments(*values)
-    stub("ArgumentList", values: values, length: values.length)
+    double("ArgumentList", values: values, length: values.length)
   end
 end
 

--- a/spec/support/delegate_matcher.rb
+++ b/spec/support/delegate_matcher.rb
@@ -5,8 +5,9 @@ RSpec::Matchers.define :delegate do |original_method|
   end
 
   match do |original_object|
-    result = stub
-    @target_object.stubs(@target_method).returns(result)
+    result = double
+    allow(@target_object).to receive(@target_method).
+      and_return(result)
 
     expect(original_object.send(original_method)).to eq result
   end

--- a/spec/support/gitsh_runner.rb
+++ b/spec/support/gitsh_runner.rb
@@ -4,11 +4,11 @@ require 'tmpdir'
 require 'gitsh/cli'
 require 'gitsh/environment'
 require 'gitsh/readline_blank_filter'
+require 'rspec/mocks/test_double'
 require File.expand_path('../file_system', __FILE__)
 
 class GitshRunner
   include FileSystemHelper
-  include Mocha::API
 
   UP_ARROW = "\033[A"
 
@@ -17,7 +17,7 @@ class GitshRunner
   end
 
   def initialize(options)
-    @input_stream = stub('STDIN', tty?: true)
+    @input_stream = RSpec::Mocks::Double.new('STDIN', tty?: true)
     @output_stream = Tempfile.new('stdout')
     @error_stream = Tempfile.new('stderr')
     @readline = ReadlineBlankFilter.new(FakeReadline.new)

--- a/spec/support/stubbed_method_result.rb
+++ b/spec/support/stubbed_method_result.rb
@@ -1,0 +1,21 @@
+class StubbedMethodResult
+  def initialize
+    @results = []
+  end
+
+  def raises(error, message = nil)
+    @results << proc { raise error.new(message) }
+
+    self
+  end
+
+  def returns(value)
+    @results << proc { value }
+
+    self
+  end
+
+  def next_result
+    @results.shift.call
+  end
+end

--- a/spec/units/argument_builder_spec.rb
+++ b/spec/units/argument_builder_spec.rb
@@ -4,8 +4,9 @@ require 'gitsh/argument_builder'
 describe Gitsh::ArgumentBuilder do
   describe 'building a StringArgument with #add_literal' do
     it 'concatenates the values passed to subsequent add_literal calls' do
-      string_argument = stub('StringArgument')
-      Gitsh::Arguments::StringArgument.stubs(:new).returns(string_argument)
+      string_argument = double('StringArgument')
+      allow(Gitsh::Arguments::StringArgument).to receive(:new).
+        and_return(string_argument)
 
       built_argument = described_class.build do |builder|
         builder.add_literal('Hello')
@@ -21,8 +22,9 @@ describe Gitsh::ArgumentBuilder do
 
   describe 'building a VariableArgument with #add_variable' do
     it 'creates a variable argument to access the variable' do
-      variable_argument = stub('VariableArgument')
-      Gitsh::Arguments::VariableArgument.stubs(:new).returns(variable_argument)
+      variable_argument = double('VariableArgument')
+      allow(Gitsh::Arguments::VariableArgument).to receive(:new).
+        and_return(variable_argument)
 
       built_argument = described_class.build do |builder|
         builder.add_variable('author')
@@ -36,8 +38,8 @@ describe Gitsh::ArgumentBuilder do
 
   describe 'building a Subshell with #add_subshell' do
     it 'creates a subshell' do
-      subshell = stub('Subshell')
-      Gitsh::Arguments::Subshell.stubs(:new).returns(subshell)
+      subshell = double('Subshell')
+      allow(Gitsh::Arguments::Subshell).to receive(:new).and_return(subshell)
 
       built_argument = described_class.build do |builder|
         builder.add_subshell('!pwd')
@@ -51,10 +53,12 @@ describe Gitsh::ArgumentBuilder do
 
   describe 'building a CompositeArgument with multiple calls to #add_variable' do
     it 'creates a composite argument of several VariableArguments' do
-      composite_argument = stub('CompositeArgument')
-      variable_argument = stub('VariableArgument')
-      Gitsh::Arguments::VariableArgument.stubs(:new).returns(variable_argument)
-      Gitsh::Arguments::CompositeArgument.stubs(:new).returns(composite_argument)
+      composite_argument = double('CompositeArgument')
+      variable_argument = double('VariableArgument')
+      allow(Gitsh::Arguments::VariableArgument).to receive(:new).
+        and_return(variable_argument)
+      allow(Gitsh::Arguments::CompositeArgument).to receive(:new).
+        and_return(composite_argument)
 
       built_argument = described_class.build do |builder|
         builder.add_variable('foo')
@@ -73,12 +77,12 @@ describe Gitsh::ArgumentBuilder do
 
   describe 'building a CompositeArgument with mixed types' do
     it 'creates a composite argument' do
-      composite_argument = stub('CompositeArgument')
-      string_argument = stub('StringArgument')
-      variable_argument = stub('VariableArgument')
-      Gitsh::Arguments::CompositeArgument.stubs(:new).returns(composite_argument)
-      Gitsh::Arguments::StringArgument.stubs(:new).returns(string_argument)
-      Gitsh::Arguments::VariableArgument.stubs(:new).returns(variable_argument)
+      composite_argument = double('CompositeArgument')
+      string_argument = double('StringArgument')
+      variable_argument = double('VariableArgument')
+      allow(Gitsh::Arguments::CompositeArgument).to receive(:new).and_return(composite_argument)
+      allow(Gitsh::Arguments::StringArgument).to receive(:new).and_return(string_argument)
+      allow(Gitsh::Arguments::VariableArgument).to receive(:new).and_return(variable_argument)
 
       built_argument = described_class.build do |builder|
         builder.add_literal('pre')

--- a/spec/units/argument_list_spec.rb
+++ b/spec/units/argument_list_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'gitsh/argument_list'
 
-describe Gitsh::ArgumentList do 
+describe Gitsh::ArgumentList do
   describe '#length' do
     it 'returns the number of arguments' do
       argument_list = Gitsh::ArgumentList.new(['hello', 'goodbye'])
@@ -12,9 +12,9 @@ describe Gitsh::ArgumentList do
 
   describe '#values' do
     it 'returns the values of the arguments' do
-      env = stub('env')
-      hello_arg = stub('hello_arg', value: 'hello')
-      goodbye_arg = stub('goodbye_arg', value: 'goodbye')
+      env = double('env')
+      hello_arg = spy('hello_arg', value: 'hello')
+      goodbye_arg = spy('goodbye_arg', value: 'goodbye')
       argument_list = Gitsh::ArgumentList.new([hello_arg, goodbye_arg])
 
       expect(argument_list.values(env)).to eq ['hello', 'goodbye']

--- a/spec/units/arguments/composite_argument_spec.rb
+++ b/spec/units/arguments/composite_argument_spec.rb
@@ -4,9 +4,9 @@ require 'gitsh/arguments/composite_argument'
 describe Gitsh::Arguments::CompositeArgument do
   describe '#value' do
     it 'returns the concatenated values of the arguments passed to the initializer' do
-      env = stub('env')
-      first_argument = stub('first_argument', value: 'Hello')
-      second_argument = stub('second_argument', value: 'World')
+      env = double('env')
+      first_argument = double('first_argument', value: 'Hello')
+      second_argument = double('second_argument', value: 'World')
       argument = described_class.new([first_argument, second_argument])
 
       expect(argument.value(env)).to eq 'HelloWorld'

--- a/spec/units/arguments/string_argument_spec.rb
+++ b/spec/units/arguments/string_argument_spec.rb
@@ -5,7 +5,7 @@ describe Gitsh::Arguments::StringArgument do
   describe '#value' do
     it 'returns the string passed to the initializer' do
       arg = described_class.new('Hello world')
-      env = stub('env')
+      env = double('env')
 
       expect(arg.value(env)).to eq 'Hello world'
     end

--- a/spec/units/arguments/subshell_spec.rb
+++ b/spec/units/arguments/subshell_spec.rb
@@ -15,7 +15,7 @@ describe Gitsh::Arguments::Subshell do
 
   describe '#value' do
     it 'creates a new interpreter and executes the subshell command inside of it' do
-      env = stub('env')
+      env = double('env')
       subshell_command = 'status'
 
       output = described_class.new(

--- a/spec/units/capturing_environment_spec.rb
+++ b/spec/units/capturing_environment_spec.rb
@@ -4,7 +4,7 @@ require 'gitsh/capturing_environment'
 describe Gitsh::CapturingEnvironment do
   describe '#captured_output' do
     it 'returns any output written to the output stream' do
-      env = stub('env')
+      env = double('env')
       capturing_env = described_class.new(env)
       capturing_env.output_stream.puts 'Hello, world'
       capturing_env.output_stream.puts 'Goodbye'
@@ -15,8 +15,8 @@ describe Gitsh::CapturingEnvironment do
 
   describe 'delegations' do
     it 'delegates unknown methods to the wrapped environment' do
-      return_value = stub('return_value')
-      env = stub('env', foo: return_value)
+      return_value = double('return_value')
+      env = double('env', foo: return_value)
       capturing_env = described_class.new(env)
 
       expect(capturing_env).to respond_to(:foo)

--- a/spec/units/cli_spec.rb
+++ b/spec/units/cli_spec.rb
@@ -5,7 +5,7 @@ describe Gitsh::CLI do
   describe '#run' do
     context 'with valid arguments and no script file' do
       it 'calls the interactive runner' do
-        interactive_runner = stub('InteractiveRunner', run: nil)
+        interactive_runner = double('InteractiveRunner', run: nil)
         cli = Gitsh::CLI.new(
           args: [],
           interactive_runner: interactive_runner
@@ -19,26 +19,26 @@ describe Gitsh::CLI do
 
     context 'when STDIN is not a TTY' do
       it 'calls the script runner with -' do
-        script_runner = stub('ScriptRunner', run: nil)
-        interactive_runner = stub('InteractiveRunner', run: nil)
+        script_runner = double('ScriptRunner', run: nil)
+        interactive_runner = double('InteractiveRunner', run: nil)
         cli = Gitsh::CLI.new(
           args: [],
           script_runner: script_runner,
           interactive_runner: interactive_runner,
-          env: stub('Environment', tty?: false),
+          env: double('Environment', tty?: false),
         )
 
         cli.run
 
         expect(script_runner).to have_received(:run).with('-')
-        expect(interactive_runner).to have_received(:run).never
+        expect(interactive_runner).not_to have_received(:run)
       end
     end
 
     context 'with a script file' do
       it 'calls the script runner with the script file' do
-        script_runner = stub('ScriptRunner', run: nil)
-        interactive_runner = stub('InteractiveRunner', run: nil)
+        script_runner = double('ScriptRunner', run: nil)
+        interactive_runner = double('InteractiveRunner', run: nil)
         cli = Gitsh::CLI.new(
           args: ['path/to/a/script'],
           script_runner: script_runner,
@@ -48,16 +48,17 @@ describe Gitsh::CLI do
         cli.run
 
         expect(script_runner).to have_received(:run).with('path/to/a/script')
-        expect(interactive_runner).to have_received(:run).never
+        expect(interactive_runner).not_to have_received(:run)
       end
     end
 
     context 'with an unreadable script file' do
       it 'exits' do
-        env = stub('env', puts_error: nil)
-        script_runner = stub('ScriptRunner')
-        script_runner.stubs(:run).raises(Gitsh::NoInputError, 'Oh no!')
-        interactive_runner = stub('InteractiveRunner')
+        env = double('env', puts_error: nil)
+        script_runner = double('ScriptRunner')
+        allow(script_runner).to receive(:run).
+          and_raise(Gitsh::NoInputError, 'Oh no!')
+        interactive_runner = double('InteractiveRunner')
         cli = Gitsh::CLI.new(
           env: env,
           args: ['path/to/a/script'],
@@ -72,7 +73,7 @@ describe Gitsh::CLI do
 
     context 'with invalid arguments' do
       it 'exits with a usage message' do
-        env = stub('Environment', puts_error: nil)
+        env = double('Environment', puts_error: nil)
         cli = Gitsh::CLI.new(args: %w( --bad-argument ), env: env)
 
         expect { cli.run }.to raise_exception(SystemExit)

--- a/spec/units/commands/error_handler_spec.rb
+++ b/spec/units/commands/error_handler_spec.rb
@@ -5,9 +5,9 @@ describe Gitsh::Commands::ErrorHandler do
   describe '#execute' do
     context 'the command executes successfully' do
       it 'returns the same value as the command' do
-        env = stub('env')
-        successful_execution = stub('successful_execution')
-        command_instance = stub('command_instance', execute: successful_execution)
+        env = double('env')
+        successful_execution = double('successful_execution')
+        command_instance = double('command_instance', execute: successful_execution)
         handler = Gitsh::Commands::ErrorHandler.new(command_instance, env)
 
         expect(handler.execute).to be command_instance.execute
@@ -16,9 +16,10 @@ describe Gitsh::Commands::ErrorHandler do
 
     context 'the command raises an error' do
       it 'prints the error and returns false' do
-        env = stub('env', puts_error: nil)
-        command_instance = stub('command_instance')
-        command_instance.stubs(:execute).raises(Gitsh::Error, 'Oh noes!')
+        env = spy('env', puts_error: nil)
+        command_instance = double('command_instance')
+        allow(command_instance).to receive(:execute).
+          and_raise(Gitsh::Error, 'Oh noes!')
         handler = Gitsh::Commands::ErrorHandler.new(command_instance, env)
 
         expect(handler.execute).to eq false

--- a/spec/units/commands/factory_spec.rb
+++ b/spec/units/commands/factory_spec.rb
@@ -4,11 +4,12 @@ require 'gitsh/commands/factory'
 describe Gitsh::Commands::Factory do
   describe '#build' do
     it 'returns an instance of the given command class' do
-      env = stub('env')
-      error_handler = stub('error_handler')
-      Gitsh::Commands::ErrorHandler.stubs(:new).returns(error_handler)
-      command_instance = stub('command_instance')
-      command_class = stub('command_class', new: command_instance)
+      env = double('env')
+      error_handler = double('error_handler')
+      allow(Gitsh::Commands::ErrorHandler).to receive(:new).
+        and_return(error_handler)
+      command_instance = double('command_instance')
+      command_class = spy('command_class', new: command_instance)
       context = { env: env, command: 'status' }
       factory = Gitsh::Commands::Factory.new(command_class, context)
 

--- a/spec/units/commands/git_command_spec.rb
+++ b/spec/units/commands/git_command_spec.rb
@@ -3,18 +3,21 @@ require 'gitsh/commands/git_command'
 
 describe Gitsh::Commands::GitCommand do
   let(:env) do
-    stub('Environment', {
+    double('Environment', {
       git_command: '/usr/bin/env git',
-      output_stream: stub(to_i: 1),
-      error_stream: stub(to_i: 2)
+      output_stream: double('OutputStream', to_i: 1),
+      error_stream: double('ErrorStream', to_i: 2)
     })
   end
 
-  before { Process.stubs(spawn: 1, wait: nil) }
+  before do
+    allow(Process).to receive(:spawn).and_return(1)
+    allow(Process).to receive(:wait)
+  end
 
   describe '#execute' do
     it 'spawns a process with the sub command and arguments' do
-      env.stubs(config_variables: {})
+      allow(env).to receive(:config_variables).and_return({})
       command = described_class.new(
         env,
         'commit',
@@ -33,10 +36,10 @@ describe Gitsh::Commands::GitCommand do
     end
 
     it 'passes on configuration variables from the environment' do
-      env.stubs(config_variables: {
+      allow(env).to receive(:config_variables).and_return(
         :'test.example' => 'This is an example',
         :'foo.bar' => '1'
-      })
+      )
       command = described_class.new(
         env,
         'commit',

--- a/spec/units/commands/internal/chdir_spec.rb
+++ b/spec/units/commands/internal/chdir_spec.rb
@@ -6,14 +6,14 @@ describe Gitsh::Commands::InternalCommand::Chdir do
 
   describe '#execute' do
     it 'returns true for correct directories' do
-      env = stub(:[]= => true, puts_error: true)
+      env = double('Environment', :[]= => true, puts_error: true)
       command = described_class.new(env, 'cd', arguments('./'))
 
       expect(command.execute).to be_truthy
     end
 
     it 'returns false with invalid arguments' do
-      env = stub(:[]= => true, puts_error: true)
+      env = double('Environment', :[]= => true, puts_error: true)
       command = described_class.new(env, 'cd', arguments('foo'))
 
       expect(command.execute).to be_falsey

--- a/spec/units/commands/internal/echo_spec.rb
+++ b/spec/units/commands/internal/echo_spec.rb
@@ -6,7 +6,7 @@ describe Gitsh::Commands::InternalCommand::Echo do
 
   describe '#execute' do
     it 'prints all arguments to the environment joined with a space' do
-      env = stub('env', puts: nil)
+      env = double('env', puts: nil)
       command = described_class.new(env, 'echo', arguments('foo', 'bar'))
 
       expect(command.execute).to be_truthy
@@ -14,7 +14,7 @@ describe Gitsh::Commands::InternalCommand::Echo do
     end
 
     it 'prints a newline when no arguments are passed' do
-      env = stub('env', puts: nil)
+      env = double('env', puts: nil)
       command = described_class.new(env, 'echo', arguments())
 
       expect(command.execute).to be_truthy

--- a/spec/units/commands/internal/exit_spec.rb
+++ b/spec/units/commands/internal/exit_spec.rb
@@ -6,7 +6,7 @@ describe Gitsh::Commands::InternalCommand::Exit do
 
   describe '#execute' do
     it 'exits the program' do
-      command = described_class.new(stub('env'), 'exit', arguments())
+      command = described_class.new(double('env'), 'exit', arguments())
       expect { command.execute }.to raise_exception(SystemExit)
     end
   end

--- a/spec/units/commands/internal/help_spec.rb
+++ b/spec/units/commands/internal/help_spec.rb
@@ -7,22 +7,22 @@ describe Gitsh::Commands::InternalCommand::Help do
   describe "#execute" do
     context "with no arguments" do
       it "prints out some stuff" do
-        env = stub('env', puts: nil)
+        env = spy('env', puts: nil)
         command = described_class.new(env, 'help', arguments())
 
         expect(command.execute).to be_truthy
-        expect(env).to have_received(:puts).at_least_once
+        expect(env).to have_received(:puts).at_least(1).times
       end
     end
 
     context "with an argument that matches an existing command" do
       it "prints out command-specific information" do
-        env = stub('env', puts: nil)
+        env = spy('env', puts: nil)
         command = described_class.new(env, 'help', arguments('set'))
-        set_command = stub('Set', help_message: 'Sets variables')
-        Gitsh::Commands::InternalCommand.stubs(:command_class).
+        set_command = double('Set', help_message: 'Sets variables')
+        allow(Gitsh::Commands::InternalCommand).to receive(:command_class).
           with('set').
-          returns(set_command)
+          and_return(set_command)
 
         expect(command.execute).to be_truthy
         expect(env).to have_received(:puts).with('Sets variables')
@@ -31,12 +31,12 @@ describe Gitsh::Commands::InternalCommand::Help do
 
     context 'with a colon-prefixed argument' do
       it 'strips the colon' do
-        env = stub('env', puts: nil)
+        env = spy('env', puts: nil)
         command = described_class.new(env, 'help', arguments(':set'))
-        set_command = stub('Set', help_message: 'Sets variables')
-        Gitsh::Commands::InternalCommand.stubs(:command_class).
+        set_command = double('Set', help_message: 'Sets variables')
+        allow(Gitsh::Commands::InternalCommand).to receive(:command_class).
           with('set').
-          returns(set_command)
+          and_return(set_command)
 
         expect(command.execute).to be_truthy
         expect(env).to have_received(:puts).with('Sets variables')
@@ -45,7 +45,7 @@ describe Gitsh::Commands::InternalCommand::Help do
 
     context "with arguments that don't match an existing command" do
       it "prints out some stuff" do
-        env = stub('env', puts: nil)
+        env = spy('env', puts: nil)
         command = described_class.new(
           env,
           'help',
@@ -53,7 +53,7 @@ describe Gitsh::Commands::InternalCommand::Help do
         )
 
         expect(command.execute).to be_truthy
-        expect(env).to have_received(:puts).at_least_once
+        expect(env).to have_received(:puts).at_least(1).times
       end
     end
   end

--- a/spec/units/commands/internal/set_spec.rb
+++ b/spec/units/commands/internal/set_spec.rb
@@ -6,7 +6,7 @@ describe Gitsh::Commands::InternalCommand::Set do
 
   describe '#execute' do
     it 'sets a variable on the environment' do
-      env = stub('env', :[]=)
+      env = spy('env')
       command = described_class.new(env, 'set', arguments('foo', 'bar'))
 
       command.execute
@@ -15,14 +15,14 @@ describe Gitsh::Commands::InternalCommand::Set do
     end
 
     it 'returns true with correct arguments' do
-      env = stub(:[]= => true, puts_error: true)
+      env = double('Environment', :[]= => true, puts_error: true)
       command = described_class.new(env, 'set', arguments('foo', 'bar'))
 
       expect(command.execute).to be_truthy
     end
 
     it 'returns false with invalid arguments' do
-      env = stub(:[]= => true, puts_error: true)
+      env = double('Environment', :[]= => true, puts_error: true)
       command = described_class.new(env, 'set', arguments('foo'))
 
       expect(command.execute).to be_falsey

--- a/spec/units/commands/internal/source_spec.rb
+++ b/spec/units/commands/internal/source_spec.rb
@@ -7,9 +7,9 @@ describe Gitsh::Commands::InternalCommand::Source do
   describe "#execute" do
     context "with a valid file" do
       it "executes the script_runner and returns true" do
-        env = stub('env')
-        script_runner = stub('ScriptRunner', run: nil)
-        Gitsh::ScriptRunner.stubs(:new).returns(script_runner)
+        env = double('env')
+        script_runner = spy('ScriptRunner', run: nil)
+        allow(Gitsh::ScriptRunner).to receive(:new).and_return(script_runner)
         command = described_class.new(env, 'source', arguments('/path'))
 
         result = command.execute
@@ -22,7 +22,7 @@ describe Gitsh::Commands::InternalCommand::Source do
 
     context "with no file argument" do
       it "prints a usage message and returns false" do
-        env = stub('env', puts_error: nil)
+        env = spy('env', puts_error: nil)
         command = described_class.new(env, 'source', arguments())
 
         result = command.execute

--- a/spec/units/commands/internal/unknown_spec.rb
+++ b/spec/units/commands/internal/unknown_spec.rb
@@ -6,14 +6,14 @@ describe Gitsh::Commands::InternalCommand::Unknown do
 
   describe '#execute' do
     it 'outputs an error message' do
-      env = stub('env', puts_error: nil)
+      env = spy('env', puts_error: nil)
       command = described_class.new(env, 'notacommand', arguments())
 
       command.execute
 
       expect(env).to have_received(:puts_error).with(
-                         'gitsh: notacommand: command not found'
-                     )
+        'gitsh: notacommand: command not found'
+      )
     end
   end
 end

--- a/spec/units/commands/internal_command_spec.rb
+++ b/spec/units/commands/internal_command_spec.rb
@@ -4,37 +4,37 @@ require 'gitsh/commands/internal_command'
 describe Gitsh::Commands::InternalCommand do
   describe '.new' do
     it 'returns a Set command when given the command "set"' do
-      command = described_class.new(stub('env'), 'set', %w(foo bar))
+      command = described_class.new(double('env'), 'set', %w(foo bar))
       expect(command).to be_a described_class::Set
     end
 
     it 'returns an Exit command when given the command "exit"' do
-      command = described_class.new(stub('env'), 'exit', arguments())
+      command = described_class.new(double('env'), 'exit', arguments())
       expect(command).to be_a described_class::Exit
     end
 
     it 'returns an Exit command when given the command "q"' do
-      command = described_class.new(stub('env'), 'q', arguments())
+      command = described_class.new(double('env'), 'q', arguments())
       expect(command).to be_a described_class::Exit
     end
 
     it 'returns a Chdir command when given the command "cd"' do
-      command = described_class.new(stub('env'), 'cd', '/some/path')
+      command = described_class.new(double('env'), 'cd', '/some/path')
       expect(command).to be_a described_class::Chdir
     end
 
     it 'returns a Help command when given the command "help"' do
-      command = described_class.new(stub('env'), 'help', arguments())
+      command = described_class.new(double('env'), 'help', arguments())
       expect(command).to be_a described_class::Help
     end
 
     it 'returns a Source command when given the command "source"' do
-      command = described_class.new(stub('env'), 'source', arguments('/some/path'))
+      command = described_class.new(double('env'), 'source', arguments('/some/path'))
       expect(command).to be_a described_class::Source
     end
 
     it 'returns an Unknown command when given anything else' do
-      command = described_class.new(stub('env'), 'notacommand', %w(foo bar))
+      command = described_class.new(double('env'), 'notacommand', %w(foo bar))
       expect(command).to be_a described_class::Unknown
     end
   end

--- a/spec/units/commands/tree_spec.rb
+++ b/spec/units/commands/tree_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 require 'gitsh/commands/tree'
 
 describe Gitsh::Commands::Tree do
-  let(:t) { stub(execute: true) }
-  let(:f) { stub(execute: false) }
+  let(:t) { double(execute: true) }
+  let(:f) { double(execute: false) }
 
   describe Gitsh::Commands::Tree::Or do
     it 'executes f, then t' do
@@ -17,7 +17,7 @@ describe Gitsh::Commands::Tree do
       Gitsh::Commands::Tree::Or.new(t, f).execute
 
       expect(t).to have_received(:execute).once
-      expect(f).to have_received(:execute).never
+      expect(f).not_to have_received(:execute)
     end
   end
 
@@ -25,7 +25,7 @@ describe Gitsh::Commands::Tree do
     it 'executes f, then stops' do
       Gitsh::Commands::Tree::And.new(f, t).execute
 
-      expect(t).to have_received(:execute).never
+      expect(t).not_to have_received(:execute)
       expect(f).to have_received(:execute).once
     end
 
@@ -57,7 +57,7 @@ describe Gitsh::Commands::Tree do
       ).execute
 
       expect(t).to have_received(:execute).twice
-      expect(f).to have_received(:execute).never
+      expect(f).not_to have_received(:execute)
     end
 
     it 'calls all t, f, t' do
@@ -76,7 +76,7 @@ describe Gitsh::Commands::Tree do
         f
       ).execute
 
-      expect(t).to have_received(:execute).never
+      expect(t).not_to have_received(:execute)
       expect(f).to have_received(:execute).twice
     end
 

--- a/spec/units/completer_spec.rb
+++ b/spec/units/completer_spec.rb
@@ -103,14 +103,14 @@ describe Gitsh::Completer do
   end
 
   def build_completer(options)
-    readline = stub('Readline', line_buffer: options.fetch(:input))
-    env = stub('Environment', {
+    readline = double('Readline', line_buffer: options.fetch(:input))
+    env = double('Environment', {
       git_commands: options.fetch(:git_commands, %w( add commit )),
       git_aliases: options.fetch(:git_aliases, %w( graph )),
       repo_heads: options.fetch(:repo_heads, %w( master )),
       repo_remotes: options.fetch(:repo_remotes, %w( remote )),
     })
-    internal_command = stub('InternalCommand', {
+    internal_command = double('InternalCommand', {
       commands: options.fetch(:internal_commands, %w( :set :exit ))
     })
     Gitsh::Completer.new(readline, env, internal_command)

--- a/spec/units/git_repository_spec.rb
+++ b/spec/units/git_repository_spec.rb
@@ -316,6 +316,6 @@ describe Gitsh::GitRepository do
   end
 
   def env
-    stub(git_command: '/usr/bin/env git')
+    double(git_command: '/usr/bin/env git')
   end
 end

--- a/spec/units/interactive_runner_spec.rb
+++ b/spec/units/interactive_runner_spec.rb
@@ -36,12 +36,12 @@ describe Gitsh::InteractiveRunner do
 
     it 'handles a SIGINT' do
       runner = build_interactive_runner
-
-      readline.stubs(:readline).
+      readline_results = StubbedMethodResult.new.
         returns('a').
-        then.raises(Interrupt).
-        then.returns('b').
-        then.raises(SystemExit)
+        raises(Interrupt).
+        returns('b').
+        raises(SystemExit)
+      allow(readline).to receive(:readline) { readline_results.next_result }
 
       begin
         runner.run
@@ -55,7 +55,7 @@ describe Gitsh::InteractiveRunner do
 
     it 'handles a SIGWINCH' do
       readline = SignallingReadline.new('WINCH')
-      readline.stubs(:set_screen_size)
+      allow(readline).to receive(:set_screen_size)
       runner = build_interactive_runner(readline: readline)
 
       expect { runner.run }.not_to raise_exception
@@ -75,19 +75,19 @@ describe Gitsh::InteractiveRunner do
   end
 
   def script_runner
-    @script_runner ||= stub('script_runner', run: nil)
+    @script_runner ||= spy('script_runner', run: nil)
   end
 
   def interpreter
-    @interpreter ||= stub('interpreter', execute: nil)
+    @interpreter ||= spy('interpreter', execute: nil)
   end
 
   def history
-    @history ||= stub('history', load: nil, save: nil)
+    @history ||= spy('history', load: nil, save: nil)
   end
 
   def readline
-    @readline ||= stub('readline', {
+    @readline ||= spy('readline', {
       :'completion_append_character=' => nil,
       :'completion_proc=' => nil,
       readline: nil
@@ -95,7 +95,7 @@ describe Gitsh::InteractiveRunner do
   end
 
   def env
-    @env ||= stub('Environment', {
+    @env ||= double('Environment', {
       print: nil,
       puts: nil,
       repo_initialized?: false,
@@ -106,6 +106,6 @@ describe Gitsh::InteractiveRunner do
   end
 
   def term_info
-    stub('term_info', color_support?: true, lines: 24, cols: 80)
+    double('term_info', color_support?: true, lines: 24, cols: 80)
   end
 end

--- a/spec/units/interpreter_spec.rb
+++ b/spec/units/interpreter_spec.rb
@@ -5,10 +5,10 @@ require 'parslet'
 describe Gitsh::Interpreter do
   describe '#execute' do
     it 'transforms the command into an command object and executes it' do
-      env = stub
-      parsed = stub(execute: nil)
-      parser = stub('Parser', parse_and_transform: parsed)
-      parser_factory = stub(new: parser)
+      env = double
+      parsed = spy(execute: nil)
+      parser = spy('Parser', parse_and_transform: parsed)
+      parser_factory = spy(new: parser)
 
       interpreter = Gitsh::Interpreter.new(env, parser_factory: parser_factory)
       interpreter.execute('add -p')
@@ -19,10 +19,11 @@ describe Gitsh::Interpreter do
     end
 
     it 'handles parse errors' do
-      env = stub('env', puts_error: nil)
-      parser = stub('Parser')
-      parser.stubs(:parse_and_transform).raises(Parslet::ParseFailed, 'Parse failed')
-      parser_factory = stub('ParserFactory', new: parser)
+      env = spy('env', puts_error: nil)
+      parser = double('Parser')
+      allow(parser).to receive(:parse_and_transform).
+        and_raise(Parslet::ParseFailed, 'Parse failed')
+      parser_factory = double('ParserFactory', new: parser)
 
       interpreter = Gitsh::Interpreter.new(env, parser_factory: parser_factory)
       interpreter.execute('bad command')

--- a/spec/units/magic_variables_spec.rb
+++ b/spec/units/magic_variables_spec.rb
@@ -5,7 +5,7 @@ describe Gitsh::MagicVariables do
   describe '#fetch' do
     context 'with an unknown variable name and a block' do
       it 'yields to the block' do
-        repo = stub('GitRepository')
+        repo = double('GitRepository')
         magic_variables = described_class.new(repo)
 
         result = magic_variables.fetch(:_not_a_real_variable) { 'default' }
@@ -16,7 +16,7 @@ describe Gitsh::MagicVariables do
 
     context 'with _prior' do
       it 'returns the name of the previous branch' do
-        repo = stub('GitRepository', revision_name: 'a-branch-name')
+        repo = double('GitRepository', revision_name: 'a-branch-name')
         magic_variables = described_class.new(repo)
 
         expect(magic_variables.fetch(:_prior)).to eq 'a-branch-name'
@@ -26,7 +26,7 @@ describe Gitsh::MagicVariables do
 
     context 'with _merge_base' do
       it 'returns the SHA of the base commit for an in-progress merge' do
-        repo = stub('GitRepository', merge_base: 'abc124567890')
+        repo = double('GitRepository', merge_base: 'abc124567890')
         magic_variables = described_class.new(repo)
 
         expect(magic_variables.fetch(:_merge_base)).to eq 'abc124567890'
@@ -41,7 +41,7 @@ describe Gitsh::MagicVariables do
             rebase_path = Pathname.new(tmpdir_path).join('rebase-apply')
             rebase_path.mkpath
             write_file(rebase_path.join('onto'), 'abc123')
-            repo = stub('GitRepository', git_dir: tmpdir_path)
+            repo = double('GitRepository', git_dir: tmpdir_path)
             magic_variables = described_class.new(repo)
 
             expect(magic_variables.fetch(:_rebase_base)).to eq 'abc123'
@@ -55,7 +55,7 @@ describe Gitsh::MagicVariables do
             rebase_path = Pathname.new(tmpdir_path).join('rebase-merge')
             rebase_path.mkpath
             write_file(rebase_path.join('onto'), 'def456')
-            repo = stub('GitRepository', git_dir: tmpdir_path)
+            repo = double('GitRepository', git_dir: tmpdir_path)
             magic_variables = described_class.new(repo)
 
             expect(magic_variables.fetch(:_rebase_base)).to eq 'def456'
@@ -66,7 +66,7 @@ describe Gitsh::MagicVariables do
       context 'when there is no rebase in progress' do
         it 'returns nil' do
           Dir.mktmpdir do |tmpdir_path|
-            repo = stub('GitRepository', git_dir: tmpdir_path)
+            repo = double('GitRepository', git_dir: tmpdir_path)
             magic_variables = described_class.new(repo)
 
             expect(magic_variables.fetch(:_rebase_base)).to be_nil

--- a/spec/units/parser_spec.rb
+++ b/spec/units/parser_spec.rb
@@ -4,10 +4,10 @@ require 'gitsh/parser'
 describe Gitsh::Parser do
   describe '#parse_and_transform' do
     it 'returns an object built from the parsed command' do
-      env = stub('Environment', fetch: nil)
-      transformed = stub
-      transformer = stub('Transformer', apply: transformed)
-      transformer_factory = stub(new: transformer)
+      env = double('Environment', fetch: nil)
+      transformed = double('Transformed')
+      transformer = double('Transformer', apply: transformed)
+      transformer_factory = double('TransformerFactory', new: transformer)
       parser = described_class.new(env: env, transformer_factory: transformer_factory)
 
       result = parser.parse_and_transform('status')

--- a/spec/units/prompt_color_spec.rb
+++ b/spec/units/prompt_color_spec.rb
@@ -7,7 +7,7 @@ describe Gitsh::PromptColor do
   describe '#status_color' do
     context 'with an uninitialized repo' do
       it 'uses the gitsh.color.uninitialized setting' do
-        color = stub('color')
+        color = double('color')
         env = stub_env(repo_initialized?: false, repo_config_color: color)
         prompt_color = described_class.new(env)
 
@@ -19,7 +19,7 @@ describe Gitsh::PromptColor do
 
     context 'with untracked files' do
       it 'uses the gitsh.color.untracked setting' do
-        color = stub('color')
+        color = double('color')
         env = stub_env(repo_has_untracked_files?: true, repo_config_color: color)
         prompt_color = described_class.new(env)
 
@@ -31,7 +31,7 @@ describe Gitsh::PromptColor do
 
     context 'with modified files' do
       it 'uses the gitsh.color.modified setting' do
-        color = stub('color')
+        color = double('color')
         env = stub_env(repo_has_modified_files?: true, repo_config_color: color)
         prompt_color = described_class.new(env)
 
@@ -43,7 +43,7 @@ describe Gitsh::PromptColor do
 
     context 'with a clean repo' do
       it 'uses the gitsh.color.default setting' do
-        color = stub('color')
+        color = double('color')
         env = stub_env(repo_config_color: color)
         prompt_color = described_class.new(env)
 
@@ -60,6 +60,6 @@ describe Gitsh::PromptColor do
       repo_has_untracked_files?: false,
       repo_has_modified_files?: false,
     }
-    env = stub('env', defaults.merge(overrides))
+    env = double('env', defaults.merge(overrides))
   end
 end

--- a/spec/units/prompter_spec.rb
+++ b/spec/units/prompter_spec.rb
@@ -80,7 +80,7 @@ describe Gitsh::Prompter do
       end
 
       it 'replaces %c with a color code based on the status' do
-        prompt_color = stub('PromptColor', status_color: blue)
+        prompt_color = double('PromptColor', status_color: blue)
         env = env_double(repo_has_modified_files?: true, format: '%c')
         prompter = Gitsh::Prompter.new(env: env, prompt_color: prompt_color)
 
@@ -138,9 +138,9 @@ describe Gitsh::Prompter do
         repo_current_head: 'master',
         repo_config_color: red,
       }
-      stub('Environment', default_attrs.merge(attrs)) do |env|
-        env.stubs(:[]).with('gitsh.prompt').returns(format)
-        env.stubs(:fetch).with('gitsh.prompt').returns(
+      double('Environment', default_attrs.merge(attrs)).tap do |env|
+        allow(env).to receive(:[]).with('gitsh.prompt').and_return(format)
+        allow(env).to receive(:fetch).with('gitsh.prompt').and_return(
           format || Gitsh::Prompter::DEFAULT_FORMAT
         )
       end

--- a/spec/units/script_runner_spec.rb
+++ b/spec/units/script_runner_spec.rb
@@ -6,7 +6,7 @@ describe Gitsh::ScriptRunner do
   describe '#run' do
     it 'passes each command to the interpreter' do
       script = temp_file('script', "commit -m 'Changes'\npush -f")
-      interpreter = stub('Interpreter', execute: nil)
+      interpreter = spy('Interpreter', execute: nil)
       runner = described_class.new(interpreter: interpreter)
 
       runner.run script.path
@@ -19,8 +19,8 @@ describe Gitsh::ScriptRunner do
     context 'with -' do
       it 'reads commands from STDIN' do
         input_stream = StringIO.new("push\npull\n")
-        env = stub('Environment', input_stream: input_stream)
-        interpreter = stub('Interpreter', execute: nil)
+        env = double('Environment', input_stream: input_stream)
+        interpreter = spy('Interpreter', execute: nil)
         runner = described_class.new(env: env, interpreter: interpreter)
 
         runner.run '-'
@@ -33,8 +33,8 @@ describe Gitsh::ScriptRunner do
 
     context 'with a file that does not exist' do
       it 'raises a NoInputError' do
-        env = stub('Environment')
-        interpreter = stub('Interpreter', execute: nil)
+        env = double('Environment')
+        interpreter = double('Interpreter', execute: nil)
         runner = described_class.new(env: env, interpreter: interpreter)
 
         expect { runner.run 'no/such/script' }.to raise_exception(
@@ -47,9 +47,9 @@ describe Gitsh::ScriptRunner do
     context 'with a file that the current user cannot read' do
       it 'raises a NoInputError' do
         script = temp_file('script', "commit -m 'Changes'\npush -f")
-        File.stubs(:open).raises(Errno::EACCES)
-        env = stub('Environment')
-        interpreter = stub('Interpreter', execute: nil)
+        allow(File).to receive(:open).and_raise(Errno::EACCES)
+        env = double('Environment')
+        interpreter = double('Interpreter', execute: nil)
         runner = described_class.new(env: env, interpreter: interpreter)
 
         expect { runner.run script.path }.to raise_exception(

--- a/spec/units/term_info_spec.rb
+++ b/spec/units/term_info_spec.rb
@@ -55,10 +55,10 @@ describe Gitsh::TermInfo do
   end
 
   def stub_tput_invocation(options = {})
-    Open3.stubs(:capture3).returns [
+    allow(Open3).to receive(:capture3).and_return [
       options.fetch(:output, ''),
       options.fetch(:error, ''),
-      stub('exit_status', success?: options.fetch(:success, true))
+      double('exit_status', success?: options.fetch(:success, true))
     ]
   end
 end

--- a/spec/units/transformer_spec.rb
+++ b/spec/units/transformer_spec.rb
@@ -3,7 +3,7 @@ require 'gitsh/transformer'
 
 describe Gitsh::Transformer do
   describe '#apply' do
-    let(:env) { stub }
+    let(:env) { double }
     let(:transformer) { described_class.new }
 
     it 'transforms blank lines' do
@@ -152,22 +152,24 @@ describe Gitsh::Transformer do
   end
 
   def stub_argument_builder
-    argument = stub('Argument')
-    builder = stub(
+    argument = double('Argument')
+    builder = double(
       'ArgumentBuilder',
       add_literal: nil,
       add_variable: nil,
       add_subshell: nil,
       argument: argument,
     )
-    Gitsh::ArgumentBuilder.stubs(:build).yields(builder).returns(argument)
+    allow(Gitsh::ArgumentBuilder).to receive(:build).and_yield(builder).
+      and_return(argument)
     builder
   end
 
   def stub_command_factory
-    command_instance = stub('command_instance')
-    factory_instance = stub('factory_instance', build: command_instance)
-    Gitsh::Commands::Factory.stubs(:new).returns(factory_instance)
+    command_instance = double('command_instance')
+    factory_instance = double('factory_instance', build: command_instance)
+    allow(Gitsh::Commands::Factory).to receive(:new).
+      and_return(factory_instance)
     factory_instance
   end
 end


### PR DESCRIPTION
- Replace `stub` with `double` from Rspec.
  - Use `spy` instead where applicable.
- Add `sequenced_double` helper to allow two arbitrary mock implementations to
  be called after each other.

Closes #215