### PR TITLE
Refactor shell commands

### DIFF
--- a/lib/gitsh/commands/git_command.rb
+++ b/lib/gitsh/commands/git_command.rb
@@ -1,20 +1,42 @@
 require 'shellwords'
-require 'gitsh/commands/shell_command'
+require 'gitsh/shell_command_runner'
 
-module Gitsh::Commands
-  class GitCommand < ShellCommand
-    private
+module Gitsh
+  module Commands
+    class GitCommand
+      def initialize(env, command, args, options = {})
+        @env = env
+        @command = command
+        @args = args
+        @shell_command_runner = options.fetch(
+          :shell_command_runner,
+          ShellCommandRunner,
+        )
+      end
 
-    def command_with_arguments
-      [git_command, config_arguments, command, arg_values].flatten
-    end
+      def execute
+        shell_command_runner.run(command_with_arguments, env)
+      end
 
-    def git_command
-      Shellwords.split(env.git_command)
-    end
+      private
 
-    def config_arguments
-      env.config_variables.map { |k, v| ['-c', "#{k}=#{v}"] }
+      attr_reader :env, :command, :args, :shell_command_runner
+
+      def command_with_arguments
+        [git_command, config_arguments, command, arg_values].flatten
+      end
+
+      def git_command
+        Shellwords.split(env.git_command)
+      end
+
+      def config_arguments
+        env.config_variables.map { |k, v| ['-c', "#{k}=#{v}"] }
+      end
+
+      def arg_values
+        args.values(env)
+      end
     end
   end
 end

--- a/lib/gitsh/commands/shell_command.rb
+++ b/lib/gitsh/commands/shell_command.rb
@@ -1,41 +1,33 @@
-module Gitsh::Commands
-  class ShellCommand
-    def initialize(env, command, args)
-      @env = env
-      @command = command
-      @args = args
-    end
+require 'gitsh/shell_command_runner'
 
-    def execute
-      pid = Process.spawn(
-        *command_with_arguments,
-        out: env.output_stream.to_i,
-        err: env.error_stream.to_i
-      )
-      wait_for_process(pid)
-      $? && $?.success?
-    rescue SystemCallError => e
-      env.puts_error e.message
-      false
-    end
+module Gitsh
+  module Commands
+    class ShellCommand
+      def initialize(env, command, args, options = {})
+        @env = env
+        @command = command
+        @args = args
+        @shell_command_runner = options.fetch(
+          :shell_command_runner,
+          ShellCommandRunner,
+        )
+      end
 
-    private
+      def execute
+        shell_command_runner.run(command_with_arguments, env)
+      end
 
-    attr_reader :env, :command, :args
+      private
 
-    def command_with_arguments
-      [command, arg_values].flatten
-    end
+      attr_reader :env, :command, :args, :shell_command_runner
 
-    def arg_values
-      args.values(env)
-    end
+      def command_with_arguments
+        [command, arg_values].flatten
+      end
 
-    def wait_for_process(pid)
-      Process.wait(pid)
-    rescue Interrupt
-      Process.kill('INT', pid)
-      retry
+      def arg_values
+        args.values(env)
+      end
     end
   end
 end

--- a/lib/gitsh/shell_command_runner.rb
+++ b/lib/gitsh/shell_command_runner.rb
@@ -1,0 +1,36 @@
+module Gitsh
+  class ShellCommandRunner
+    def self.run(command_with_arguments, env)
+      new(command_with_arguments, env).run
+    end
+
+    def initialize(command_with_arguments, env)
+      @command_with_arguments = command_with_arguments
+      @env = env
+    end
+
+    def run
+      pid = Process.spawn(
+        *command_with_arguments,
+        out: env.output_stream.to_i,
+        err: env.error_stream.to_i
+      )
+      wait_for_process(pid)
+      $? && $?.success?
+    rescue SystemCallError => e
+      env.puts_error e.message
+      false
+    end
+
+    private
+
+    attr_reader :command_with_arguments, :env
+
+    def wait_for_process(pid)
+      Process.wait(pid)
+    rescue Interrupt
+      Process.kill('INT', pid)
+      retry
+    end
+  end
+end

--- a/spec/units/commands/git_command_spec.rb
+++ b/spec/units/commands/git_command_spec.rb
@@ -44,6 +44,7 @@ describe Gitsh::Commands::GitCommand do
         env,
         'commit',
         arguments('-m', 'A test commit'),
+        shell_command_runner: mock_runner,
       )
 
       command.execute

--- a/spec/units/commands/git_command_spec.rb
+++ b/spec/units/commands/git_command_spec.rb
@@ -2,43 +2,36 @@ require 'spec_helper'
 require 'gitsh/commands/git_command'
 
 describe Gitsh::Commands::GitCommand do
-  let(:env) do
-    double('Environment', {
-      git_command: '/usr/bin/env git',
-      output_stream: double('OutputStream', to_i: 1),
-      error_stream: double('ErrorStream', to_i: 2)
-    })
-  end
-
-  before do
-    allow(Process).to receive(:spawn).and_return(1)
-    allow(Process).to receive(:wait)
-  end
-
   describe '#execute' do
-    it 'spawns a process with the sub command and arguments' do
-      allow(env).to receive(:config_variables).and_return({})
+    it 'delegates to the Gitsh::ShellCommandRunner' do
+      env = double(:env, git_command: '/usr/bin/env git', config_variables: {})
+      expected_result = double(:result)
+      mock_runner = double(:shell_command_runner, run: expected_result)
+
       command = described_class.new(
         env,
-        'commit',
-        arguments('-m', 'A test commit'),
+        "commit",
+        arguments("-m", "Some stuff"),
+        shell_command_runner: mock_runner,
       )
+      result = command.execute
 
-      command.execute
-
-      expect(Process).to have_received(:spawn).with(
-        '/usr/bin/env', 'git',
-        'commit',
-        '-m', 'A test commit',
-        out: env.output_stream.to_i,
-        err: env.error_stream.to_i
+      expect(mock_runner).to have_received(:run).with(
+        ["/usr/bin/env", "git", "commit", "-m", "Some stuff"],
+        env,
       )
+      expect(result).to eq expected_result
     end
 
     it 'passes on configuration variables from the environment' do
-      allow(env).to receive(:config_variables).and_return(
-        :'test.example' => 'This is an example',
-        :'foo.bar' => '1'
+      mock_runner = double(:shell_command_runner, run: true)
+      env = double(
+        :env,
+        git_command: '/usr/bin/env git',
+        config_variables: {
+          :'test.example' => 'This is an example',
+          :'foo.bar' => '1',
+        },
       )
       command = described_class.new(
         env,
@@ -49,14 +42,15 @@ describe Gitsh::Commands::GitCommand do
 
       command.execute
 
-      expect(Process).to have_received(:spawn).with(
-        '/usr/bin/env', 'git',
-        '-c', 'test.example=This is an example',
-        '-c', 'foo.bar=1',
-        'commit',
-        '-m', 'A test commit',
-        out: env.output_stream.to_i,
-        err: env.error_stream.to_i
+      expect(mock_runner).to have_received(:run).with(
+        [
+          '/usr/bin/env', 'git',
+          '-c', 'test.example=This is an example',
+          '-c', 'foo.bar=1',
+          'commit',
+          '-m', 'A test commit',
+        ],
+        env,
       )
     end
   end

--- a/spec/units/commands/shell_command_spec.rb
+++ b/spec/units/commands/shell_command_spec.rb
@@ -3,72 +3,24 @@ require 'gitsh/commands/shell_command'
 
 describe Gitsh::Commands::ShellCommand do
   describe '#execute' do
-    before do
-      allow(Process).to receive(:spawn).and_return(1)
-      allow(Process).to receive(:wait)
-      allow(Process).to receive(:kill)
-      ensure_exit_status_exists
-    end
+    it 'delegates to the Gitsh::ShellCommandRunner' do
+      env = double(:env)
+      expected_result = double(:result)
+      mock_runner = double(:shell_command_runner, run: expected_result)
 
-    it 'spawns a process with the command and arguments' do
-      command = described_class.new(env, 'echo', arguments('Hello world'))
-
-      command.execute
-
-      expect(Process).to have_received(:spawn).with(
-        'echo', 'Hello world',
-        out: env.output_stream.to_i,
-        err: env.error_stream.to_i
+      command = described_class.new(
+        env,
+        "echo",
+        arguments("Hello", "world"),
+        shell_command_runner: mock_runner,
       )
+      result = command.execute
+
+      expect(mock_runner).to have_received(:run).with(
+        ["echo", "Hello", "world"],
+        env,
+      )
+      expect(result).to eq expected_result
     end
-
-    it 'returns true when the shell command succeeds' do
-      allow($?).to receive(:success?).and_return(true)
-      command = described_class.new(env, 'echo', arguments('Hello world'))
-
-      expect(command.execute).to eq true
-    end
-
-    it 'returns false when the shell command fails' do
-      allow($?).to receive(:success?).and_return(false)
-      command = described_class.new(env, 'badcommand', arguments('Hello world'))
-
-      expect(command.execute).to eq false
-    end
-
-    it 'returns false when Process.spawn raises' do
-      allow(Process).to receive(:spawn).and_raise(Errno::ENOENT, 'No such file')
-      command = described_class.new(env, 'badcommand', arguments('Hello world'))
-
-      expect(command.execute).to eq false
-    end
-
-    it 'forwards interrupts to the child process' do
-      pid = 12
-      wait_results = StubbedMethodResult.new.
-        raises(Interrupt).
-        returns(nil)
-      allow(Process).to receive(:spawn).and_return(pid)
-      allow(Process).to receive(:wait).with(pid) { wait_results.next_result }
-      command = described_class.new(env, 'vim', arguments())
-
-      command.execute
-
-      expect(Process).to have_received(:wait).with(pid).twice
-      expect(Process).to have_received(:kill).with('INT', pid).once
-    end
-  end
-
-  def ensure_exit_status_exists
-    `pwd`
-    expect($?).not_to be_nil
-  end
-
-  let(:env) do
-    double('Environment',
-      output_stream: double('OutputStream', to_i: 1),
-      error_stream: double('ErrorStream', to_i: 2),
-      puts_error: nil
-    )
   end
 end

--- a/spec/units/shell_command_runner_spec.rb
+++ b/spec/units/shell_command_runner_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+require 'gitsh/shell_command_runner'
+
+describe Gitsh::ShellCommandRunner do
+  describe '#run' do
+    before do
+      allow(Process).to receive(:spawn).and_return(1)
+      allow(Process).to receive(:wait)
+      allow(Process).to receive(:kill)
+      ensure_exit_status_exists
+    end
+
+    it 'spawns a process with the command and arguments' do
+      runner = described_class.new(["echo", "Hello world"], env)
+
+      runner.run
+
+      expect(Process).to have_received(:spawn).with(
+        'echo', 'Hello world',
+        out: env.output_stream.to_i,
+        err: env.error_stream.to_i
+      )
+    end
+
+    it 'returns true when the shell command succeeds' do
+      allow($?).to receive(:success?).and_return(true)
+      runner = described_class.new(['goodcommand'], env)
+
+      expect(runner.run).to eq true
+    end
+
+    it 'returns false when the shell command fails' do
+      allow($?).to receive(:success?).and_return(false)
+      runner = described_class.new(['badcommand'], env)
+
+      expect(runner.run).to eq false
+    end
+
+    it 'returns false when Process.spawn raises' do
+      allow(Process).to receive(:spawn).and_raise(Errno::ENOENT, 'No such file')
+      runner = described_class.new(['badcommand'], env)
+
+      expect(runner.run).to eq false
+    end
+
+    it 'forwards interrupts to the child process' do
+      pid = 12
+      wait_results = StubbedMethodResult.new.
+        raises(Interrupt).
+        returns(nil)
+      allow(Process).to receive(:spawn).and_return(pid)
+      allow(Process).to receive(:wait).with(pid) { wait_results.next_result }
+      runner = described_class.new(["vim"], env)
+
+      runner.run
+
+      expect(Process).to have_received(:wait).with(pid).twice
+      expect(Process).to have_received(:kill).with('INT', pid).once
+    end
+  end
+
+  def ensure_exit_status_exists
+    `pwd`
+    expect($?).not_to be_nil
+  end
+
+  let(:env) do
+    double('Environment',
+      output_stream: double('OutputStream', to_i: 1),
+      error_stream: double('ErrorStream', to_i: 2),
+      puts_error: nil
+    )
+  end
+end


### PR DESCRIPTION
Refactors `Gitsh::Commands::ShellCommand` and `Gitsh::Commands::GitCommand`

* Extract a `Gitsh::ShellCommandRunner` from `Gitsh::Commands::ShellCommand`.
* Replace inheritance with composition.
* Pave the way to solve #134 without modifying the behaviour of Git commands.