### PR TITLE
Support ~ in paths given to `:source`

### DIFF
--- a/lib/gitsh/commands/internal_command.rb
+++ b/lib/gitsh/commands/internal_command.rb
@@ -182,7 +182,7 @@ TXT
       end
 
       def path
-        arg_values.first
+        File.expand_path(arg_values.first)
       end
     end
 

--- a/spec/integration/source_command_spec.rb
+++ b/spec/integration/source_command_spec.rb
@@ -13,6 +13,18 @@ describe 'The :source command' do
         expect(gitsh).to output /Yes it did!/
       end
     end
+
+    it 'expands ~ in paths' do
+      GitshRunner.interactive do |gitsh|
+        write_file("#{ENV['HOME']}/.gitshrc", ':set source_worked "True"')
+
+        gitsh.type ':source ~/.gitshrc'
+        gitsh.type ':echo $source_worked'
+
+        expect(gitsh).to output_no_errors
+        expect(gitsh).to output /True/
+      end
+    end
   end
 
   context 'no source file is given' do


### PR DESCRIPTION
The `:cd` command already supported `~` in paths, but `:source` did not. This commit fixes that inconsistency.