### PR TITLE
Use non-zero exit status on fatal errors.

### DIFF
--- a/src/gitsh.rb.in
+++ b/src/gitsh.rb.in
@@ -9,4 +9,5 @@ begin
   Gitsh::CLI.new.run
 rescue => e
   $stderr.puts "gitsh: Error: #{e.message}"
+  exit 1
 end


### PR DESCRIPTION
In which I correct an embarrassing oversight.

Fixes #233 
