### PR TITLE
Raise UnsetVariableError for magic variables.

### DIFF
--- a/lib/gitsh/magic_variables.rb
+++ b/lib/gitsh/magic_variables.rb
@@ -21,15 +21,22 @@ module Gitsh
     end
 
     def _prior
-      repo.revision_name('@{-1}')
+      repo.revision_name('@{-1}') ||
+        raise(UnsetVariableError, 'No prior branch')
     end
 
     def _merge_base
-      repo.merge_base('HEAD', 'MERGE_HEAD')
+      repo.merge_base('HEAD', 'MERGE_HEAD').tap do |merge_base|
+        if merge_base.empty?
+          raise UnsetVariableError, 'No merge in progress'
+        end
+      end
     end
 
     def _rebase_base
-      read_file(['rebase-apply', 'onto']) || read_file(['rebase-merge', 'onto'])
+      read_file(['rebase-apply', 'onto']) ||
+        read_file(['rebase-merge', 'onto']) ||
+        raise(UnsetVariableError, 'No rebase in progress')
     end
 
     def read_file(path_components)

--- a/spec/integration/magic_variables_spec.rb
+++ b/spec/integration/magic_variables_spec.rb
@@ -17,6 +17,16 @@ describe 'Magic variables' do
         expect(gitsh).to output 'my-feature-branch'
       end
     end
+
+    it 'outputs an error when there is no previous branch' do
+      GitshRunner.interactive do |gitsh|
+        gitsh.type('init')
+        gitsh.type('commit --allow-empty -m "Initial commit"')
+        gitsh.type('branch -d $_prior')
+
+        expect(gitsh).to output_error(/No prior branch/)
+      end
+    end
   end
 
   context '$_merge_base' do
@@ -32,6 +42,15 @@ describe 'Magic variables' do
         expect(gitsh).to output expected_merge_base
       end
     end
+
+    it 'outputs an error when there is no merge in progress' do
+      GitshRunner.interactive do |gitsh|
+        gitsh.type('init')
+        gitsh.type(':echo $_merge_base')
+
+        expect(gitsh).to output_error(/No merge in progress/)
+      end
+    end
   end
 
   context '$_rebase_base' do
@@ -45,6 +64,15 @@ describe 'Magic variables' do
         gitsh.type(':echo $_rebase_base')
 
         expect(gitsh).to output expected_rebase_base
+      end
+    end
+
+    it 'outputs an error when there is no rebase in progress' do
+      GitshRunner.interactive do |gitsh|
+        gitsh.type('init')
+        gitsh.type(':echo $_rebase_base')
+
+        expect(gitsh).to output_error(/No rebase in progress/)
       end
     end
   end

--- a/spec/units/magic_variables_spec.rb
+++ b/spec/units/magic_variables_spec.rb
@@ -22,6 +22,15 @@ describe Gitsh::MagicVariables do
         expect(magic_variables.fetch(:_prior)).to eq 'a-branch-name'
         expect(repo).to have_received(:revision_name).with('@{-1}')
       end
+
+      it 'raises when there is no prior branch' do
+        repo = double('GitRepository', revision_name: nil)
+        magic_variables = described_class.new(repo)
+
+        expect { magic_variables.fetch(:_prior) }.to raise_exception(
+          Gitsh::UnsetVariableError,
+        )
+      end
     end
 
     context 'with _merge_base' do
@@ -31,6 +40,15 @@ describe Gitsh::MagicVariables do
 
         expect(magic_variables.fetch(:_merge_base)).to eq 'abc124567890'
         expect(repo).to have_received(:merge_base).with('HEAD', 'MERGE_HEAD')
+      end
+
+      it 'raises when there is no merge in progress' do
+        repo = double('GitRepository', merge_base: '')
+        magic_variables = described_class.new(repo)
+
+        expect { magic_variables.fetch(:_merge_base) }.to raise_exception(
+          Gitsh::UnsetVariableError,
+        )
       end
     end
 
@@ -64,12 +82,14 @@ describe Gitsh::MagicVariables do
       end
 
       context 'when there is no rebase in progress' do
-        it 'returns nil' do
+        it 'raises an exception' do
           Dir.mktmpdir do |tmpdir_path|
             repo = double('GitRepository', git_dir: tmpdir_path)
             magic_variables = described_class.new(repo)
 
-            expect(magic_variables.fetch(:_rebase_base)).to be_nil
+            expect { magic_variables.fetch(:_rebase_base) }.to raise_exception(
+              Gitsh::UnsetVariableError,
+            )
           end
         end
       end


### PR DESCRIPTION
The magic variables that gitsh provides all depend on certain state, e.g. the `$_merge_base` variable is only applicable during a merge.

This commit brings magic variables into line with regular user-defined variables, but raising an `UnsetVariableError` if they aren't currently set, i.e. if the state from which the variable derives its value doesn't exist.

Fixes #230 