### PR TITLE
Use bundle exec rspec to run specs

### DIFF
--- a/spec/Makefile.am
+++ b/spec/Makefile.am
@@ -1,4 +1,4 @@
 TESTS = $(testfiles)
 TEST_EXTENSIONS = .rb
-RB_LOG_COMPILER = rspec
+RB_LOG_COMPILER = bundle exec rspec
 AM_RB_LOG_FLAGS = -I $(abs_top_builddir)/spec -I $(abs_top_builddir)/lib


### PR DESCRIPTION
On Mac OS X 10.11.4 and Debian 8 using system Ruby the `make check` task
would fail on the `units/terminal_spec.rb` file with a `NoMethodError`
for `allow` on `CommandStubber`. This was probably because rspec-mocks
did not properly laod.

Running specs using `bundle exec rspec` solves this.