### PR TITLE
Provide a helpful message if git is not executable

### DIFF
--- a/lib/gitsh/cli.rb
+++ b/lib/gitsh/cli.rb
@@ -24,7 +24,9 @@ module Gitsh
       parse_arguments
       if unparsed_args.any?
         exit_with_usage_message
-      elsif script_file
+      end
+      ensure_executable_git
+      if script_file
         run_script
       else
         interactive_runner.run
@@ -81,6 +83,22 @@ module Gitsh
           exit EX_OK
         end
       end
+    end
+
+    def ensure_executable_git
+      IO.popen(env.git_command).close
+    rescue Errno::ENOENT
+      env.puts_error(
+        "gitsh: #{env.git_command}: No such file or directory\nEnsure git is "\
+        'on your PATH, or specify the path to git using the --git option',
+      )
+      exit EX_UNAVAILABLE
+    rescue Errno::EACCES
+      env.puts_error(
+        "gitsh: #{env.git_command}: Permission denied\nEnsure git is "\
+        'executable',
+      )
+      exit EX_UNAVAILABLE
     end
   end
 end

--- a/lib/gitsh/exit_statuses.rb
+++ b/lib/gitsh/exit_statuses.rb
@@ -2,4 +2,5 @@ module Gitsh
   EX_OK = 0
   EX_USAGE = 64
   EX_NOINPUT = 66
+  EX_UNAVAILABLE = 69
 end

--- a/spec/integration/default_git_path_spec.rb
+++ b/spec/integration/default_git_path_spec.rb
@@ -23,8 +23,4 @@ describe 'Default git path' do
       expect(gitsh).to output /^Fake git: init/
     end
   end
-
-  def fake_git_path
-    File.expand_path('../../fixtures/fake_git', __FILE__)
-  end
 end

--- a/spec/integration/running_scripts_spec.rb
+++ b/spec/integration/running_scripts_spec.rb
@@ -6,7 +6,7 @@ describe 'Executing gitsh scripts' do
       in_a_temporary_directory do
         write_file('myscript.gitsh', "init\n\ncommit")
 
-        expect("#{gitsh} --git #{fake_git} myscript.gitsh").to execute.
+        expect("#{gitsh} --git #{fake_git_path} myscript.gitsh").to execute.
           successfully.
           with_output_matching(/^Fake git: init\nFake git: commit\n$/)
       end
@@ -14,7 +14,7 @@ describe 'Executing gitsh scripts' do
 
     context 'when the script file does not exist' do
       it 'exits with a useful error message' do
-        expect("#{gitsh} --git #{fake_git} noscript.gitsh").to execute.
+        expect("#{gitsh} --git #{fake_git_path} noscript.gitsh").to execute.
           with_exit_status(66).
           with_error_output_matching(/^gitsh: noscript\.gitsh: No such file or directory$/)
       end
@@ -26,8 +26,8 @@ describe 'Executing gitsh scripts' do
       in_a_temporary_directory do
         write_file('myscript.gitsh', "init\n\ncommit")
 
-        expect("cat myscript.gitsh | #{gitsh} --git #{fake_git}").to execute.
-          successfully.
+        expect("cat myscript.gitsh | #{gitsh} --git #{fake_git_path}").
+          to execute.successfully.
           with_output_matching(/^Fake git: init\nFake git: commit\n$/)
       end
     end
@@ -35,9 +35,5 @@ describe 'Executing gitsh scripts' do
 
   def gitsh
     File.expand_path('../../../bin/gitsh', __FILE__)
-  end
-
-  def fake_git
-    File.expand_path('../../../spec/fixtures/fake_git', __FILE__)
   end
 end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,0 +1,9 @@
+module FixturesHelper
+  def fake_git_path
+    File.expand_path('../../../spec/fixtures/fake_git', __FILE__)
+  end
+end
+
+RSpec.configure do |config|
+  config.include FixturesHelper
+end

--- a/spec/units/cli_spec.rb
+++ b/spec/units/cli_spec.rb
@@ -21,11 +21,16 @@ describe Gitsh::CLI do
       it 'calls the script runner with -' do
         script_runner = double('ScriptRunner', run: nil)
         interactive_runner = double('InteractiveRunner', run: nil)
+        env = double(
+          'Environment',
+          tty?: false,
+          git_command: fake_git_path,
+        )
         cli = Gitsh::CLI.new(
           args: [],
           script_runner: script_runner,
           interactive_runner: interactive_runner,
-          env: double('Environment', tty?: false),
+          env: env,
         )
 
         cli.run
@@ -54,7 +59,7 @@ describe Gitsh::CLI do
 
     context 'with an unreadable script file' do
       it 'exits' do
-        env = double('env', puts_error: nil)
+        env = double('env', puts_error: nil, git_command: fake_git_path)
         script_runner = double('ScriptRunner')
         allow(script_runner).to receive(:run).
           and_raise(Gitsh::NoInputError, 'Oh no!')
@@ -77,6 +82,42 @@ describe Gitsh::CLI do
         cli = Gitsh::CLI.new(args: %w( --bad-argument ), env: env)
 
         expect { cli.run }.to raise_exception(SystemExit)
+      end
+    end
+
+    context 'with a non-existent git' do
+      it 'exits with a helpful error message' do
+        env = double('Environment', puts_error: nil, git_command: 'nonexistent')
+        cli = Gitsh::CLI.new(args: [], env: env)
+
+        expect { cli.run }.to raise_exception(SystemExit)
+        expect(env).to have_received(:puts_error).with(
+          "gitsh: nonexistent: No such file or directory\nEnsure git is on "\
+          'your PATH, or specify the path to git using the --git option',
+        )
+      end
+    end
+
+    context 'with a non-executable git' do
+      it 'exits with a helpful error message' do
+        non_executable = Tempfile.new('git')
+        non_executable.close
+        begin
+          env = double(
+            'Environment',
+            puts_error: nil,
+            git_command: non_executable.path,
+          )
+          cli = Gitsh::CLI.new(args: [], env: env)
+
+          expect { cli.run }.to raise_exception(SystemExit)
+          expect(env).to have_received(:puts_error).with(
+            "gitsh: #{non_executable.path}: Permission denied\nEnsure git is "\
+            'executable',
+          )
+        ensure
+          non_executable.unlink
+        end
       end
     end
   end


### PR DESCRIPTION
Display a helpful message and exit early when gitsh is installed on a
system without git or when a non-existent git is specified using the
`--git` option.

This fixes #193.