### PR TITLE
Tab complete spaces (and other special characters)

### DIFF
--- a/ext/gitsh/extconf.rb
+++ b/ext/gitsh/extconf.rb
@@ -55,6 +55,8 @@ readline.require_func("rl_set_screen_size")
 readline.require_var("rl_completion_append_character")
 readline.require_var("rl_editing_mode")
 readline.require_var("rl_line_buffer")
+readline.require_var("rl_char_is_quoted_p")
+readline.require_var("rl_completion_quote_character")
 
 readline.have_func("rl_getc")
 readline.have_func("rl_getc_function")

--- a/lib/gitsh/completion_escaper.rb
+++ b/lib/gitsh/completion_escaper.rb
@@ -22,15 +22,15 @@ module Gitsh
     attr_reader :completer, :line_editor
 
     def escape(option)
-      option.gsub(/([#{escapables}])/) { |char| "\\#{char}" }
+      option.gsub(escapables) { |char| "\\#{char}" }
     end
 
     def unescape(input)
-      input.gsub(/\\([#{escapables}])/, '\1')
+      input.gsub(/\\(#{escapables})/, '\1')
     end
 
     def escapables
-      ESCAPABLES[line_editor.completion_quote_character]
+      ESCAPABLES[line_editor.completion_quote_character].to_regexp
     end
   end
 end

--- a/lib/gitsh/completion_escaper.rb
+++ b/lib/gitsh/completion_escaper.rb
@@ -22,13 +22,7 @@ module Gitsh
     attr_reader :completer, :line_editor
 
     def escape(option)
-      escaped = option.gsub(/([#{escapables}])(?!$)/) { |char| "\\#{char}" }
-
-      if completing_quoted_argument?
-        escaped.strip
-      else
-        escaped
-      end
+      option.gsub(/([#{escapables}])/) { |char| "\\#{char}" }
     end
 
     def unescape(input)
@@ -37,10 +31,6 @@ module Gitsh
 
     def escapables
       ESCAPABLES[line_editor.completion_quote_character]
-    end
-
-    def completing_quoted_argument?
-      !line_editor.completion_quote_character.nil?
     end
   end
 end

--- a/lib/gitsh/interactive_runner.rb
+++ b/lib/gitsh/interactive_runner.rb
@@ -42,7 +42,6 @@ module Gitsh
       :script_runner
 
     def setup_line_editor
-      line_editor.completion_append_character = nil
       line_editor.completion_proc = CompletionEscaper.new(
         Completer.new(line_editor, env),
         line_editor: line_editor,

--- a/lib/gitsh/interactive_runner.rb
+++ b/lib/gitsh/interactive_runner.rb
@@ -1,10 +1,12 @@
 require 'gitsh/completer'
+require 'gitsh/completion_escaper'
 require 'gitsh/error'
 require 'gitsh/history'
 require 'gitsh/interpreter'
 require 'gitsh/line_editor'
 require 'gitsh/line_editor_history_filter'
 require 'gitsh/prompter'
+require 'gitsh/quote_detector'
 require 'gitsh/script_runner'
 require 'gitsh/terminal'
 
@@ -41,7 +43,13 @@ module Gitsh
 
     def setup_line_editor
       line_editor.completion_append_character = nil
-      line_editor.completion_proc = Completer.new(line_editor, env)
+      line_editor.completion_proc = CompletionEscaper.new(
+        Completer.new(line_editor, env),
+        line_editor: line_editor,
+      )
+      line_editor.completer_quote_characters = %('")
+      line_editor.completer_word_break_characters = ' &|;'
+      line_editor.quoting_detection_proc = QuoteDetector.new
     end
 
     def handle_window_resize

--- a/lib/gitsh/parser.rb
+++ b/lib/gitsh/parser.rb
@@ -3,6 +3,11 @@ require 'gitsh/transformer'
 
 module Gitsh
   class Parser < Parslet::Parser
+    UNQUOTED_STRING_TERMINATORS = %q(\\s'"&|;#).freeze
+    UNQUOTED_STRING_ESCAPABLES = (UNQUOTED_STRING_TERMINATORS + %q(\\\$)).freeze
+    SOFT_STRING_ESCAPABLES = %q(\\\$").freeze
+    HARD_STRING_ESCAPABLES = %q(\\\').freeze
+
     def initialize(options={})
       super()
       @env = options.fetch(:env)
@@ -70,10 +75,16 @@ module Gitsh
 
     rule(:unquoted_string) do
       (
+        unquoted_string_escaped_literal |
         variable |
         subshell |
-        match(%q([^\s'"&|;#])).as(:literal)
+        match(not_character_class(UNQUOTED_STRING_TERMINATORS)).as(:literal)
       ).repeat(1)
+    end
+
+    rule(:unquoted_string_escaped_literal) do
+      str('\\') >>
+        match(character_class(UNQUOTED_STRING_ESCAPABLES)).as(:literal)
     end
 
     rule(:empty_string) do
@@ -82,15 +93,26 @@ module Gitsh
 
     rule(:soft_string) do
       str('"') >> (
-        (str('\\') >> match('[$"\\\]').as(:literal)) |
+        soft_string_escaped_literal |
         variable |
         subshell |
         (str('"').absent? >> any).as(:literal)
       ).repeat(0) >> str('"')
     end
 
+    rule(:soft_string_escaped_literal) do
+      str('\\') >> match(character_class(SOFT_STRING_ESCAPABLES)).as(:literal)
+    end
+
     rule(:hard_string) do
-      str("'") >> (str("'").absent? >> any).as(:literal).repeat(0) >> str("'")
+      str("'") >> (
+        hard_string_escaped_literal |
+        (str("'").absent? >> any).as(:literal)
+      ).repeat(0) >> str("'")
+    end
+
+    rule(:hard_string_escaped_literal) do
+      str('\\') >> match(character_class(HARD_STRING_ESCAPABLES)).as(:literal)
     end
 
     rule(:command_identifier) do
@@ -159,6 +181,14 @@ module Gitsh
 
     def autocorrect_enabled?
       env.fetch('help.autocorrect') { '0' } != '0'
+    end
+
+    def character_class(characters)
+      "[#{characters}]"
+    end
+
+    def not_character_class(characters)
+      "[^#{characters}]"
     end
   end
 end

--- a/lib/gitsh/parser/character_class.rb
+++ b/lib/gitsh/parser/character_class.rb
@@ -1,0 +1,25 @@
+require 'parslet'
+
+module Gitsh
+  class Parser < Parslet::Parser
+    class CharacterClass
+      attr_reader :characters
+
+      def initialize(characters)
+        @characters = characters
+      end
+
+      def +(other)
+        self.class.new(characters + other.characters)
+      end
+
+      def parser_atom
+        Parslet.match(to_regexp)
+      end
+
+      def to_regexp
+        Regexp.new("[#{Regexp.escape(characters.join)}]")
+      end
+    end
+  end
+end

--- a/lib/gitsh/quote_detector.rb
+++ b/lib/gitsh/quote_detector.rb
@@ -1,0 +1,7 @@
+module Gitsh
+  class QuoteDetector
+    def call(text, index)
+      index > 0 && text[index - 1] == '\\' && !call(text, index - 1)
+    end
+  end
+end

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -93,7 +93,7 @@ fails.
 execute
 .Ic left ,
 and then
-.Ic right.
+.Ic right .
 .El
 .
 .Sh PROMPT
@@ -268,6 +268,53 @@ For example:
 .Bd -literal -offset indent
 @ :set directory $(!pwd)
 .Ed
+.Sh COMMAND ARGUMENTS
+.Pp
+When arguments are passed to Git commands, internal commands, or shell
+commands, gitsh will recognise and interpret various methods of quoting
+characters. These are similar to those supported by
+.Xr sh 1 ,
+and other general-purpose shells.
+.Pp
+In general, a charater which would otherwise have some special meaning may
+be included as a literal character in an argument if it is prefixed with a
+.Ic \e
+character.
+.Pp
+In an
+.Em unquoted
+argument, the string delimiters
+.Pf ( Ic '" Ns ),
+the variable or sub-shell prefix
+.Pf ( Ic $ Ns ),
+and any character which would indicated the end of the argument
+(spaces,
+.Ic &|;# Ns )
+can be escaped.
+.Pp
+In a
+.Em double-quoted
+argument, only the string delimiter
+.Pf ( Ic \(dq Ns ),
+and the variable or sub-shell prefix
+.Pf ( Ic $ Ns )
+can be escaped.
+.Pp
+In a
+.Em single-quoted
+argument, very few characters have special meaning, and so only the
+string delimiter
+.Pf ( Ic ' Ns )
+can be escaped.
+.Pp
+A literal
+.Ic \e
+character can always be produced by repeating it
+.Pf ( Ic \e\e Ns ),
+but a single
+.Ic \e
+will also be interpreted as a literal as long as it isn't followed by
+a character that can be escaped in the current context.
 .Sh CONFIGURATION
 The following
 .Xr git-config 1

--- a/spec/integration/tab_completion_spec.rb
+++ b/spec/integration/tab_completion_spec.rb
@@ -43,6 +43,9 @@ describe 'Completing things with tab' do
       gitsh.type('init')
 
       gitsh.type(":se\t arthur 'Arthur Dent <arthur@tea.example.com>'")
+
+      expect(gitsh).to output_no_errors
+
       gitsh.type('commit --allow-empty --author $arthur -m "More tea"')
       gitsh.type('log --format="%ae - %s"')
 
@@ -66,12 +69,21 @@ describe 'Completing things with tab' do
   it 'completes paths' do
     GitshRunner.interactive do |gitsh|
       gitsh.type('init')
-      write_file('foo.txt')
-      gitsh.type("add f\t")
-      gitsh.type('commit -m "Add foo.txt"')
+      write_file('some text file.txt')
+      write_file('another file.txt')
+      gitsh.type("add som\t")
+
+      expect(gitsh).to output_no_errors
+
+      gitsh.type("add another\\ f\t")
+
+      expect(gitsh).to output_no_errors
+
+      gitsh.type('commit -m "Add some text file"')
       gitsh.type('ls-files')
 
-      expect(gitsh).to output(/foo\.txt/)
+      expect(gitsh).to output(/another file\.txt/)
+      expect(gitsh).to output(/some text file\.txt/)
     end
   end
 

--- a/spec/integration/tab_completion_spec.rb
+++ b/spec/integration/tab_completion_spec.rb
@@ -11,11 +11,11 @@ describe 'Completing things with tab' do
 
       gitsh.type("com\t --allow-empty -m 'Some commit'")
 
-      expect(gitsh).to output /Some commit/
+      expect(gitsh).to output(/Some commit/)
 
       gitsh.type("bra\t")
 
-      expect(gitsh).to output /my-feature/
+      expect(gitsh).to output(/my-feature/)
     end
   end
 
@@ -27,14 +27,14 @@ describe 'Completing things with tab' do
       gitsh.type("zec\t")
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /zzz/
+      expect(gitsh).to output(/zzz/)
 
       gitsh.type(':set alias.yecho "!echo yyy"')
 
       gitsh.type("yec\t")
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /yyy/
+      expect(gitsh).to output(/yyy/)
     end
   end
 
@@ -47,7 +47,7 @@ describe 'Completing things with tab' do
       gitsh.type('log --format="%ae - %s"')
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /^arthur@tea\.example\.com - More tea$/
+      expect(gitsh).to output(/^arthur@tea\.example\.com - More tea$/)
     end
   end
 
@@ -71,7 +71,7 @@ describe 'Completing things with tab' do
       gitsh.type('commit -m "Add foo.txt"')
       gitsh.type('ls-files')
 
-      expect(gitsh).to output /foo\.txt/
+      expect(gitsh).to output(/foo\.txt/)
     end
   end
 
@@ -84,7 +84,7 @@ describe 'Completing things with tab' do
       gitsh.type("log --format=%s master~2..mas\t")
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /\AThird\nSecond\n\Z/
+      expect(gitsh).to output(/\AThird\nSecond\n\Z/)
     end
   end
 end

--- a/spec/support/file_system.rb
+++ b/spec/support/file_system.rb
@@ -6,6 +6,10 @@ module FileSystemHelper
     File.open(name, 'w') { |f| f << "#{contents}\n" }
   end
 
+  def make_directory(name)
+    Dir.mkdir(name)
+  end
+
   def temp_file(name, contents)
     Tempfile.new(name).tap do |f|
       f.write("#{contents}\n")

--- a/spec/units/completer_spec.rb
+++ b/spec/units/completer_spec.rb
@@ -11,8 +11,8 @@ describe Gitsh::Completer do
           git_aliases: %w( adder )
         )
 
-        expect(completer.call('sta')).to eq ['stage ', 'stash ', 'status ']
-        expect(completer.call('ad')).to eq ['add ', 'adder ']
+        expect(completer.call('sta')).to eq ['stage', 'stash', 'status']
+        expect(completer.call('ad')).to eq ['add', 'adder']
       end
 
       it 'completes internal commands' do
@@ -21,8 +21,8 @@ describe Gitsh::Completer do
           internal_commands: %w( :set :exit )
         )
 
-        expect(completer.call(':')).to eq [':set ', ':exit ']
-        expect(completer.call(':s')).to eq [':set ']
+        expect(completer.call(':')).to eq [':set', ':exit']
+        expect(completer.call(':s')).to eq [':set']
       end
     end
 
@@ -33,9 +33,9 @@ describe Gitsh::Completer do
           repo_heads: %w( master my-feature v1.0 )
         )
 
-        expect(completer.call('')).to include 'master ', 'my-feature ', 'v1.0 '
-        expect(completer.call('m')).to include 'master ', 'my-feature '
-        expect(completer.call('m')).not_to include 'v1.0 '
+        expect(completer.call('')).to include 'master', 'my-feature', 'v1.0'
+        expect(completer.call('m')).to include 'master', 'my-feature'
+        expect(completer.call('m')).not_to include 'v1.0'
       end
 
       it 'completes head when branch include a dot' do
@@ -44,7 +44,7 @@ describe Gitsh::Completer do
           repo_heads: %w( fix-v1.5 fix-v1.6 )
         )
 
-        expect(completer.call('fix-v1.')).to include 'fix-v1.5 ', 'fix-v1.6 '
+        expect(completer.call('fix-v1.')).to include 'fix-v1.5', 'fix-v1.6'
       end
 
       it 'completes heads starting with :' do
@@ -53,7 +53,7 @@ describe Gitsh::Completer do
           repo_heads: %w( master my-feature )
         )
 
-        expect(completer.call('master:m')).to include 'master:my-feature '
+        expect(completer.call('master:m')).to include 'master:my-feature'
       end
 
       it 'ignores input before punctuation when completing heads' do
@@ -62,7 +62,7 @@ describe Gitsh::Completer do
           repo_heads: %w( master my-feature )
         )
 
-        expect(completer.call('mas:')).to include 'mas:master ', 'mas:my-feature '
+        expect(completer.call('mas:')).to include 'mas:master', 'mas:my-feature'
       end
 
       it 'completes paths beginning with a ~ character' do
@@ -72,7 +72,7 @@ describe Gitsh::Completer do
             FileUtils.touch('file')
           end
 
-          expect(completer.call('~/')).to include "#{first_regular_file('~')} "
+          expect(completer.call('~/')).to include first_regular_file('~')
         end
       end
 
@@ -81,7 +81,7 @@ describe Gitsh::Completer do
         project_root = File.expand_path('../../../', __FILE__)
         path = File.join(project_root, 'spec/./units/../units')
 
-        expect(completer.call("#{path}/")).to include "#{first_regular_file(path)} "
+        expect(completer.call("#{path}/")).to include first_regular_file(path)
       end
 
       it 'completes directories with a trailing slash' do
@@ -96,14 +96,60 @@ describe Gitsh::Completer do
           repo_remotes: %w( origin upstream )
         )
 
-        expect(completer.call('')).to include 'upstream ', 'origin '
-        expect(completer.call('up')).to include 'upstream '
+        expect(completer.call('')).to include 'upstream', 'origin'
+        expect(completer.call('up')).to include 'upstream'
+      end
+    end
+
+    context 'with multiple matching options' do
+      it 'sets the completion_append_character to a space' do
+        line_editor = build_line_editor(input: 'add ')
+        completer = build_completer(line_editor: line_editor)
+        in_a_temporary_directory do
+          write_file('somefile.txt')
+          make_directory('somedir')
+
+          completer.call('some')
+
+          expect(line_editor).
+            to have_received(:completion_append_character=).with(' ')
+        end
+      end
+    end
+
+    context 'with a single matching option that is not a directory path' do
+      it 'sets the completion_append_character to a space' do
+        line_editor = build_line_editor(input: 'add ')
+        completer = build_completer(line_editor: line_editor)
+        in_a_temporary_directory do
+          write_file('somefile.txt')
+
+          completer.call('some')
+
+          expect(line_editor).
+            to have_received(:completion_append_character=).with(' ')
+        end
+      end
+    end
+
+    context 'with a single matching option that is a directory path' do
+      it 'sets the completion_append_character to nil' do
+        line_editor = build_line_editor(input: 'add ')
+        completer = build_completer(line_editor: line_editor)
+        in_a_temporary_directory do
+          make_directory('somedir')
+
+          completer.call('some')
+
+          expect(line_editor).
+            to have_received(:completion_append_character=).with(nil)
+        end
       end
     end
   end
 
   def build_completer(options)
-    line_editor = double('LineEditor', line_buffer: options.fetch(:input))
+    line_editor = options.fetch(:line_editor) { build_line_editor(options) }
     env = double('Environment', {
       git_commands: options.fetch(:git_commands, %w( add commit )),
       git_aliases: options.fetch(:git_aliases, %w( graph )),
@@ -114,6 +160,14 @@ describe Gitsh::Completer do
       commands: options.fetch(:internal_commands, %w( :set :exit ))
     })
     Gitsh::Completer.new(line_editor, env, internal_command)
+  end
+
+  def build_line_editor(options)
+    double(
+      'LineEditor',
+      line_buffer: options.fetch(:input),
+      :completion_append_character= => nil,
+    )
   end
 
   def first_regular_file(directory)

--- a/spec/units/completion_escaper_spec.rb
+++ b/spec/units/completion_escaper_spec.rb
@@ -10,31 +10,31 @@ describe Gitsh::CompletionEscaper do
           completer_input: 'op',
           completer: -> (_) do
             [
-              %q(option ),
-              %q(with space ),
-              %q("quotes" ),
-              %q('quotes' ),
-              %q(slash\ ),
-              %q($var_like ),
-              %q(a&b ),
-              %q(a|b ),
-              %q(a;b ),
-              %q(#comment-like ),
+              %q(option),
+              %q(with space),
+              %q("quotes"),
+              %q('quotes'),
+              %q(slash\\),
+              %q($var_like),
+              %q(a&b),
+              %q(a|b),
+              %q(a;b),
+              %q(#comment-like),
             ]
           end,
         )
 
         expect(options).to eq [
-          %q(option ),
-          %q(with\ space ),
-          %q(\"quotes\" ),
-          %q(\'quotes\' ),
-          %q(slash\\\\ ),
-          %q(\$var_like ),
-          %q(a\&b ),
-          %q(a\|b ),
-          %q(a\;b ),
-          %q(\#comment-like ),
+          %q(option),
+          %q(with\ space),
+          %q(\"quotes\"),
+          %q(\'quotes\'),
+          %q(slash\\\\),
+          %q(\$var_like),
+          %q(a\&b),
+          %q(a\|b),
+          %q(a\;b),
+          %q(\#comment-like),
         ]
       end
 
@@ -42,7 +42,7 @@ describe Gitsh::CompletionEscaper do
         completer_argument = nil
         completer = -> (text) do
           completer_argument = text
-          ['some file.txt ']
+          ['some file.txt']
         end
         options = escape_options(
           quote_character: nil,
@@ -51,7 +51,7 @@ describe Gitsh::CompletionEscaper do
         )
 
         expect(completer_argument).to eq 'some f'
-        expect(options).to eq ['some\\ file.txt ']
+        expect(options).to eq ['some\\ file.txt']
       end
 
       it 'recognises escaped escape characters' do
@@ -86,22 +86,22 @@ describe Gitsh::CompletionEscaper do
     end
 
     context 'with an unclosed single quote' do
-      it 'escapes slashes and single quotes, and strips trailing whitespace' do
+      it 'escapes slashes and single quotes' do
         options = escape_options(
           quote_character: "'",
           completer_input: 'op',
           completer: -> (_) do
             [
-              %q(option ),
-              %q(with space ),
-              %q("quotes" ),
-              %q('quotes' ),
-              %q(slash\ ),
-              %q($var_like ),
-              %q(a&b ),
-              %q(a|b ),
-              %q(a;b ),
-              %q(#comment-like ),
+              %q(option),
+              %q(with space),
+              %q("quotes"),
+              %q('quotes'),
+              %q(slash\\),
+              %q($var_like),
+              %q(a&b),
+              %q(a|b),
+              %q(a;b),
+              %q(#comment-like),
             ]
           end,
         )
@@ -122,22 +122,22 @@ describe Gitsh::CompletionEscaper do
     end
 
     context 'with an unclosed double quote' do
-      it 'escapes slashes, double quotes, and $, and strips trailing whitespace' do
+      it 'escapes slashes, double quotes, and $' do
         options = escape_options(
           quote_character: '"',
           completer_input: 'op',
           completer: -> (_) do
             [
-              %q(option ),
-              %q(with space ),
-              %q("quotes" ),
-              %q('quotes' ),
-              %q(slash\ ),
-              %q($var_like ),
-              %q(a&b ),
-              %q(a|b ),
-              %q(a;b ),
-              %q(#comment-like ),
+              %q(option),
+              %q(with space),
+              %q("quotes"),
+              %q('quotes'),
+              %q(slash\\),
+              %q($var_like),
+              %q(a&b),
+              %q(a|b),
+              %q(a;b),
+              %q(#comment-like),
             ]
           end,
         )

--- a/spec/units/completion_escaper_spec.rb
+++ b/spec/units/completion_escaper_spec.rb
@@ -1,0 +1,173 @@
+require 'spec_helper'
+require 'gitsh/completion_escaper'
+
+describe Gitsh::CompletionEscaper do
+  describe '#call' do
+    context 'without any quote characters' do
+      it 'escapes spaces, slashes, quotes, operators, etc.' do
+        options = escape_options(
+          quote_character: nil,
+          completer_input: 'op',
+          completer: -> (_) do
+            [
+              %q(option ),
+              %q(with space ),
+              %q("quotes" ),
+              %q('quotes' ),
+              %q(slash\ ),
+              %q($var_like ),
+              %q(a&b ),
+              %q(a|b ),
+              %q(a;b ),
+              %q(#comment-like ),
+            ]
+          end,
+        )
+
+        expect(options).to eq [
+          %q(option ),
+          %q(with\ space ),
+          %q(\"quotes\" ),
+          %q(\'quotes\' ),
+          %q(slash\\\\ ),
+          %q(\$var_like ),
+          %q(a\&b ),
+          %q(a\|b ),
+          %q(a\;b ),
+          %q(\#comment-like ),
+        ]
+      end
+
+      it 'unescapes the input before passing it to the completer' do
+        completer_argument = nil
+        completer = -> (text) do
+          completer_argument = text
+          ['some file.txt ']
+        end
+        options = escape_options(
+          quote_character: nil,
+          completer_input: 'some\\ f',
+          completer: completer,
+        )
+
+        expect(completer_argument).to eq 'some f'
+        expect(options).to eq ['some\\ file.txt ']
+      end
+
+      it 'recognises escaped escape characters' do
+        completer_argument = nil
+        completer = -> (text) do
+          completer_argument = text
+          []
+        end
+        escape_options(
+          quote_character: nil,
+          completer_input: 'some\\\\ f',
+          completer: completer,
+        )
+
+        expect(completer_argument).to eq 'some\\ f'
+      end
+
+      it 'only unescapes valid escape sequences' do
+        completer_argument = nil
+        completer = -> (text) do
+          completer_argument = text
+          []
+        end
+        escape_options(
+          quote_character: nil,
+          completer_input: 'not\\escaped',
+          completer: completer,
+        )
+
+        expect(completer_argument).to eq 'not\\escaped'
+      end
+    end
+
+    context 'with an unclosed single quote' do
+      it 'escapes slashes and single quotes, and strips trailing whitespace' do
+        options = escape_options(
+          quote_character: "'",
+          completer_input: 'op',
+          completer: -> (_) do
+            [
+              %q(option ),
+              %q(with space ),
+              %q("quotes" ),
+              %q('quotes' ),
+              %q(slash\ ),
+              %q($var_like ),
+              %q(a&b ),
+              %q(a|b ),
+              %q(a;b ),
+              %q(#comment-like ),
+            ]
+          end,
+        )
+
+        expect(options).to eq [
+          %q(option),
+          %q(with space),
+          %q("quotes"),
+          %q(\'quotes\'),
+          %q(slash\\\\),
+          %q($var_like),
+          %q(a&b),
+          %q(a|b),
+          %q(a;b),
+          %q(#comment-like),
+        ]
+      end
+    end
+
+    context 'with an unclosed double quote' do
+      it 'escapes slashes, double quotes, and $, and strips trailing whitespace' do
+        options = escape_options(
+          quote_character: '"',
+          completer_input: 'op',
+          completer: -> (_) do
+            [
+              %q(option ),
+              %q(with space ),
+              %q("quotes" ),
+              %q('quotes' ),
+              %q(slash\ ),
+              %q($var_like ),
+              %q(a&b ),
+              %q(a|b ),
+              %q(a;b ),
+              %q(#comment-like ),
+            ]
+          end,
+        )
+
+        expect(options).to eq [
+          %q(option),
+          %q(with space),
+          %q(\"quotes\"),
+          %q('quotes'),
+          %q(slash\\\\),
+          %q(\$var_like),
+          %q(a&b),
+          %q(a|b),
+          %q(a;b),
+          %q(#comment-like),
+        ]
+      end
+    end
+  end
+
+  def escape_options(options)
+    quote_character = options.fetch(:quote_character)
+    completer_input = options.fetch(:completer_input)
+    completer = options.fetch(:completer)
+
+    line_editor = double(
+      :line_editor,
+      completion_quote_character: quote_character,
+    )
+    escaper = described_class.new(completer, line_editor: line_editor)
+    escaper.call(completer_input)
+  end
+end

--- a/spec/units/interactive_runner_spec.rb
+++ b/spec/units/interactive_runner_spec.rb
@@ -21,7 +21,6 @@ describe Gitsh::InteractiveRunner do
       runner = build_interactive_runner
       runner.run
 
-      expect(line_editor).to have_received(:completion_append_character=)
       expect(line_editor).to have_received(:completion_proc=)
     end
 

--- a/spec/units/parser/character_class_spec.rb
+++ b/spec/units/parser/character_class_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+require 'gitsh/parser/character_class'
+require 'parslet'
+
+describe Gitsh::Parser::CharacterClass do
+  describe '#characters' do
+    it 'returns the characters passed to the initializer' do
+      chars = ['a', 'e', 'i', 'o', 'u']
+      vowels = described_class.new(chars)
+
+      expect(vowels.characters).to eq chars
+    end
+  end
+
+  describe '#+' do
+    it 'returns a new character class combining two others' do
+      a = described_class.new(['a'])
+      b = described_class.new(['b'])
+
+      result = a + b
+
+      expect(result.characters).to eq ['a', 'b']
+    end
+  end
+
+  describe '#parser_atom' do
+    it 'returns a Parslet::Atom matching the chracters in the class' do
+      vowels = described_class.new(['a', 'e', 'i', 'o', 'u'])
+
+      atom = vowels.parser_atom
+
+      expect(atom).to be_a Parslet::Atoms::Base
+      expect(atom).to parse('a')
+      expect(atom).not_to parse('b')
+    end
+  end
+
+  describe '#to_regexp' do
+    it 'returns a Regexp matching the characters in the class' do
+      vowels = described_class.new(['a', 'e', 'i', 'o', 'u'])
+
+      regexp = vowels.to_regexp
+
+      expect(regexp).to be_a Regexp
+      expect(regexp).to match 'a'
+      expect(regexp).not_to match 'b'
+    end
+
+    context 'with characters that need escaping in a Regexp' do
+      it 'returns a properly escaped Regexp' do
+        chars = described_class.new(['^', '$'])
+
+        regexp = chars.to_regexp
+
+        expect(regexp).to be_a Regexp
+        expect(regexp).to match '^'
+        expect(regexp).to match '$'
+        expect(regexp).not_to match 'a'
+      end
+    end
+  end
+end

--- a/spec/units/parser_spec.rb
+++ b/spec/units/parser_spec.rb
@@ -100,6 +100,19 @@ describe Gitsh::Parser do
       )
     end
 
+    it 'parses a command with unquoted arguments containing escaped characters' do
+      [' ', '"', '\'', '\\', '$', '&', '|', ';', '#'].each do |char|
+        expect(parser).to parse("add first pre\\#{char}post third").as(
+          git_cmd: 'add',
+          args: [
+            { arg: parser_literals('first') },
+            { arg: parser_literals("pre#{char}post") },
+            { arg: parser_literals('third') }
+          ]
+        )
+      end
+    end
+
     it 'parses a command with variable arguments' do
       expect(parser).to parse('foo $bar $f_o-o.bar $_bar').as(
         git_cmd: 'foo',
@@ -160,14 +173,26 @@ describe Gitsh::Parser do
       )
     end
 
-    it 'parses a command with string arguments containing escaped quotes and slashes' do
-      expect(parser).to parse(%q(commit "It's \"great\"" "C:\\foo\bar")).as(
-        git_cmd: 'commit',
-        args: [
-          { arg: parser_literals('It\'s "great"') },
-          { arg: parser_literals('C:\foo\bar') }
-        ]
-      )
+    it 'parses a command with double-quoted arguments containing escaped characters' do
+      ['"', '\\', '$'].each do |char|
+        expect(parser).to parse("add \"pre\\#{char}post\"").as(
+          git_cmd: 'add',
+          args: [
+            { arg: parser_literals("pre#{char}post") },
+          ]
+        )
+      end
+    end
+
+    it 'does not interpret all \ characters in double-quoted arguments as escapes' do
+      ['a', ' ', '\'', '&', '|', ';', '#'].each do |char|
+        expect(parser).to parse("add \"pre\\#{char}post\"").as(
+          git_cmd: 'add',
+          args: [
+            { arg: parser_literals("pre\\#{char}post") },
+          ]
+        )
+      end
     end
 
     it 'parses a command with string arguments containing the comment prefix' do
@@ -175,15 +200,6 @@ describe Gitsh::Parser do
         git_cmd: 'commit',
         args: [
           { arg: parser_literals('Not a #comment') },
-        ]
-      )
-    end
-
-    it 'parses a command with double-quoted arguments containing escaped variables' do
-      expect(parser).to parse('foo "prefix \$bar"').as(
-        git_cmd: 'foo',
-        args: [
-          { arg: parser_literals('prefix $bar') }
         ]
       )
     end
@@ -197,6 +213,28 @@ describe Gitsh::Parser do
           { arg: parser_literals('$path/file') }
         ]
       )
+    end
+
+    it 'parses a command with single-quoted arguments containing escaped characters' do
+      ['\'', '\\'].each do |char|
+        expect(parser).to parse("add 'pre\\#{char}post'").as(
+          git_cmd: 'add',
+          args: [
+            { arg: parser_literals("pre#{char}post") },
+          ]
+        )
+      end
+    end
+
+    it 'does not interpret all \ characters in single-quoted arguments as escapes' do
+      ['a', ' ', '"', '&', '|', ';', '#', '$'].each do |char|
+        expect(parser).to parse("add 'pre\\#{char}post'").as(
+          git_cmd: 'add',
+          args: [
+            { arg: parser_literals("pre\\#{char}post") },
+          ]
+        )
+      end
     end
 
     it 'parses a shell command with arguments' do

--- a/spec/units/quote_detector_spec.rb
+++ b/spec/units/quote_detector_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'gitsh/quote_detector'
+
+describe Gitsh::QuoteDetector do
+  describe '#call' do
+    context 'for an escaped character' do
+      it 'returns true' do
+        expect(detect('a\\ b', 2)).to be true
+        expect(detect('\\ b', 1)).to be true
+      end
+    end
+
+    context 'for an unescaped character' do
+      it 'returns false' do
+        expect(detect('a b', 1)).to be false
+        expect(detect(' b', 0)).to be false
+      end
+    end
+
+    context 'for repeated escape characters' do
+      it 'returns true for odd numbers' do
+        expect(detect('a\\\\ b', 3)).to be false
+        expect(detect('a\\\\\\ b', 4)).to be true
+        expect(detect('a\\\\\\\\ b', 5)).to be false
+
+        expect(detect('\\\\ b', 2)).to be false
+        expect(detect('\\\\\\ b', 3)).to be true
+        expect(detect('\\\\\\\\ b', 4)).to be false
+      end
+    end
+  end
+
+  def detect(text, index)
+    described_class.new.call(text, index)
+  end
+end


### PR DESCRIPTION
Allows users to tab-complete options that contain exotic characters like spaces, by:

* Explicitly telling GNU Readline which characters constitute word boundaries in the gitsh language.
* Using GNU Readline's `char_is_quoted_p` setting to inform Readline when a word boundary is escaped.
* Expanding the parser to support more escape sequences.
* Decorating the completer with a new `Gitsh::CompletionEscaper` which unescapes user input on the way in (so we can match it against the possibly completions) and then escapes the completions on the way out (so they can be correctly parsed by the shell)