### PR TITLE
Refactor completion suffix

### DIFF
--- a/lib/gitsh/completion_escaper.rb
+++ b/lib/gitsh/completion_escaper.rb
@@ -22,13 +22,7 @@ module Gitsh
     attr_reader :completer, :line_editor
 
     def escape(option)
-      escaped = option.gsub(/([#{escapables}])(?!$)/) { |char| "\\#{char}" }
-
-      if completing_quoted_argument?
-        escaped.strip
-      else
-        escaped
-      end
+      option.gsub(/([#{escapables}])/) { |char| "\\#{char}" }
     end
 
     def unescape(input)
@@ -37,10 +31,6 @@ module Gitsh
 
     def escapables
       @_escapables ||= ESCAPABLES[line_editor.completion_quote_character]
-    end
-
-    def completing_quoted_argument?
-      !line_editor.completion_quote_character.nil?
     end
   end
 end

--- a/lib/gitsh/interactive_runner.rb
+++ b/lib/gitsh/interactive_runner.rb
@@ -42,7 +42,6 @@ module Gitsh
       :script_runner
 
     def setup_line_editor
-      line_editor.completion_append_character = nil
       line_editor.completion_proc = CompletionEscaper.new(
         Completer.new(line_editor, env),
         line_editor: line_editor,

--- a/spec/support/file_system.rb
+++ b/spec/support/file_system.rb
@@ -6,6 +6,10 @@ module FileSystemHelper
     File.open(name, 'w') { |f| f << "#{contents}\n" }
   end
 
+  def make_directory(name)
+    Dir.mkdir(name)
+  end
+
   def temp_file(name, contents)
     Tempfile.new(name).tap do |f|
       f.write("#{contents}\n")

--- a/spec/units/completer_spec.rb
+++ b/spec/units/completer_spec.rb
@@ -11,8 +11,8 @@ describe Gitsh::Completer do
           git_aliases: %w( adder )
         )
 
-        expect(completer.call('sta')).to eq ['stage ', 'stash ', 'status ']
-        expect(completer.call('ad')).to eq ['add ', 'adder ']
+        expect(completer.call('sta')).to eq ['stage', 'stash', 'status']
+        expect(completer.call('ad')).to eq ['add', 'adder']
       end
 
       it 'completes internal commands' do
@@ -21,8 +21,8 @@ describe Gitsh::Completer do
           internal_commands: %w( :set :exit )
         )
 
-        expect(completer.call(':')).to eq [':set ', ':exit ']
-        expect(completer.call(':s')).to eq [':set ']
+        expect(completer.call(':')).to eq [':set', ':exit']
+        expect(completer.call(':s')).to eq [':set']
       end
     end
 
@@ -33,9 +33,9 @@ describe Gitsh::Completer do
           repo_heads: %w( master my-feature v1.0 )
         )
 
-        expect(completer.call('')).to include 'master ', 'my-feature ', 'v1.0 '
-        expect(completer.call('m')).to include 'master ', 'my-feature '
-        expect(completer.call('m')).not_to include 'v1.0 '
+        expect(completer.call('')).to include 'master', 'my-feature', 'v1.0'
+        expect(completer.call('m')).to include 'master', 'my-feature'
+        expect(completer.call('m')).not_to include 'v1.0'
       end
 
       it 'completes head when branch include a dot' do
@@ -44,7 +44,7 @@ describe Gitsh::Completer do
           repo_heads: %w( fix-v1.5 fix-v1.6 )
         )
 
-        expect(completer.call('fix-v1.')).to include 'fix-v1.5 ', 'fix-v1.6 '
+        expect(completer.call('fix-v1.')).to include 'fix-v1.5', 'fix-v1.6'
       end
 
       it 'completes heads starting with :' do
@@ -53,7 +53,7 @@ describe Gitsh::Completer do
           repo_heads: %w( master my-feature )
         )
 
-        expect(completer.call('master:m')).to include 'master:my-feature '
+        expect(completer.call('master:m')).to include 'master:my-feature'
       end
 
       it 'ignores input before punctuation when completing heads' do
@@ -62,7 +62,7 @@ describe Gitsh::Completer do
           repo_heads: %w( master my-feature )
         )
 
-        expect(completer.call('mas:')).to include 'mas:master ', 'mas:my-feature '
+        expect(completer.call('mas:')).to include 'mas:master', 'mas:my-feature'
       end
 
       it 'completes paths beginning with a ~ character' do
@@ -72,7 +72,7 @@ describe Gitsh::Completer do
             FileUtils.touch('file')
           end
 
-          expect(completer.call('~/')).to include "#{first_regular_file('~')} "
+          expect(completer.call('~/')).to include first_regular_file('~')
         end
       end
 
@@ -81,7 +81,7 @@ describe Gitsh::Completer do
         project_root = File.expand_path('../../../', __FILE__)
         path = File.join(project_root, 'spec/./units/../units')
 
-        expect(completer.call("#{path}/")).to include "#{first_regular_file(path)} "
+        expect(completer.call("#{path}/")).to include first_regular_file(path)
       end
 
       it 'completes directories with a trailing slash' do
@@ -96,14 +96,60 @@ describe Gitsh::Completer do
           repo_remotes: %w( origin upstream )
         )
 
-        expect(completer.call('')).to include 'upstream ', 'origin '
-        expect(completer.call('up')).to include 'upstream '
+        expect(completer.call('')).to include 'upstream', 'origin'
+        expect(completer.call('up')).to include 'upstream'
+      end
+    end
+
+    context 'with multiple matching options' do
+      it 'sets the completion_append_character to a space' do
+        line_editor = build_line_editor(input: 'add ')
+        completer = build_completer(line_editor: line_editor)
+        in_a_temporary_directory do
+          write_file('somefile.txt')
+          make_directory('somedir')
+
+          completer.call('some')
+
+          expect(line_editor).
+            to have_received(:completion_append_character=).with(' ')
+        end
+      end
+    end
+
+    context 'with a single matching option that is not a directory path' do
+      it 'sets the completion_append_character to a space' do
+        line_editor = build_line_editor(input: 'add ')
+        completer = build_completer(line_editor: line_editor)
+        in_a_temporary_directory do
+          write_file('somefile.txt')
+
+          completer.call('some')
+
+          expect(line_editor).
+            to have_received(:completion_append_character=).with(' ')
+        end
+      end
+    end
+
+    context 'with a single matching option that is a directory path' do
+      it 'sets the completion_append_character to nil' do
+        line_editor = build_line_editor(input: 'add ')
+        completer = build_completer(line_editor: line_editor)
+        in_a_temporary_directory do
+          make_directory('somedir')
+
+          completer.call('some')
+
+          expect(line_editor).
+            to have_received(:completion_append_character=).with(nil)
+        end
       end
     end
   end
 
   def build_completer(options)
-    line_editor = double('LineEditor', line_buffer: options.fetch(:input))
+    line_editor = options.fetch(:line_editor) { build_line_editor(options) }
     env = double('Environment', {
       git_commands: options.fetch(:git_commands, %w( add commit )),
       git_aliases: options.fetch(:git_aliases, %w( graph )),
@@ -114,6 +160,14 @@ describe Gitsh::Completer do
       commands: options.fetch(:internal_commands, %w( :set :exit ))
     })
     Gitsh::Completer.new(line_editor, env, internal_command)
+  end
+
+  def build_line_editor(options)
+    double(
+      'LineEditor',
+      line_buffer: options.fetch(:input),
+      :completion_append_character= => nil,
+    )
   end
 
   def first_regular_file(directory)

--- a/spec/units/completion_escaper_spec.rb
+++ b/spec/units/completion_escaper_spec.rb
@@ -10,31 +10,31 @@ describe Gitsh::CompletionEscaper do
           completer_input: 'op',
           completer: -> (_) do
             [
-              %q(option ),
-              %q(with space ),
-              %q("quotes" ),
-              %q('quotes' ),
-              %q(slash\ ),
-              %q($var_like ),
-              %q(a&b ),
-              %q(a|b ),
-              %q(a;b ),
-              %q(#comment-like ),
+              %q(option),
+              %q(with space),
+              %q("quotes"),
+              %q('quotes'),
+              %q(slash\\),
+              %q($var_like),
+              %q(a&b),
+              %q(a|b),
+              %q(a;b),
+              %q(#comment-like),
             ]
           end,
         )
 
         expect(options).to eq [
-          %q(option ),
-          %q(with\ space ),
-          %q(\"quotes\" ),
-          %q(\'quotes\' ),
-          %q(slash\\\\ ),
-          %q(\$var_like ),
-          %q(a\&b ),
-          %q(a\|b ),
-          %q(a\;b ),
-          %q(\#comment-like ),
+          %q(option),
+          %q(with\ space),
+          %q(\"quotes\"),
+          %q(\'quotes\'),
+          %q(slash\\\\),
+          %q(\$var_like),
+          %q(a\&b),
+          %q(a\|b),
+          %q(a\;b),
+          %q(\#comment-like),
         ]
       end
 
@@ -42,7 +42,7 @@ describe Gitsh::CompletionEscaper do
         completer_argument = nil
         completer = -> (text) do
           completer_argument = text
-          ['some file.txt ']
+          ['some file.txt']
         end
         options = escape_options(
           quote_character: nil,
@@ -51,7 +51,7 @@ describe Gitsh::CompletionEscaper do
         )
 
         expect(completer_argument).to eq 'some f'
-        expect(options).to eq ['some\\ file.txt ']
+        expect(options).to eq ['some\\ file.txt']
       end
 
       it 'recognises escaped escape characters' do
@@ -86,22 +86,22 @@ describe Gitsh::CompletionEscaper do
     end
 
     context 'with an unclosed single quote' do
-      it 'escapes slashes and single quotes, and strips trailing whitespace' do
+      it 'escapes slashes and single quotes' do
         options = escape_options(
           quote_character: "'",
           completer_input: 'op',
           completer: -> (_) do
             [
-              %q(option ),
-              %q(with space ),
-              %q("quotes" ),
-              %q('quotes' ),
-              %q(slash\ ),
-              %q($var_like ),
-              %q(a&b ),
-              %q(a|b ),
-              %q(a;b ),
-              %q(#comment-like ),
+              %q(option),
+              %q(with space),
+              %q("quotes"),
+              %q('quotes'),
+              %q(slash\\),
+              %q($var_like),
+              %q(a&b),
+              %q(a|b),
+              %q(a;b),
+              %q(#comment-like),
             ]
           end,
         )
@@ -122,22 +122,22 @@ describe Gitsh::CompletionEscaper do
     end
 
     context 'with an unclosed double quote' do
-      it 'escapes slashes, double quotes, and $, and strips trailing whitespace' do
+      it 'escapes slashes, double quotes, and $' do
         options = escape_options(
           quote_character: '"',
           completer_input: 'op',
           completer: -> (_) do
             [
-              %q(option ),
-              %q(with space ),
-              %q("quotes" ),
-              %q('quotes' ),
-              %q(slash\ ),
-              %q($var_like ),
-              %q(a&b ),
-              %q(a|b ),
-              %q(a;b ),
-              %q(#comment-like ),
+              %q(option),
+              %q(with space),
+              %q("quotes"),
+              %q('quotes'),
+              %q(slash\\),
+              %q($var_like),
+              %q(a&b),
+              %q(a|b),
+              %q(a;b),
+              %q(#comment-like),
             ]
           end,
         )

--- a/spec/units/interactive_runner_spec.rb
+++ b/spec/units/interactive_runner_spec.rb
@@ -21,7 +21,6 @@ describe Gitsh::InteractiveRunner do
       runner = build_interactive_runner
       runner.run
 
-      expect(line_editor).to have_received(:completion_append_character=)
       expect(line_editor).to have_received(:completion_proc=)
     end
 


### PR DESCRIPTION
### Before this commit

We'd set `Gitsh::LineEditor.completion_append_character` to `nil`, and then append a space to any completion option that wasn't a directory path (e.g., completions might include `"file.txt "` with a trailing space, and `"dir/"` without a trailing space).

The benefit of this was that you could tab complete a directory name, not have a space appended, and continue typing the path. You could also tab complete any other argument, have a space appended, and begin typing the next argument.

The down side was that we needed to manually remove the space from the end of the options if we were completing a quoted argument, and we needed to avoid escaping spaces at the end of a completion when completing an unquoted argument.

### After this commit

We set `LineEditor.completion_append_character` dynamically based on the completion options that matched the user input. If we have a single option that's a directory path, we set it to `nil`. If we have multiple options, or a single option that's not a directory path, we set it to space.

This maintains almost identical behaviour, but has a few advantages:

* We can drop all the special case code for not escaping the trailing space, or for removing the trailing space when completing a quoted argument.
* Readline will add a trailing space for us after the end of a completed quoted argument, which saves typing it by hand and is more similar to what other shells do.

(This PR depends on #259)