### PR TITLE
Improve prompt generation speed

### DIFF
--- a/lib/gitsh/environment.rb
+++ b/lib/gitsh/environment.rb
@@ -82,16 +82,8 @@ module Gitsh
       repo.current_head
     end
 
-    def repo_initialized?
-      repo.initialized?
-    end
-
-    def repo_has_modified_files?
-      repo.has_modified_files?
-    end
-
-    def repo_has_untracked_files?
-      repo.has_untracked_files?
+    def repo_status
+      repo.status
     end
 
     def repo_config_color(name, default)

--- a/lib/gitsh/git_repository/status.rb
+++ b/lib/gitsh/git_repository/status.rb
@@ -1,0 +1,29 @@
+module Gitsh
+  class GitRepository
+    class Status
+      def initialize(status_porcelain, git_dir)
+        @status_porcelain = status_porcelain
+        @git_dir = git_dir
+      end
+
+      def initialized?
+        if @initialized.nil?
+          @initialized = File.exist?(git_dir)
+        end
+        @initialized
+      end
+
+      def has_untracked_files?
+        status_porcelain.lines.select { |l| l.start_with?('??') }.any?
+      end
+
+      def has_modified_files?
+        status_porcelain.lines.select { |l| l =~ /^ ?[A-Z]/ }.any?
+      end
+
+      private
+
+      attr_reader :status_porcelain, :git_dir
+    end
+  end
+end

--- a/lib/gitsh/prompt_color.rb
+++ b/lib/gitsh/prompt_color.rb
@@ -6,12 +6,12 @@ module Gitsh
       @env = env
     end
 
-    def status_color
-      if !env.repo_initialized?
+    def status_color(status)
+      if !status.initialized?
         env.repo_config_color('gitsh.color.uninitialized', 'normal red')
-      elsif env.repo_has_untracked_files?
+      elsif status.has_untracked_files?
         env.repo_config_color('gitsh.color.untracked', 'red')
-      elsif env.repo_has_modified_files?
+      elsif status.has_modified_files?
         env.repo_config_color('gitsh.color.modified', 'yellow')
       else
         env.repo_config_color('gitsh.color.default', 'blue')

--- a/spec/integration/prompt_spec.rb
+++ b/spec/integration/prompt_spec.rb
@@ -37,4 +37,23 @@ describe 'The gitsh prompt' do
       expect(gitsh).to prompt_with "#{Dir.getwd}:master@ "
     end
   end
+
+  it 'displays the repository status using prompt sigils' do
+    GitshRunner.interactive do |gitsh|
+      expect(gitsh).to prompt_with "#{cwd_basename} uninitialized!! "
+
+      gitsh.type('init')
+
+      expect(gitsh).to prompt_with "#{cwd_basename} master@ "
+
+      write_file 'example.txt'
+      gitsh.type('')
+
+      expect(gitsh).to prompt_with "#{cwd_basename} master! "
+
+      gitsh.type('add --intent-to-add example.txt')
+
+      expect(gitsh).to prompt_with "#{cwd_basename} master& "
+    end
+  end
 end

--- a/spec/units/environment_spec.rb
+++ b/spec/units/environment_spec.rb
@@ -244,23 +244,9 @@ describe Gitsh::Environment do
       end
     end
 
-    describe '#repo_initialized?' do
+    describe '#repo_status' do
       it 'is delegated to the GitRepository' do
-        expect(env).to delegate(:repo_initialized?).to(repo, :initialized?)
-      end
-    end
-
-    describe '#repo_has_modified_files?' do
-      it 'is delegated to the GitRepository' do
-        expect(env).to delegate(:repo_has_modified_files?).
-          to(repo, :has_modified_files?)
-      end
-    end
-
-    describe '#repo_has_untracked_files?' do
-      it 'is delegated to the GitRepository' do
-        expect(env).to delegate(:repo_has_untracked_files?).
-          to(repo, :has_untracked_files?)
+        expect(env).to delegate(:repo_status).to(repo, :status)
       end
     end
 

--- a/spec/units/git_repository/status_spec.rb
+++ b/spec/units/git_repository/status_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'gitsh/git_repository/status'
+
+describe Gitsh::GitRepository::Status do
+  describe '#initialized?' do
+    it 'returns true when git directory exists' do
+      repository_git_dir = File.expand_path('../../../../.git', __FILE__)
+      status = Gitsh::GitRepository::Status.new('', repository_git_dir)
+      expect(status).to be_initialized
+
+      status = Gitsh::GitRepository::Status.new('', '/.git')
+      expect(status).not_to be_initialized
+    end
+  end
+
+  describe "#has_modified_files?" do
+    it 'returns true when there are modified files in the repository' do
+      status = Gitsh::GitRepository::Status.new(
+        "?? example1.txt\n M example2.txt\n",
+        ''
+      )
+      expect(status).to have_modified_files
+
+      status = Gitsh::GitRepository::Status.new(
+        "?? example1.txt\n?? example2.txt",
+        ''
+      )
+      expect(status).not_to have_modified_files
+    end
+  end
+
+  describe "#has_untracked_files?" do
+    it 'returns true when there are untracked files in the repository' do
+      status = Gitsh::GitRepository::Status.new(
+        " M example1.txt\n?? example2.txt\n",
+        '',
+      )
+      expect(status).to have_untracked_files
+
+      status = Gitsh::GitRepository::Status.new(
+        " M example1.txt\n M example2.txt\n",
+        ''
+      )
+      expect(status).not_to have_untracked_files
+    end
+  end
+end

--- a/spec/units/git_repository_spec.rb
+++ b/spec/units/git_repository_spec.rb
@@ -5,20 +5,6 @@ require 'gitsh/git_repository'
 describe Gitsh::GitRepository do
   include Color
 
-  describe '#initialized?' do
-    it 'returns true when the current directory is a git repository' do
-      Dir.chdir(repository_root) do
-        expect(Gitsh::GitRepository.new(env)).to be_initialized
-      end
-    end
-
-    it 'returns false when the current directory is not a git repository' do
-      Dir.chdir('/') do
-        expect(Gitsh::GitRepository.new(env)).not_to be_initialized
-      end
-    end
-  end
-
   describe '#git_dir' do
     it 'returns the path to the .git directory' do
       with_a_temporary_home_directory do
@@ -89,37 +75,6 @@ describe Gitsh::GitRepository do
       Dir.chdir('/') do
         repo = Gitsh::GitRepository.new(env)
         expect(repo.current_head).to be_nil
-      end
-    end
-  end
-
-  context '#has_untracked_files?' do
-    it 'returns true when there are untracked files in the repository' do
-      with_a_temporary_home_directory do
-        in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
-          run 'git init'
-          expect(repo).not_to have_untracked_files
-          write_file 'example.txt'
-          expect(repo).to have_untracked_files
-        end
-      end
-    end
-  end
-
-  context '#has_modified_files?' do
-    it 'returns true when there are modified files' do
-      with_a_temporary_home_directory do
-        in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
-          run 'git init'
-          write_file 'example.txt'
-          expect(repo).not_to have_modified_files
-          run 'git add example.txt'
-          expect(repo).to have_modified_files
-          run 'git commit -m "Add example.txt"'
-          expect(repo).not_to have_modified_files
-        end
       end
     end
   end

--- a/spec/units/interactive_runner_spec.rb
+++ b/spec/units/interactive_runner_spec.rb
@@ -111,7 +111,6 @@ describe Gitsh::InteractiveRunner do
     @env ||= double('Environment', {
       print: nil,
       puts: nil,
-      repo_initialized?: false,
       repo_config_color: '',
       fetch: '',
       :[] => nil

--- a/spec/units/prompt_color_spec.rb
+++ b/spec/units/prompt_color_spec.rb
@@ -8,10 +8,11 @@ describe Gitsh::PromptColor do
     context 'with an uninitialized repo' do
       it 'uses the gitsh.color.uninitialized setting' do
         color = double('color')
-        env = stub_env(repo_initialized?: false, repo_config_color: color)
+        env = double('env', repo_config_color: color)
         prompt_color = described_class.new(env)
+        status = double('status', initialized?: false)
 
-        expect(prompt_color.status_color).to eq color
+        expect(prompt_color.status_color(status)).to eq color
         expect(env).to have_received(:repo_config_color).
           with('gitsh.color.uninitialized', 'normal red')
       end
@@ -20,10 +21,15 @@ describe Gitsh::PromptColor do
     context 'with untracked files' do
       it 'uses the gitsh.color.untracked setting' do
         color = double('color')
-        env = stub_env(repo_has_untracked_files?: true, repo_config_color: color)
+        env = double('env', repo_config_color: color)
+        status = double(
+          'status',
+          initialized?: true,
+          has_untracked_files?: true,
+        )
         prompt_color = described_class.new(env)
 
-        expect(prompt_color.status_color).to eq color
+        expect(prompt_color.status_color(status)).to eq color
         expect(env).to have_received(:repo_config_color).
           with('gitsh.color.untracked', 'red')
       end
@@ -32,10 +38,16 @@ describe Gitsh::PromptColor do
     context 'with modified files' do
       it 'uses the gitsh.color.modified setting' do
         color = double('color')
-        env = stub_env(repo_has_modified_files?: true, repo_config_color: color)
+        env = double('env', repo_config_color: color)
+        status = double(
+          'status',
+          initialized?: true,
+          has_untracked_files?: false,
+          has_modified_files?: true,
+        )
         prompt_color = described_class.new(env)
 
-        expect(prompt_color.status_color).to eq color
+        expect(prompt_color.status_color(status)).to eq color
         expect(env).to have_received(:repo_config_color).
           with('gitsh.color.modified', 'yellow')
       end
@@ -44,22 +56,19 @@ describe Gitsh::PromptColor do
     context 'with a clean repo' do
       it 'uses the gitsh.color.default setting' do
         color = double('color')
-        env = stub_env(repo_config_color: color)
+        env = double('env', repo_config_color: color)
+        status = double(
+          'status',
+          initialized?: true,
+          has_untracked_files?: false,
+          has_modified_files?: false,
+        )
         prompt_color = described_class.new(env)
 
-        expect(prompt_color.status_color).to eq color
+        expect(prompt_color.status_color(status)).to eq color
         expect(env).to have_received(:repo_config_color).
           with('gitsh.color.default', 'blue')
       end
     end
-  end
-
-  def stub_env(overrides = {})
-    defaults = {
-      repo_initialized?: true,
-      repo_has_untracked_files?: false,
-      repo_has_modified_files?: false,
-    }
-    env = double('env', defaults.merge(overrides))
   end
 end


### PR DESCRIPTION
Generating and displaying the prompt in gitsh is currently painfully slow on my MacBook Air. This PR is an attempt to improve on this.

I started to investigate by printing all git commands passed to `Open3.capture3` in `GitRepository#git_output`:

```
"/usr/bin/env git rev-parse --git-dir"
"/usr/bin/env git rev-parse --git-dir"
"/usr/bin/env git symbolic-ref HEAD --short"
"/usr/bin/env git rev-parse --git-dir"
"/usr/bin/env git rev-parse --git-dir"
"/usr/bin/env git symbolic-ref HEAD --short"
"/usr/bin/env git rev-parse --git-dir"
"/usr/bin/env git rev-parse --git-dir"
"/usr/bin/env git symbolic-ref HEAD --short"
"/usr/bin/env git rev-parse --git-dir"
"/usr/bin/env git rev-parse --git-dir"
"/usr/bin/env git status --porcelain"
"/usr/bin/env git status --porcelain"
"/usr/bin/env git config --get-color gitsh.color.modified yellow"
"/usr/bin/env git rev-parse --git-dir"
"/usr/bin/env git rev-parse --git-dir"
"/usr/bin/env git status --porcelain"
"/usr/bin/env git status --porcelain"
```

Generating the prompt on my system took ~1.1 seconds.

I observed that most of the calls to external git commands were duplicated.

I then added `puts` statements in many of the methods in `Prompter` and `PromptColor` in order to find out where the calls were made. I went on to reduce this number by introducing memoization in a way that, to my knowledge, doesn't affect the behavior of the program.

The three commits in this PR are the results of this. It brings the generation time down to 0.3 seconds and the following calls to external git commands:

```
"/usr/bin/env git rev-parse --git-dir"
"/usr/bin/env git status --porcelain"
"/usr/bin/env git config --get-color gitsh.color.modified yellow"
"/usr/bin/env git symbolic-ref HEAD --short"
```

In doing this I exposed a new `status` method on `GitRepository`. I didn't figure out a good way to test this new method. It is currently implicitly tested through the `has_untracked_files?` and `has_modified_files?` specs. I considered the following options:
1. Duplicate the existing tests but in the exercise, call `status.has_untracked_files?` instead of `has_untracked_files?`. I don't think the duplicated tests would provide much value.
2. Create a new spec for `GitRepository::Status` passing in example `git status --porcelain` output and replace the existing specs with specs that test that the original methods delegate to the status object. Since the existing specs tests the git repository on an integration level by altering a real git repository and the new specs would be hard to implement this way, this option seems to reduce the value of the test suite.

I'd love some input on this.

In my last commit I also inline the `PromptColor` method within the `Prompter` to make use of the cache inside it. Only having one method and no private helpers, it seemed like the `PromptColor` didn't really pull it's own weight so I think this is a good trade off. I'm also unsure of the value provided by the `PromptColor` spec since it mostly duplicated the conditional logic of the implementation. Therefor I didn't add any similar tests for `Prompter`.
