### PR TITLE
Ignore shared objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ lib/gitsh/version.rb
 gitsh-*.tar.gz
 vendor/gems
 *.o
+*.so
 
 # Ruby C-extension
 *.bundle


### PR DESCRIPTION
This causes Git to ignore `ext/gitsh/line_editor_native.so`, which was created when building `gitsh` on Linux.