### PR TITLE
Show home directory as a tilde in the prompt

### DIFF
--- a/lib/gitsh/prompter.rb
+++ b/lib/gitsh/prompter.rb
@@ -20,8 +20,8 @@ module Gitsh
         '%b' => branch_name,
         "%B" => shortened_branch_name,
         '%c' => status_color,
-        '%d' => Dir.getwd,
-        '%D' => File.basename(Dir.getwd),
+        '%d' => working_directory,
+        '%D' => File.basename(working_directory),
         '%w' => clear_color,
         '%#' => terminator
       })
@@ -30,6 +30,10 @@ module Gitsh
     private
 
     attr_reader :env, :prompt_color
+
+    def working_directory
+      Dir.getwd.sub(/\A#{Dir.home}/, '~')
+    end
 
     def padded_prompt_format
       "#{prompt_format.chomp} "

--- a/spec/units/prompter_spec.rb
+++ b/spec/units/prompter_spec.rb
@@ -118,14 +118,16 @@ describe Gitsh::Prompter do
         env = env_double(format: '%d')
         prompter = Gitsh::Prompter.new(env: env)
 
-        expect(prompter.prompt).to eq "#{Dir.getwd} "
+        expect(prompter.prompt).to eq "#{Dir.getwd.sub(/\A#{Dir.home}/, '~')} "
       end
 
       it 'replaces %D with the basename of the current directory' do
         env = env_double(format: '%D')
         prompter = Gitsh::Prompter.new(env: env)
 
-        expect(prompter.prompt).to eq "#{File.basename(Dir.getwd)} "
+        expect(prompter.prompt).to eq(
+          "#{File.basename(Dir.getwd.sub(/\A#{Dir.home}/, '~'))} "
+        )
       end
     end
 


### PR DESCRIPTION
When `gitsh` is launched from the user's home directory, the basename of the current working directory shown in the prompt is typically the same as the user's username, which is a potential source of confusion as to what this prompt section shows. With this commit, the directory name is shown as a tilde when the current working directory is the user's home directory, as is conventional for Unix shells.

Without this commit:

    $ cd ~
    $ pwd
    /home/srs
    $ gitsh
    gitsh 0.10
    Type :exit to exit
    srs uninitialized!!

With this commit:

    $ cd ~
    $ pwd
    /home/srs
    $ gitsh
    gitsh 0.10
    Type :exit to exit
    ~ uninitialized!!