### PR TITLE
Don't always close quotes when tab completing.

### DIFF
--- a/ext/gitsh/extconf.rb
+++ b/ext/gitsh/extconf.rb
@@ -53,6 +53,7 @@ end
 
 readline.require_func("rl_set_screen_size")
 readline.require_var("rl_completion_append_character")
+readline.require_var("rl_completion_suppress_quote")
 readline.require_var("rl_editing_mode")
 readline.require_var("rl_line_buffer")
 readline.require_var("rl_char_is_quoted_p")

--- a/ext/gitsh/src/line_editor.c
+++ b/ext/gitsh/src/line_editor.c
@@ -1070,6 +1070,36 @@ readline_s_get_completion_append_character(VALUE self)
 
 /*
  * call-seq:
+ *   Gitsh::LineEditor.completion_suppress_quote = true_or_false
+ *
+ * When set to true, indicates that Readline should not append a closing
+ * quote character when completing a quoted argument.
+ *
+ * Can only be set during a completion, i.e. from within your
+ * LineEditor.completion_proc.
+ */
+static VALUE
+readline_s_set_completion_supress_quote(VALUE self, VALUE flag)
+{
+    rl_completion_suppress_quote = RTEST(flag);
+    return self;
+}
+
+/*
+ * call-seq:
+ *   Gitsh::LineEditor.completion_suppress_quote -> boolean
+ *
+ * Returns a boolean indicating if Readline will suppress the closing quote
+ * when completion a quoted argument. The default is false (a closing
+ * quote will be appended).
+ */
+static VALUE
+readline_s_get_completion_supress_quote(VALUE self)
+{
+    return rl_completion_suppress_quote ? Qtrue : Qfalse;
+}
+/*
+ * call-seq:
  *   Gitsh::LineEditor.completion_quote_character -> char
  *
  * When called during a completion (e.g. from within your completion_proc),
@@ -1581,6 +1611,10 @@ Init_line_editor_native(void)
                                readline_s_set_completion_append_character, 1);
     rb_define_singleton_method(mLineEditor, "completion_append_character",
                                readline_s_get_completion_append_character, 0);
+    rb_define_singleton_method(mLineEditor, "completion_suppress_quote=",
+                               readline_s_set_completion_supress_quote, 1);
+    rb_define_singleton_method(mLineEditor, "completion_suppress_quote",
+                               readline_s_get_completion_supress_quote, 0);
     rb_define_singleton_method(mLineEditor, "completion_quote_character",
                                readline_s_get_completion_quote_character, 0);
     rb_define_singleton_method(mLineEditor, "completer_word_break_characters=",

--- a/lib/gitsh/completer.rb
+++ b/lib/gitsh/completer.rb
@@ -22,6 +22,8 @@ module Gitsh
 
       def call
         line_editor.completion_append_character = completion_append_character
+        line_editor.completion_suppress_quote = incomplete_path?
+
         matches
       end
 
@@ -30,11 +32,15 @@ module Gitsh
       attr_reader :input, :line_editor, :env, :internal_command
 
       def completion_append_character
-        if matches.size == 1 && matches.first.end_with?('/')
+        if incomplete_path?
           nil
         else
           ' '
         end
+      end
+
+      def incomplete_path?
+        matches.size == 1 && matches.first.end_with?('/')
       end
 
       def matches

--- a/spec/integration/tab_completion_spec.rb
+++ b/spec/integration/tab_completion_spec.rb
@@ -87,6 +87,23 @@ describe 'Completing things with tab' do
     end
   end
 
+  it 'completes quoted paths' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type('init')
+      make_directory('sub directory')
+      write_file('sub directory/some text file.txt')
+      write_file('sub directory/some other file.txt')
+      gitsh.type("add 'sub\tso\tother\t")
+
+      expect(gitsh).to output_no_errors
+
+      gitsh.type('commit -m "First commit"')
+      gitsh.type('ls-files')
+
+      expect(gitsh).to output(/sub directory\/some other file\.txt/)
+    end
+  end
+
   it 'completes after punctuation' do
     GitshRunner.interactive do |gitsh|
       gitsh.type('init')

--- a/spec/units/completer_spec.rb
+++ b/spec/units/completer_spec.rb
@@ -102,7 +102,7 @@ describe Gitsh::Completer do
     end
 
     context 'with multiple matching options' do
-      it 'sets the completion_append_character to a space' do
+      it 'configures the line editor to append quotes and spaces' do
         line_editor = build_line_editor(input: 'add ')
         completer = build_completer(line_editor: line_editor)
         in_a_temporary_directory do
@@ -113,12 +113,14 @@ describe Gitsh::Completer do
 
           expect(line_editor).
             to have_received(:completion_append_character=).with(' ')
+          expect(line_editor).
+            to have_received(:completion_suppress_quote=).with(false)
         end
       end
     end
 
     context 'with a single matching option that is not a directory path' do
-      it 'sets the completion_append_character to a space' do
+      it 'configures the line editor to append quotes and spaces' do
         line_editor = build_line_editor(input: 'add ')
         completer = build_completer(line_editor: line_editor)
         in_a_temporary_directory do
@@ -128,12 +130,14 @@ describe Gitsh::Completer do
 
           expect(line_editor).
             to have_received(:completion_append_character=).with(' ')
+          expect(line_editor).
+            to have_received(:completion_suppress_quote=).with(false)
         end
       end
     end
 
     context 'with a single matching option that is a directory path' do
-      it 'sets the completion_append_character to nil' do
+      it 'configures the line editor not to append quotes or spaces' do
         line_editor = build_line_editor(input: 'add ')
         completer = build_completer(line_editor: line_editor)
         in_a_temporary_directory do
@@ -143,6 +147,8 @@ describe Gitsh::Completer do
 
           expect(line_editor).
             to have_received(:completion_append_character=).with(nil)
+          expect(line_editor).
+            to have_received(:completion_suppress_quote=).with(true)
         end
       end
     end
@@ -167,6 +173,7 @@ describe Gitsh::Completer do
       'LineEditor',
       line_buffer: options.fetch(:input),
       :completion_append_character= => nil,
+      :completion_suppress_quote= => nil,
     )
   end
 

--- a/spec/units/line_editor_spec.rb
+++ b/spec/units/line_editor_spec.rb
@@ -13,6 +13,7 @@ describe Gitsh::LineEditor do
       completer_quote_characters: described_class.completer_quote_characters || '',
       completer_word_break_characters: described_class.completer_word_break_characters || ' ',
       completion_append_character: described_class.completion_append_character,
+      completion_suppress_quote: described_class.completion_suppress_quote,
       completion_case_fold: described_class.completion_case_fold,
       completion_proc: described_class.completion_proc,
       pre_input_hook: described_class.pre_input_hook,
@@ -20,6 +21,7 @@ describe Gitsh::LineEditor do
     }
 
     described_class.completion_append_character = ' '
+    described_class.completion_suppress_quote = false
     described_class.delete_text
     described_class.point = 0
   end
@@ -362,6 +364,23 @@ describe Gitsh::LineEditor do
           line = described_class.readline('> ', false)
 
           expect(line).to eq 'first outputx'
+        end
+      end
+    end
+
+    context 'when completion_suppress_quote is set' do
+      it 'does not append a closing quote' do
+        with_temp_stdio do |stdio|
+          described_class.completion_proc = -> (_text) do
+            described_class.completion_suppress_quote = true
+            ['output']
+          end
+          described_class.completer_quote_characters = "'"
+
+          stdio.type("first 'second\t")
+          line = described_class.readline('> ', false)
+
+          expect(line).to eq "first 'output "
         end
       end
     end


### PR DESCRIPTION
When the thing we've managed to complete isn't a full argument (i.e. it's a directory name, and the user may want to add more components to the path), don't append a quote if it's a quoted argument.

Fixes #262