### PR TITLE
Add install ruby step to mac os installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ sh$</code></pre>
         gitsh% ⏎
         # On branch master
         nothing to commit, working directory clean
-        gitsh% 
+        gitsh%
 
 * Easily execute shell commands:
 
@@ -76,6 +76,7 @@ sh$</code></pre>
 
 * Mac OS X, via homebrew:
 
+        brew install ruby   # for proper readline support
         brew tap thoughtbot/formulae
         brew install gitsh
 
@@ -85,7 +86,7 @@ sh$</code></pre>
 
         sudo pkg_add gitsh
 
-See the [installation guide][INSTALL] for install instructions for other
+See the [installation guide][INSTALL] for details and install instructions for other
 operating systems.
 
 ## Contributing to gitsh


### PR DESCRIPTION
If a mac user followed the standard installation guide and had the standard mac os ruby installed he would have a very ugly and almost unworkable history behaviour (see https://github.com/thoughtbot/gitsh/issues/177).

This adds the simple solution for this issue to the install guide, so other users don't need to dive into the github issue history to get a nice gitsh experience.