### PR TITLE
Use SHA256 for Homebrew and Arch package digests.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -122,4 +122,4 @@ release_clean_arch:
 	rm -rf release-arch
 
 DIST_SHA: Makefile dist
-	$(eval DIST_SHA := $(shell shasum $(srcdir)/$(DIST_ARCHIVES) | cut -d' ' -f1))
+	$(eval DIST_SHA := $(shell shasum -a 256 $(srcdir)/$(DIST_ARCHIVES) | cut -d' ' -f1))

--- a/arch/PKGBUILD.in
+++ b/arch/PKGBUILD.in
@@ -8,7 +8,7 @@ url="http://thoughtbot.github.io/@PACKAGE@/"
 license=('custom')
 depends=('ruby>=2.0.0' 'readline')
 source=("http://thoughtbot.github.io/@PACKAGE@/@DIST_ARCHIVES@")
-sha1sums=('@DIST_SHA@')
+sha256sums=('@DIST_SHA@')
 
 build() {
   cd "$srcdir/$pkgname-$pkgver"

--- a/homebrew/gitsh.rb.in
+++ b/homebrew/gitsh.rb.in
@@ -6,7 +6,7 @@ class Gitsh < Formula
 
   homepage 'https://github.com/thoughtbot/@PACKAGE@/'
   url 'http://thoughtbot.github.io/@PACKAGE@/@DIST_ARCHIVES@'
-  sha1 '@DIST_SHA@'
+  sha256 '@DIST_SHA@'
 
   def self.old_system_ruby?
     system_ruby_version = `#{SYSTEM_RUBY_PATH} -e "puts RUBY_VERSION"`.chomp


### PR DESCRIPTION
The package managers use the digest to verify the integrity of the tarball they've downloaded. 

Homebrew has deprecated SHA1, and we were using the same digest in both places, so upgrade both for simplicity.