### PR TITLE
Honor DESTDIR during make install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,8 +41,8 @@ clean-local:
 	cd ext/gitsh && $(MAKE) clean
 
 install-data-local:
-	mkdir -p "$(pkgrubylibdir)"
-	cp ext/gitsh/line_editor_native.* "$(pkgrubylibdir)"
+	mkdir -p "$(DESTDIR)$(pkgrubylibdir)"
+	cp ext/gitsh/line_editor_native.* "$(DESTDIR)$(pkgrubylibdir)"
 
 distclean-local:
 	rm -rf vendor/gems


### PR DESCRIPTION
Trying to create a package for Archlinux I bumped into this error
```
cd ext/gitsh && make
make[1]: Entering directory '/home/cippaciong/.build/gitsh/src/gitsh-0.11/ext/gitsh'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/cippaciong/.build/gitsh/src/gitsh-0.11/ext/gitsh'
make[1]: Entering directory '/home/cippaciong/.build/gitsh/src/gitsh-0.11'
 /usr/bin/mkdir -p '/home/cippaciong/.build/gitsh/pkg/gitsh//usr/bin'
  /usr/bin/install -c gitsh '/home/cippaciong/.build/gitsh/pkg/gitsh//usr/bin'
mkdir -p "/usr/share/gitsh/ruby/lib/gitsh"
mkdir: cannot create directory ‘/usr/share/gitsh/ruby/lib’: Permission denied
make[1]: *** [Makefile:1336: install-data-local] Error 1
make[1]: Leaving directory '/home/cippaciong/.build/gitsh/src/gitsh-0.11'
make: *** [Makefile:1185: install-am] Error 2
```
Between version 0.10 and 0.11 `make` stopped honoring DESTDIR and I think the regression has been introduced in f5be3e3b915b777674cb01b0260ef496789597eb.