### PR TITLE
Homebrew: use env=std by default.

### DIFF
--- a/homebrew/gitsh.rb.in
+++ b/homebrew/gitsh.rb.in
@@ -4,6 +4,7 @@ class Gitsh < Formula
   SYSTEM_RUBY_PATH = '/usr/bin/ruby'
   HOMEBREW_RUBY_PATH = "#{HOMEBREW_PREFIX}/bin/ruby"
 
+  env :std
   homepage 'https://github.com/thoughtbot/@PACKAGE@/'
   url 'http://thoughtbot.github.io/@PACKAGE@/@DIST_ARCHIVES@'
   sha256 '@DIST_SHA@'


### PR DESCRIPTION
This causes Homebrew to set the appropriate LDFLAGS for Readline, which
is a keg only formula.

Without this, gitsh can't build against system Ruby (although it still
worked on systems where Homebrew's ruby formula was installed).

I couldn't find good documentation for the difference between `env=std`
and `env=superenv`, but this is where the necessary LDFLAGS value is set:

  https://github.com/Homebrew/brew/blob/89fd34b/Library/Homebrew/build.rb#L100