### PR TITLE
Support alternative names for Readline.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -62,6 +62,14 @@ library is named ereadline, you might use:
           LDFLAGS="-L/usr/local/lib" \
           ./configure
 
+Finally, on macOS systems with a universal Ruby binary (e.g. /usr/bin/ruby),
+and a non-universal Readline shared library, you may need to explicitly pass
+an architecture to use via the $READLINE_ARCH environment variable:
+
+        READLINE_ARCH=x86_64 \
+          RUBY=/usr/bin/ruby \
+          ./configure
+
 
 Installation
 ------------

--- a/INSTALL
+++ b/INSTALL
@@ -53,6 +53,15 @@ you might use:
           LDFLAGS="-L/usr/local/opt/readline/lib" \
           ./configure
 
+If your system uses a different name for Readline, you can set the
+$READLINE_LIB environment variable. For example, on OpenBSD where the Readline
+library is named ereadline, you might use:
+
+        READLINE_LIB="ereadline" \
+          CPPFLAGS="-I/usr/local/include/ereadline" \
+          LDFLAGS="-L/usr/local/lib" \
+          ./configure
+
 
 Installation
 ------------

--- a/INSTALL.in
+++ b/INSTALL.in
@@ -62,6 +62,14 @@ library is named ereadline, you might use:
           LDFLAGS="-L/usr/local/lib" \
           ./configure
 
+Finally, on macOS systems with a universal Ruby binary (e.g. /usr/bin/ruby),
+and a non-universal Readline shared library, you may need to explicitly pass
+an architecture to use via the $READLINE_ARCH environment variable:
+
+        READLINE_ARCH=x86_64 \
+          RUBY=/usr/bin/ruby \
+          ./configure
+
 
 Installation
 ------------

--- a/INSTALL.in
+++ b/INSTALL.in
@@ -53,6 +53,15 @@ you might use:
           LDFLAGS="-L/usr/local/opt/readline/lib" \
           ./configure
 
+If your system uses a different name for Readline, you can set the
+$READLINE_LIB environment variable. For example, on OpenBSD where the Readline
+library is named ereadline, you might use:
+
+        READLINE_LIB="ereadline" \
+          CPPFLAGS="-I/usr/local/include/ereadline" \
+          LDFLAGS="-L/usr/local/lib" \
+          ./configure
+
 
 Installation
 ------------

--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,8 @@ AC_ARG_VAR(
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_PROG_CC
-AC_PATH_PROGS([RUBY], [ruby ruby20 ruby21], [], $(getconf PATH))
-AC_PATH_PROGS([RUBY], [ruby ruby20 ruby21])
+AC_PATH_PROGS([RUBY], [ruby ruby20 ruby21 ruby22 ruby23 ruby24], [], $(getconf PATH))
+AC_PATH_PROGS([RUBY], [ruby ruby20 ruby21 ruby22 ruby23 ruby24])
 
 if test -n $RUBY; then
   case $RUBY in $HOME/*)

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,10 @@ AC_ARG_VAR(
   [READLINE_LIB],
   [The name of the readline library on your system, e.g. ereadline on OpenBSD]
 )
+AC_ARG_VAR(
+  [READLINE_ARCH],
+  [The architecture of the readline library on your system, e.g. x86_64]
+)
 
 AC_CONFIG_MACRO_DIR([m4])
 
@@ -39,11 +43,16 @@ if test "$newer" == "$srcdir/Gemfile.lock"; then
 fi
 
 AS_IF([test "x$READLINE_LIB" = x], [READLINE_LIB="readline"])
+AS_IF(
+    [test "x$READLINE_ARCH" = x],
+    [readline_arch_arg=""],
+    [readline_arch_arg="--with-arch-flag=\"-arch $READLINE_ARCH\""]
+)
 current_dir="$PWD"
 cd "$srcdir/ext/gitsh"
 AS_IF(
     [$RUBY extconf.rb --with-ldflags="$LDFLAGS" --with-cppflags="$CPPFLAGS" \
-      --with-readlinelib="$READLINE_LIB"],
+      --with-readlinelib="$READLINE_LIB" "$readline_arch_arg"],
     [],
     AC_MSG_ERROR(Failed to configure Ruby extension)
 )

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,10 @@ AC_INIT(gitsh, 0.11.1, hello@thoughtbot.com)
 AM_INIT_AUTOMAKE([subdir-objects])
 
 AC_ARG_VAR([RUBY],[The path of the Ruby binary to use])
+AC_ARG_VAR(
+  [READLINE_LIB],
+  [The name of the readline library on your system, e.g. ereadline on OpenBSD]
+)
 
 AC_CONFIG_MACRO_DIR([m4])
 
@@ -34,10 +38,12 @@ if test "$newer" == "$srcdir/Gemfile.lock"; then
     $srcdir/vendor/vendorize $VENDOR_DIRECTORY || AC_MSG_ERROR([Vendorizing gems failed])
 fi
 
+AS_IF([test "x$READLINE_LIB" = x], [READLINE_LIB="readline"])
 current_dir="$PWD"
 cd "$srcdir/ext/gitsh"
 AS_IF(
-    [$RUBY extconf.rb --with-ldflags="$LDFLAGS" --with-cppflags="$CPPFLAGS"],
+    [$RUBY extconf.rb --with-ldflags="$LDFLAGS" --with-cppflags="$CPPFLAGS" \
+      --with-readlinelib="$READLINE_LIB"],
     [],
     AC_MSG_ERROR(Failed to configure Ruby extension)
 )

--- a/homebrew/gitsh.rb.in
+++ b/homebrew/gitsh.rb.in
@@ -21,6 +21,7 @@ class Gitsh < Formula
 
   def install
     set_ruby_path
+    set_architecture
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
@@ -40,5 +41,9 @@ class Gitsh < Formula
     else
       ENV['RUBY'] = SYSTEM_RUBY_PATH
     end
+  end
+
+  def set_architecture
+    ENV['READLINE_ARCH'] = "-arch #{MacOS.preferred_arch}"
   end
 end


### PR DESCRIPTION
The OpenBSD port for Readline calls the library `ereadline`, which means that the gitsh configure script needed to be patched to be used on OpenBSD systems.

This commit introduces a `READLINE_LIB` environment variable, which can be used to specify an alternative name to be passed to the Ruby C-extension's configuration script.

Based on @mike-burns' patch to `configure` in the OpenBSD ports tree:
  https://marc.info/?l=openbsd-ports&m=148340820830595&w=2