### PR TITLE
Improve configure script's source file discovery.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,9 +61,9 @@ cd "$current_dir"
 rubydir=$datadir/$PACKAGE/ruby
 rubylibdir=$rubydir/lib
 pkgrubylibdir=$rubylibdir/gitsh
-libfiles="$(echo $(find "$(dirname "$0")/lib/gitsh" -name \*.rb | cut -c 3-))"
-vendorfiles="$(echo $(find "$(dirname "$0")/vendor/gems" -type f))"
-testfiles="$(echo $(find "$(dirname "$0")/spec/integration" "$(dirname "$0")/spec/units" -type f -name \*rb))"
+libfiles="$(echo $(find "$srcdir/lib/gitsh" -name \*.rb))"
+vendorfiles="$(echo $(find "$srcdir/vendor/gems" -type f))"
+testfiles="$(echo $(find "$srcdir/spec/integration" "$srcdir/spec/units" -type f -name \*rb))"
 gemsetuppath=$datadir/$PACKAGE/vendor/gems/setup.rb
 
 AC_SUBST([RUBY])


### PR DESCRIPTION
- Uses Autoconf's `$srcdir` instead of `basename $0` as the root of the source tree.
- Removes a redundant `cut`. This was intended to strip `./` from the beginnings of the resulting paths, but it wasn't portable (`./` wasn't prepended to the paths on some systems), and the way this list is generated and used has changed so much that it no longer appears to matter if the `./` is there at all.

Partly based on Mike Burns' patch to `configure` in the OpenBSD ports tree:
  https://marc.info/?l=openbsd-ports&m=148340820830595&w=2