### PR TITLE
Repo root helpers

### DIFF
--- a/lib/gitsh/commands/internal_command.rb
+++ b/lib/gitsh/commands/internal_command.rb
@@ -86,8 +86,9 @@ TXT
     class Chdir < Base
       def self.help_message
         <<-TXT
-usage: :cd path
-Changes directory to the given path.
+usage: :cd [path]
+Changes directory to the given path. Run with no arguments to change to the
+repository's root directory.
 TXT
       end
 
@@ -103,7 +104,7 @@ TXT
       private
 
       def valid_arguments?
-        args.length == 1
+        args.length == 0 || args.length == 1
       end
 
       def change_directory(env)
@@ -117,7 +118,13 @@ TXT
       end
 
       def path(env)
-        File.expand_path(arg_values(env).first)
+        values = arg_values(env)
+
+        if values.empty?
+          env.fetch(:_root)
+        else
+          File.expand_path(values.first)
+        end
       end
     end
 

--- a/lib/gitsh/git_repository.rb
+++ b/lib/gitsh/git_repository.rb
@@ -13,6 +13,10 @@ module Gitsh
       git_output('rev-parse --git-dir')
     end
 
+    def root_dir
+      git_output('rev-parse --show-toplevel')
+    end
+
     def current_head
       current_branch_name || current_tag_name || abbreviated_sha
     end

--- a/lib/gitsh/magic_variables.rb
+++ b/lib/gitsh/magic_variables.rb
@@ -39,6 +39,14 @@ module Gitsh
         raise(UnsetVariableError, 'No rebase in progress')
     end
 
+    def _root
+      repo.root_dir.tap do |root_dir|
+        if root_dir.empty?
+          raise(UnsetVariableError, 'Not a Git repository')
+        end
+      end
+    end
+
     def read_file(path_components)
       File.read(File.join(repo.git_dir, *path_components)).chomp
     rescue Errno::ENOENT

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -265,6 +265,10 @@ which we are rebasing, for example after running
 this variable would evaluate to the hash of the commit at the head of the
 .Ic master
 branch.
+.It Ic $_root
+The absolute path to the current repository's root directory. This is
+equivalent to the output of
+.Ic git-rev-parse --show-toplevel .
 .El
 .El
 .Pp
@@ -272,6 +276,11 @@ Attempting to use an unset variable will cause a command to fail. This is
 different to
 .Xr sh 1 ,
 which will ignore unset variable arguments.
+.Pp
+Magic variables will behave like unset variables when used in a context
+where they don't make sense, e.g. using
+.Ic $_root
+outside of a Git repository.
 .Sh SUB-SHELLS
 .Pp
 Sub-shells can be used to pass the output of any command--including Git

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -196,8 +196,9 @@ Or for a mix of variables and arbitrary strings:
 .Bd -literal -offset indent
 @ :echo "This is ${user.name}'s work"
 .Ed
-.It Ic :cd path
-changes directory to the given path.
+.It Ic :cd [path]
+changes directory to the given path. Without an argument it changes directory
+to the repository's root.
 .It Ic :help [command]
 displays help about the given built-in command. Without an argument it outputs
 a list of all built-in commands. When given the name of a command, it outputs a

--- a/spec/integration/cd_command_spec.rb
+++ b/spec/integration/cd_command_spec.rb
@@ -14,6 +14,20 @@ describe 'The :cd command' do
     end
   end
 
+  it 'changes to the repository root directory when given no arguments' do
+    GitshRunner.interactive do |gitsh|
+      root_path = Dir.pwd
+      gitsh.type 'init'
+      Dir.mkdir 'subdir'
+      Dir.chdir 'subdir'
+
+      gitsh.type ':cd'
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to prompt_with "#{File.basename(root_path)} master@ "
+    end
+  end
+
   it 'outputs helpful messages when given bad arguments' do
     GitshRunner.interactive do |gitsh|
       gitsh.type ':cd /not-a-real-path'
@@ -23,10 +37,6 @@ describe 'The :cd command' do
       gitsh.type ":cd #{__FILE__}"
 
       expect(gitsh).to output_error /gitsh: cd: Not a directory/
-
-      gitsh.type ':cd'
-
-      expect(gitsh).to output_error 'usage: :cd path'
     end
   end
 

--- a/spec/integration/magic_variables_spec.rb
+++ b/spec/integration/magic_variables_spec.rb
@@ -77,6 +77,21 @@ describe 'Magic variables' do
     end
   end
 
+  context '$_root' do
+    it 'evaluates to the root path of the repository' do
+      GitshRunner.interactive do |gitsh|
+        root_dir = Dir.pwd
+        make_directory('child')
+        Dir.chdir('child')
+        gitsh.type('init')
+        gitsh.type(':echo $_root')
+
+        expect(gitsh).to output_no_errors
+        expect(gitsh).to output(/#{root_dir}/)
+      end
+    end
+  end
+
   def in_a_repository_with_conflicting_branches
     GitshRunner.interactive do |gitsh|
       gitsh.type('init')

--- a/spec/units/commands/internal/chdir_spec.rb
+++ b/spec/units/commands/internal/chdir_spec.rb
@@ -6,14 +6,22 @@ describe Gitsh::Commands::InternalCommand::Chdir do
 
   describe '#execute' do
     it 'returns true for correct directories' do
-      env = double('Environment', :[]= => true, puts_error: true)
+      env = double('Environment', puts_error: true)
       command = described_class.new('cd', arguments('./'))
 
       expect(command.execute(env)).to be_truthy
     end
 
+    it 'returns true for no argument' do
+      env = double('Environment', puts_error: true)
+      allow(env).to receive(:fetch).with(:_root).and_return(Dir.pwd)
+      command = described_class.new('cd', arguments)
+
+      expect(command.execute(env)).to be_truthy
+    end
+
     it 'returns false with invalid arguments' do
-      env = double('Environment', :[]= => true, puts_error: true)
+      env = double('Environment', puts_error: true)
       command = described_class.new('cd', arguments('foo'))
 
       expect(command.execute(env)).to be_falsey

--- a/spec/units/git_repository_spec.rb
+++ b/spec/units/git_repository_spec.rb
@@ -18,6 +18,37 @@ describe Gitsh::GitRepository do
     end
   end
 
+  describe '#root_dir' do
+    it 'returns the path to the working directory' do
+      with_a_temporary_home_directory do
+        in_a_temporary_directory do
+          root_dir = Dir.pwd
+          repo = Gitsh::GitRepository.new(env)
+          run 'git init'
+
+          expect(repo.root_dir).to eq(root_dir)
+
+          run 'mkdir subdir'
+          Dir.chdir('./subdir')
+
+          expect(repo.root_dir).to eq(root_dir)
+        end
+      end
+    end
+
+    context 'when called outside of a git repository' do
+      it 'returns the empty string' do
+        with_a_temporary_home_directory do
+          in_a_temporary_directory do
+            repo = Gitsh::GitRepository.new(env)
+
+            expect(repo.root_dir).to eq('')
+          end
+        end
+      end
+    end
+  end
+
   describe '#current_head' do
     it 'returns the name of the current git branch' do
       with_a_temporary_home_directory do

--- a/spec/units/magic_variables_spec.rb
+++ b/spec/units/magic_variables_spec.rb
@@ -94,6 +94,26 @@ describe Gitsh::MagicVariables do
           end
         end
       end
+
+      context 'with _root' do
+        it 'returns the root directory of the repository' do
+          repo = double('GitRepository', root_dir: '/tmp/example')
+          magic_variables = described_class.new(repo)
+
+          expect(magic_variables.fetch(:_root)).to eq '/tmp/example'
+        end
+
+        context 'when used outside a repository' do
+          it 'raises an exception' do
+            repo = double('GitRepository', root_dir: '')
+            magic_variables = described_class.new(repo)
+
+            expect { magic_variables.fetch(:_root) }.to raise_exception(
+              Gitsh::UnsetVariableError,
+            )
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
A couple of little helpers for finding a repository's root directory:

- A `$_root` magic variable which evaluates to the repository's root.
- An update to the `:cd` command, so that it changes to the repository root when invoked without a path. Thanks to @christoomey for suggesting this one in #242.