### PR TITLE
Support explicit architectures for Readline.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -62,6 +62,14 @@ library is named ereadline, you might use:
           LDFLAGS="-L/usr/local/lib" \
           ./configure
 
+Finally, on macOS systems with a universal Ruby binary (e.g. /usr/bin/ruby),
+and a non-universal Readline shared library, you may need to explicitly pass
+an architecture to use via the $READLINE_ARCH environment variable:
+
+        READLINE_ARCH=x86_64 \
+          RUBY=/usr/bin/ruby \
+          ./configure
+
 
 Installation
 ------------

--- a/INSTALL.in
+++ b/INSTALL.in
@@ -62,6 +62,14 @@ library is named ereadline, you might use:
           LDFLAGS="-L/usr/local/lib" \
           ./configure
 
+Finally, on macOS systems with a universal Ruby binary (e.g. /usr/bin/ruby),
+and a non-universal Readline shared library, you may need to explicitly pass
+an architecture to use via the $READLINE_ARCH environment variable:
+
+        READLINE_ARCH=x86_64 \
+          RUBY=/usr/bin/ruby \
+          ./configure
+
 
 Installation
 ------------

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,10 @@ AC_ARG_VAR(
   [READLINE_LIB],
   [The name of the readline library on your system, e.g. ereadline on OpenBSD]
 )
+AC_ARG_VAR(
+  [READLINE_ARCH],
+  [The architecture of the readline library on your system, e.g. x86_64]
+)
 
 AC_CONFIG_MACRO_DIR([m4])
 
@@ -39,11 +43,16 @@ if test "$newer" == "$srcdir/Gemfile.lock"; then
 fi
 
 AS_IF([test "x$READLINE_LIB" = x], [READLINE_LIB="readline"])
+AS_IF(
+    [test "x$READLINE_ARCH" = x],
+    [readline_arch_arg=""],
+    [readline_arch_arg="--with-arch-flag=\"-arch $READLINE_ARCH\""]
+)
 current_dir="$PWD"
 cd "$srcdir/ext/gitsh"
 AS_IF(
     [$RUBY extconf.rb --with-ldflags="$LDFLAGS" --with-cppflags="$CPPFLAGS" \
-      --with-readlinelib="$READLINE_LIB"],
+      --with-readlinelib="$READLINE_LIB" "$readline_arch_arg"],
     [],
     AC_MSG_ERROR(Failed to configure Ruby extension)
 )

--- a/homebrew/gitsh.rb.in
+++ b/homebrew/gitsh.rb.in
@@ -21,6 +21,7 @@ class Gitsh < Formula
 
   def install
     set_ruby_path
+    set_architecture
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
@@ -40,5 +41,9 @@ class Gitsh < Formula
     else
       ENV['RUBY'] = SYSTEM_RUBY_PATH
     end
+  end
+
+  def set_architecture
+    ENV['READLINE_ARCH'] = "-arch #{MacOS.preferred_arch}"
   end
 end


### PR DESCRIPTION
On macOS systems, universal binaries contain multiple architectures, e.g.
the system Ruby is built for both i386 and x86_64. The Ruby `mkmf.rb` build
system will default to building universal C extensions when used with a
universal Ruby.

When installing gitsh via Homebrew, we build against the Homebrew version of
Readline. Until recently, this was a universal library (x86_64 & i386) but
is now x86_64 only [1].

It is possible to build against a universal Ruby and a non-universal
Readline, but only if the right flags are passed to the C extension's
`extconf.rb` script.

This commit:

- Adds support for a `$READLINE_ARCH` environment variable. When it is set,
  the `configure` script will pass the right `--with-arch-flags` argument to
  `extconf.rb`.

- Updates the Homebrew formula to set `$READLINE_ARCH` based on the host
  OS's preferred architecture.

[1]: https://github.com/Homebrew/homebrew-core/pull/10907