### PR TITLE
Support for multi-line commands.

### DIFF
--- a/lib/gitsh/input_strategies/file.rb
+++ b/lib/gitsh/input_strategies/file.rb
@@ -25,9 +25,13 @@ module Gitsh
       end
 
       def read_command
-        file.readline
+        next_line
       rescue EOFError
         nil
+      end
+
+      def read_continuation
+        next_line
       end
 
       def handle_parse_error(message)
@@ -44,6 +48,10 @@ module Gitsh
         else
           ::File.open(path)
         end
+      end
+
+      def next_line
+        file.readline.chomp
       end
     end
   end

--- a/lib/gitsh/input_strategies/interactive.rb
+++ b/lib/gitsh/input_strategies/interactive.rb
@@ -13,6 +13,7 @@ module Gitsh
   module InputStrategies
     class Interactive
       BLANK_LINE_REGEX = /^\s*$/
+      CONTINUATION_PROMPT = '> '.freeze
 
       def initialize(opts)
         @line_editor = opts.fetch(:line_editor) do
@@ -48,6 +49,19 @@ module Gitsh
         retry
       end
 
+      def read_continuation
+        input = begin
+          line_editor.readline(CONTINUATION_PROMPT, true)
+        rescue Interrupt
+          nil
+        end
+
+        if input.nil?
+          env.print "\n"
+        end
+
+        input
+      end
 
       def handle_parse_error(message)
         env.puts_error("gitsh: #{message}")

--- a/lib/gitsh/parser.rb
+++ b/lib/gitsh/parser.rb
@@ -19,6 +19,7 @@ module Gitsh
       '!' => Gitsh::Commands::ShellCommand,
     }.freeze
 
+    left :EOL
     left :SEMICOLON
     left :OR
     left :AND
@@ -31,6 +32,7 @@ module Gitsh
     production(:commands) do
       clause('command') { |c| c }
       clause('LEFT_PAREN .commands RIGHT_PAREN') { |c| c }
+      clause('.commands EOL .commands') { |c1, c2| Commands::Tree::Multi.new(c1, c2) }
       clause('.commands SEMICOLON .commands') { |c1, c2| Commands::Tree::Multi.new(c1, c2) }
       clause('.commands OR .commands') { |c1, c2| Commands::Tree::Or.new(c1, c2) }
       clause('.commands AND .commands') { |c1, c2| Commands::Tree::And.new(c1, c2) }

--- a/man/man1/gitsh.1
+++ b/man/man1/gitsh.1
@@ -333,6 +333,10 @@ string delimiter
 .Pf ( Ic ' Ns )
 can be escaped.
 .Pp
+Line-breaks can be escaped by ending a line with a
+.Ic \e
+character. This is useful for splitting long commands over multiple lines.
+.Pp
 A literal
 .Ic \e
 character can always be produced by repeating it

--- a/spec/integration/error_handling_spec.rb
+++ b/spec/integration/error_handling_spec.rb
@@ -11,7 +11,7 @@ describe 'Handling errors' do
 
   it 'does not explode when given a badly formatted command' do
     GitshRunner.interactive do |gitsh|
-      gitsh.type('commit -m "Unclosed quote')
+      gitsh.type('add . && || commit')
 
       expect(gitsh).to output_error /gitsh: parse error/
     end

--- a/spec/integration/multi_line_input_spec.rb
+++ b/spec/integration/multi_line_input_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe 'Multi-line input' do
+  it 'supports escaped line breaks within commands' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type(':echo Hello \\')
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to prompt_with('> ')
+
+      gitsh.type('world')
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to output(/Hello world/)
+    end
+  end
+
+  it 'supports line breaks after logical operators' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type(':echo Hello &&')
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to prompt_with('> ')
+
+      gitsh.type(':echo World')
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to output(/Hello\nWorld/)
+    end
+  end
+
+  it 'supports line breaks within strings' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type(':echo "Hello, world')
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to prompt_with('> ')
+
+      gitsh.type('')
+      gitsh.type('Goodbye, world"')
+
+      expect(gitsh).to output(/\AHello, world\n\nGoodbye, world\Z/)
+    end
+  end
+
+  it 'supports line breaks within parentheses' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type('(:echo 1')
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to prompt_with('> ')
+
+      gitsh.type(':echo 2')
+      gitsh.type(':echo 3)')
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to output(/1\n2\n3/)
+    end
+  end
+
+  it 'supports line breaks within subshells' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type(':echo $(')
+      gitsh.type(' :set greeting Hello')
+      gitsh.type(' :echo $greeting')
+      gitsh.type(')')
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to output(/Hello/)
+    end
+  end
+
+  it 'supports comments in the middle of multi-line commands' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type('(:echo 1 # comment')
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to prompt_with('> ')
+
+      gitsh.type(':echo 2')
+      gitsh.type('# another comment')
+      gitsh.type(')')
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to output(/1\n2/)
+    end
+  end
+
+  it 'supports line breaks within strings in scripts' do
+    in_a_temporary_directory do
+      write_file('multiline.gitsh', ":echo 'foo\nbar'")
+
+      expect("#{gitsh_path} multiline.gitsh").
+        to execute.successfully.
+        with_output_matching(/foo\nbar/)
+    end
+  end
+end

--- a/spec/support/tokens.rb
+++ b/spec/support/tokens.rb
@@ -1,0 +1,15 @@
+require 'rltk'
+
+module Tokens
+  def tokens(*tokens)
+    tokens.map.with_index do |token, i|
+      type, value = token
+      pos = RLTK::StreamPosition.new(i, 1, i, 10, nil)
+      RLTK::Token.new(type, value, pos)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include Tokens
+end

--- a/spec/units/input_strategies/file_spec.rb
+++ b/spec/units/input_strategies/file_spec.rb
@@ -58,8 +58,8 @@ describe Gitsh::InputStrategies::File do
       )
       input_strategy.setup
 
-      expect(input_strategy.read_command).to eq "commit -m 'Changes'\n"
-      expect(input_strategy.read_command).to eq "push -f\n"
+      expect(input_strategy.read_command).to eq 'commit -m \'Changes\''
+      expect(input_strategy.read_command).to eq 'push -f'
       expect(input_strategy.read_command).to be_nil
     end
 
@@ -73,9 +73,35 @@ describe Gitsh::InputStrategies::File do
         )
         input_strategy.setup
 
-        expect(input_strategy.read_command).to eq "push\n"
-        expect(input_strategy.read_command).to eq "pull\n"
+        expect(input_strategy.read_command).to eq 'push'
+        expect(input_strategy.read_command).to eq 'pull'
         expect(input_strategy.read_command).to be_nil
+      end
+    end
+  end
+
+  describe '#read_continuation' do
+    it 'returns the next line of the file' do
+      script = temp_file('script', "commit -m 'Changes'\npush -f")
+      input_strategy = described_class.new(
+        path: script.path,
+      )
+      input_strategy.setup
+      input_strategy.read_command
+
+      expect(input_strategy.read_continuation).to eq 'push -f'
+    end
+
+    context 'with no lines left to return' do
+      it 'raises' do
+        script = temp_file('script', 'commit -m \'Changes\'')
+        input_strategy = described_class.new(
+          path: script.path,
+        )
+        input_strategy.setup
+        input_strategy.read_command
+
+        expect { input_strategy.read_continuation }.to raise_exception(EOFError)
       end
     end
   end

--- a/spec/units/lexer_spec.rb
+++ b/spec/units/lexer_spec.rb
@@ -39,6 +39,13 @@ describe Gitsh::Lexer do
         to produce_tokens ['WORD(foo)', 'OR', 'WORD(bar)', 'EOS']
     end
 
+    it 'recognises newlines' do
+      expect("foo\nbar").
+        to produce_tokens ['WORD(foo)', 'EOL', 'WORD(bar)', 'EOS']
+      expect("foo   \n\t\fbar").
+        to produce_tokens ['WORD(foo)', 'EOL', 'WORD(bar)', 'EOS']
+    end
+
     it 'recognises parentheses' do
       expect('(foo)').
         to produce_tokens ['LEFT_PAREN', 'WORD(foo)', 'RIGHT_PAREN', 'EOS']
@@ -46,10 +53,17 @@ describe Gitsh::Lexer do
         to produce_tokens ['LEFT_PAREN', 'WORD(foo)', 'RIGHT_PAREN', 'EOS']
     end
 
-    [' ', "\t", "\r", "\n", "\f", '\'', '"', '\\', '$', '#', ';', '&', '|', '(', ')'].each do |char|
+    [' ', "\t", "\f", '\'', '"', '\\', '$', '#', ';', '&', '|', '(', ')'].each do |char|
       it "recognises unquoted words containing an escaped #{char.inspect}" do
         expect("foo\\#{char}bar").
           to produce_tokens ['WORD(foo)', "WORD(#{char})", 'WORD(bar)', 'EOS']
+      end
+    end
+
+    ["\r", "\n"].each do |char|
+      it "ignored escaped line breaks using #{char.inspect}" do
+        expect("foo\\#{char}bar").
+          to produce_tokens ['WORD(foo)', 'WORD(bar)', 'EOS']
       end
     end
 
@@ -169,9 +183,36 @@ describe Gitsh::Lexer do
       ]
     end
 
+    it 'adds an error token for trailing logical operators' do
+      expect(':echo first &&').to produce_tokens [
+        'WORD(:echo)', 'SPACE', 'WORD(first)', 'AND', 'MISSING(command)', 'EOS'
+      ]
+      expect(':echo first ||').to produce_tokens [
+        'WORD(:echo)', 'SPACE', 'WORD(first)', 'OR', 'MISSING(command)', 'EOS'
+      ]
+    end
+
+    it 'adds an error token for a trailing escape character' do
+      expect('foo\\').
+        to produce_tokens ['WORD(foo)', 'MISSING(continuation)', 'EOS']
+      expect('foo\\\\').
+        to produce_tokens ['WORD(foo)', 'WORD(\\)', 'EOS']
+      expect('foo\\\\\\').
+        to produce_tokens ['WORD(foo)', 'WORD(\\)', 'MISSING(continuation)', 'EOS']
+    end
+
     it 'ignores comments' do
       expect('# all one big comment').to produce_tokens ['EOS']
-      expect('pre #post').to produce_tokens ['WORD(pre)', 'SPACE', 'EOS']
+      expect('pre #post').to produce_tokens ['WORD(pre)', 'EOS']
+    end
+
+    it 'ignores comments in multi-line input' do
+      expect("(:echo 1 #comment\n:echo 2)").to produce_tokens [
+        'LEFT_PAREN',
+        'WORD(:echo)', 'SPACE', 'WORD(1)', 'EOL',
+        'WORD(:echo)', 'SPACE', 'WORD(2)',
+        'RIGHT_PAREN', 'EOS',
+      ]
     end
   end
 end

--- a/spec/units/parser_spec.rb
+++ b/spec/units/parser_spec.rb
@@ -169,6 +169,15 @@ describe Gitsh::Parser do
       expect(result).to be_a(Gitsh::Commands::Tree::Multi)
     end
 
+    it 'parses two commands combined with newlines' do
+      result = parse(tokens(
+        [:WORD, 'add'], [:SPACE], [:WORD, '.'],
+        [:EOL], [:WORD, 'commit'], [:EOS],
+      ))
+
+      expect(result).to be_a(Gitsh::Commands::Tree::Multi)
+    end
+
     it 'parses a command with a trailing semicolon' do
       command = stub_command_factory
 
@@ -197,14 +206,6 @@ describe Gitsh::Parser do
 
   def parse(tokens)
     described_class.new.parse(tokens)
-  end
-
-  def tokens(*tokens)
-    tokens.map.with_index do |token, i|
-      type, value = token
-      pos = RLTK::StreamPosition.new(i, 1, i, 10, nil)
-      RLTK::Token.new(type, value, pos)
-    end
   end
 
   def stub_command_factory


### PR DESCRIPTION
Line breaks are supported in similar places to sh(1). Line breaks can be escaped anywhere by ending a line with a `\` character. Unescaped line breaks are also supported:

- after logical operators (`&&` and `||`),
- within strings,
- between commands wrapped in parentheses, and
- between commands in subshells.

The `Lexer` has been expanded to insert a `MISSING` token in all situations where the input is known to be incomplete (i.e. when the input ends with an escape character, or the input ends in any of the places where an unescaped line break can be used).

After invoking the `Lexer`, the `Interpreter` checks the token stream for `MISSING` tokens. If it finds any it requests another line of input from the current input strategy, appends it to the current input, and tries again.

A new `EOL` token has been introduced to represent line breaks between commands. In the `Parser` it's treated exactly like the `SEMICOLON` token.

Lexical analysis of comments needed to be improved to allow for comments at the end of lines in a multi-line command. For example, the following input is valid:

    (:echo 1 # comment
    :echo 2)

It is semantically equivalent to:

    (:echo 1; :echo 2)

To support this, the `Lexer` will now:

- ignore whitespace before a comment's initial `#` character. This prevents extraneous `SPACE` tokens from being produced. A trailing `SPACE` token in a single line command is fine, but it can cause problems in a multi-line command.

- pop the `:comment` state without consuming the newline character at the end of a comment, allowing the default parsing rules to handle the newline, and produce an `EOL` token.