### PR TITLE
Expand historyFile path

### DIFF
--- a/lib/gitsh/history.rb
+++ b/lib/gitsh/history.rb
@@ -32,7 +32,7 @@ module Gitsh
     end
 
     def history_file_path
-      env.fetch('gitsh.historyFile') { DEFAULT_HISTORY_FILE }
+      File.expand_path(env.fetch('gitsh.historyFile') { DEFAULT_HISTORY_FILE })
     end
 
     def history_size


### PR DESCRIPTION
Expand the configured history file path, so it is possible to use a "~"
for the user's home directory instead of an absolute path.

Before, a path like "~/.local/share/gitsh_history" led to the following
error:

gitsh: Error: No such file or directory @ rb_sysopen - ~/.local/share/gitsh_history