### PR TITLE
Remove Ruby warnings

### DIFF
--- a/lib/gitsh/arguments/subshell.rb
+++ b/lib/gitsh/arguments/subshell.rb
@@ -26,7 +26,7 @@ module Gitsh
       def strip_whitespace(output)
         output.
           sub(%r{\r?\n\Z}, '').
-          gsub(%r{[\n\r\s]+}, ' ')
+          gsub(%r{\s+}, ' ')
       end
     end
   end

--- a/lib/gitsh/git_repository.rb
+++ b/lib/gitsh/git_repository.rb
@@ -57,7 +57,7 @@ module Gitsh
         "config --get #{Shellwords.escape(name)}",
         force_default_git_command
       )
-      out, err, status = Open3.capture3(command)
+      out, _, status = Open3.capture3(command)
       if status.success?
         out.chomp
       elsif block_given?

--- a/lib/gitsh/git_repository/status.rb
+++ b/lib/gitsh/git_repository/status.rb
@@ -4,12 +4,10 @@ module Gitsh
       def initialize(status_porcelain, git_dir)
         @status_porcelain = status_porcelain
         @git_dir = git_dir
+        @initialized = File.exist?(git_dir)
       end
 
       def initialized?
-        if @initialized.nil?
-          @initialized = File.exist?(git_dir)
-        end
         @initialized
       end
 

--- a/spec/integration/arguments_spec.rb
+++ b/spec/integration/arguments_spec.rb
@@ -46,7 +46,7 @@ describe '--git' do
       gitsh.type('init')
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /^Fake git: init$/
+      expect(gitsh).to output(/^Fake git: init$/)
     end
   end
 end

--- a/spec/integration/cd_command_spec.rb
+++ b/spec/integration/cd_command_spec.rb
@@ -32,11 +32,11 @@ describe 'The :cd command' do
     GitshRunner.interactive do |gitsh|
       gitsh.type ':cd /not-a-real-path'
 
-      expect(gitsh).to output_error /gitsh: cd: No such directory/
+      expect(gitsh).to output_error(/gitsh: cd: No such directory/)
 
       gitsh.type ":cd #{__FILE__}"
 
-      expect(gitsh).to output_error /gitsh: cd: Not a directory/
+      expect(gitsh).to output_error(/gitsh: cd: Not a directory/)
     end
   end
 

--- a/spec/integration/chaining_spec.rb
+++ b/spec/integration/chaining_spec.rb
@@ -5,7 +5,7 @@ describe 'Chaining methods' do
     it 'runs init and status' do
       GitshRunner.interactive do |gitsh|
         gitsh.type('init && status')
-        expect(gitsh).to output /nothing to commit/
+        expect(gitsh).to output(/nothing to commit/)
       end
     end
 
@@ -13,7 +13,7 @@ describe 'Chaining methods' do
       GitshRunner.interactive do |gitsh|
         gitsh.type('init')
         gitsh.type('fetch origin && status')
-        expect(gitsh).to_not output /nothing to commit/
+        expect(gitsh).to_not output(/nothing to commit/)
       end
     end
 
@@ -36,7 +36,7 @@ describe 'Chaining methods' do
     it 'runs init then short circuits' do
       GitshRunner.interactive do |gitsh|
         gitsh.type('init || status')
-        expect(gitsh).to_not output /nothing to commit/
+        expect(gitsh).to_not output(/nothing to commit/)
       end
     end
 
@@ -44,7 +44,7 @@ describe 'Chaining methods' do
       GitshRunner.interactive do |gitsh|
         gitsh.type('init')
         gitsh.type('fetch origin || status')
-        expect(gitsh).to output /nothing to commit/
+        expect(gitsh).to output(/nothing to commit/)
       end
     end
 
@@ -53,8 +53,8 @@ describe 'Chaining methods' do
         gitsh.type(':set name George')
         gitsh.type(':echo $user_name || :echo $name')
 
-        expect(gitsh).to output_error /user_name/
-        expect(gitsh).to output /George/
+        expect(gitsh).to output_error(/user_name/)
+        expect(gitsh).to output(/George/)
       end
     end
   end
@@ -63,9 +63,9 @@ describe 'Chaining methods' do
     it 'runs init, passes, runs fetch, fails, then runs status, and passes' do
       GitshRunner.interactive do |gitsh|
         gitsh.type('init; fetch origin; status')
-        expect(gitsh).to output /Initialized empty Git repository/
-        expect(gitsh).to output_error /Could not read from remote repository/
-        expect(gitsh).to output /nothing to commit/
+        expect(gitsh).to output(/Initialized empty Git repository/)
+        expect(gitsh).to output_error(/Could not read from remote repository/)
+        expect(gitsh).to output(/nothing to commit/)
       end
     end
 
@@ -73,7 +73,7 @@ describe 'Chaining methods' do
       GitshRunner.interactive do |gitsh|
         gitsh.type('init;')
         expect(gitsh).to output_no_errors
-        expect(gitsh).to output /Initialized/
+        expect(gitsh).to output(/Initialized/)
       end
     end
   end
@@ -82,28 +82,28 @@ describe 'Chaining methods' do
     it 'evaluates AND before OR' do
       GitshRunner.interactive do |gitsh|
         gitsh.type(':echo $unset && :echo A || :echo B')
-        expect(gitsh).not_to output /A/
-        expect(gitsh).to output /B/
+        expect(gitsh).not_to output(/A/)
+        expect(gitsh).to output(/B/)
 
         gitsh.type(':echo C || :echo D && :echo E')
-        expect(gitsh).to output /C/
-        expect(gitsh).not_to output /D/
-        expect(gitsh).not_to output /E/
+        expect(gitsh).to output(/C/)
+        expect(gitsh).not_to output(/D/)
+        expect(gitsh).not_to output(/E/)
       end
     end
 
     it 'can be overridden with parentheses' do
       GitshRunner.interactive do |gitsh|
         gitsh.type(':echo $unset && (:echo A || :echo B)')
-        expect(gitsh).not_to output_error /parse error/
-        expect(gitsh).not_to output /A/
-        expect(gitsh).not_to output /B/
+        expect(gitsh).not_to output_error(/parse error/)
+        expect(gitsh).not_to output(/A/)
+        expect(gitsh).not_to output(/B/)
 
         gitsh.type('(:echo C || :echo D) && :echo E')
-        expect(gitsh).not_to output_error /parse error/
-        expect(gitsh).to output /C/
-        expect(gitsh).not_to output /D/
-        expect(gitsh).to output /E/
+        expect(gitsh).not_to output_error(/parse error/)
+        expect(gitsh).to output(/C/)
+        expect(gitsh).not_to output(/D/)
+        expect(gitsh).to output(/E/)
       end
     end
   end

--- a/spec/integration/comment_spec.rb
+++ b/spec/integration/comment_spec.rb
@@ -19,7 +19,7 @@ describe 'Comments' do
 
       gitsh.type 'show HEAD'
 
-      expect(gitsh).not_to output /Comment/
+      expect(gitsh).not_to output(/Comment/)
     end
   end
 end

--- a/spec/integration/correction_spec.rb
+++ b/spec/integration/correction_spec.rb
@@ -19,7 +19,7 @@ describe 'Correcting input' do
         gitsh.type ':set help.autocorrect 0'
         gitsh.type 'git init'
 
-        expect(gitsh).to output_error /not a git command/
+        expect(gitsh).to output_error(/not a git command/)
         expect(gitsh).to prompt_with "#{cwd_basename} uninitialized!! "
       end
     end

--- a/spec/integration/create_repository_spec.rb
+++ b/spec/integration/create_repository_spec.rb
@@ -8,7 +8,7 @@ describe 'Creating a repository' do
 
       gitsh.type('init')
 
-      expect(gitsh).to output /^Initialized empty Git repository/
+      expect(gitsh).to output(/^Initialized empty Git repository/)
       expect(gitsh).to output_no_errors
       expect(gitsh).to prompt_with "#{cwd_basename} master@ "
     end

--- a/spec/integration/default_command_spec.rb
+++ b/spec/integration/default_command_spec.rb
@@ -6,7 +6,7 @@ describe 'Entering no command' do
       gitsh.type('init')
       gitsh.type('')
 
-      expect(gitsh).to output /nothing to commit/
+      expect(gitsh).to output(/nothing to commit/)
     end
   end
 
@@ -15,7 +15,7 @@ describe 'Entering no command' do
       gitsh.type('init')
       gitsh.type('    ')
 
-      expect(gitsh).to output /nothing to commit/
+      expect(gitsh).to output(/nothing to commit/)
     end
   end
 
@@ -26,12 +26,12 @@ describe 'Entering no command' do
       gitsh.type('commit --allow-empty -m First')
       gitsh.type('')
 
-      expect(gitsh).to output /First/
+      expect(gitsh).to output(/First/)
 
       gitsh.type('commit --allow-empty -m Second')
       gitsh.type('')
 
-      expect(gitsh).to output /Second/
+      expect(gitsh).to output(/Second/)
     end
   end
 end

--- a/spec/integration/default_git_path_spec.rb
+++ b/spec/integration/default_git_path_spec.rb
@@ -8,7 +8,7 @@ describe 'Default git path' do
       gitsh.type('init')
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /^Fake git: init/
+      expect(gitsh).to output(/^Fake git: init/)
     end
   end
 
@@ -20,7 +20,7 @@ describe 'Default git path' do
       gitsh.type('init')
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /^Fake git: init/
+      expect(gitsh).to output(/^Fake git: init/)
     end
   end
 end

--- a/spec/integration/error_handling_spec.rb
+++ b/spec/integration/error_handling_spec.rb
@@ -5,7 +5,7 @@ describe 'Handling errors' do
     GitshRunner.interactive do |gitsh|
       gitsh.type(':foobar')
 
-      expect(gitsh).to output_error /gitsh: foobar: command not found/
+      expect(gitsh).to output_error(/gitsh: foobar: command not found/)
     end
   end
 
@@ -13,7 +13,7 @@ describe 'Handling errors' do
     GitshRunner.interactive do |gitsh|
       gitsh.type('add . && || commit')
 
-      expect(gitsh).to output_error /gitsh: parse error/
+      expect(gitsh).to output_error(/gitsh: parse error/)
     end
   end
 

--- a/spec/integration/escaping_spec.rb
+++ b/spec/integration/escaping_spec.rb
@@ -5,8 +5,8 @@ describe 'Escaping commands' do
     GitshRunner.interactive do |gitsh|
       gitsh.type('init ; echo Injection')
 
-      expect(gitsh).not_to output /Injection/
-      expect(gitsh).to output_error /echo/
+      expect(gitsh).not_to output(/Injection/)
+      expect(gitsh).to output_error(/echo/)
     end
   end
 end

--- a/spec/integration/gitshrc_spec.rb
+++ b/spec/integration/gitshrc_spec.rb
@@ -8,7 +8,7 @@ describe 'A .gitshrc file in the home directory' do
         GitshRunner.interactive do |gitsh|
           gitsh.type ':echo $gitshrc_loaded'
 
-          expect(gitsh).to output /Config loaded/
+          expect(gitsh).to output(/Config loaded/)
           expect(gitsh).to output_no_errors
         end
       end

--- a/spec/integration/greeting_spec.rb
+++ b/spec/integration/greeting_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Displaying a welcome message when gitsh starts' do
   it 'helps users understand what is going on' do
     GitshRunner.interactive do |gitsh|
-      expect(gitsh).to output /gitsh #{Gitsh::VERSION}\nType :exit to exit/
+      expect(gitsh).to output(/gitsh #{Gitsh::VERSION}\nType :exit to exit/)
     end
   end
 

--- a/spec/integration/persistent_history_spec.rb
+++ b/spec/integration/persistent_history_spec.rb
@@ -4,12 +4,12 @@ describe 'Gitsh history' do
   it 'is persisted between sessions' do
     GitshRunner.interactive do |gitsh|
       gitsh.type('foobarbaz')
-      expect(gitsh).to output_error /'foobarbaz' is not a git command/
+      expect(gitsh).to output_error(/'foobarbaz' is not a git command/)
     end
 
     GitshRunner.interactive do |gitsh|
       gitsh.type(GitshRunner::UP_ARROW * 2)
-      expect(gitsh).to output_error /'foobarbaz' is not a git command/
+      expect(gitsh).to output_error(/'foobarbaz' is not a git command/)
     end
   end
 end

--- a/spec/integration/source_command_spec.rb
+++ b/spec/integration/source_command_spec.rb
@@ -10,7 +10,7 @@ describe 'The :source command' do
         gitsh.type ':echo $source_worked'
 
         expect(gitsh).to output_no_errors
-        expect(gitsh).to output /Yes it did!/
+        expect(gitsh).to output(/Yes it did!/)
       end
     end
 
@@ -22,7 +22,7 @@ describe 'The :source command' do
         gitsh.type ':echo $source_worked'
 
         expect(gitsh).to output_no_errors
-        expect(gitsh).to output /True/
+        expect(gitsh).to output(/True/)
       end
     end
   end
@@ -32,7 +32,7 @@ describe 'The :source command' do
       GitshRunner.interactive do |gitsh|
         gitsh.type ':source'
 
-        expect(gitsh).to output_error /usage/
+        expect(gitsh).to output_error(/usage/)
         expect(gitsh).to output_nothing
       end
     end
@@ -43,7 +43,7 @@ describe 'The :source command' do
       GitshRunner.interactive do |gitsh|
         gitsh.type ':source not/a/real/file'
 
-        expect(gitsh).to output_error /No such file/
+        expect(gitsh).to output_error(/No such file/)
         expect(gitsh).to output_nothing
       end
     end

--- a/spec/integration/subshell_spec.rb
+++ b/spec/integration/subshell_spec.rb
@@ -7,7 +7,7 @@ describe 'Subshell' do
       gitsh.type ':echo prefix $(status) suffix'
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /prefix.*nothing to commit.*suffix/
+      expect(gitsh).to output(/prefix.*nothing to commit.*suffix/)
     end
   end
 
@@ -18,7 +18,7 @@ describe 'Subshell' do
       gitsh.type ':echo $x'
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /x in parent shell/
+      expect(gitsh).to output(/x in parent shell/)
     end
   end
 
@@ -28,7 +28,7 @@ describe 'Subshell' do
       gitsh.type ':echo $(:echo $(status))'
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /nothing to commit/
+      expect(gitsh).to output(/nothing to commit/)
     end
   end
 
@@ -37,7 +37,7 @@ describe 'Subshell' do
       gitsh.type ':echo $(:echo foo)$(:echo bar)'
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /\bfoo\nbar\b/
+      expect(gitsh).to output(/\bfoo\nbar\b/)
     end
   end
 
@@ -46,7 +46,7 @@ describe 'Subshell' do
       gitsh.type ':echo $(:echo ")))")'
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /\)\)\)/
+      expect(gitsh).to output(/\)\)\)/)
     end
   end
 end

--- a/spec/integration/variables_spec.rb
+++ b/spec/integration/variables_spec.rb
@@ -19,7 +19,7 @@ describe 'Gitsh variables' do
       gitsh.type('log --format="%ae - %s"')
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /^john@example\.com - An initial commit$/
+      expect(gitsh).to output(/^john@example\.com - An initial commit$/)
     end
   end
 
@@ -32,7 +32,7 @@ describe 'Gitsh variables' do
       gitsh.type('config --get test.example')
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /This is a test/
+      expect(gitsh).to output(/This is a test/)
     end
   end
 
@@ -47,7 +47,7 @@ describe 'Gitsh variables' do
       gitsh.type('log --format="%s" -n 1')
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /test\.example: A configuration variable/
+      expect(gitsh).to output(/test\.example: A configuration variable/)
     end
   end
 
@@ -55,7 +55,7 @@ describe 'Gitsh variables' do
     GitshRunner.interactive do |gitsh|
       gitsh.type(':set')
 
-      expect(gitsh).to output_error /usage: :set variable value/
+      expect(gitsh).to output_error(/usage: :set variable value/)
     end
   end
 
@@ -65,7 +65,7 @@ describe 'Gitsh variables' do
       gitsh.type(':echo $greeting')
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output /hello/
+      expect(gitsh).to output(/hello/)
     end
   end
 
@@ -74,7 +74,7 @@ describe 'Gitsh variables' do
       gitsh.type(':echo "hello $unset world"')
 
       expect(gitsh).to output_nothing
-      expect(gitsh).to output_error /unset/
+      expect(gitsh).to output_error(/unset/)
     end
   end
 end

--- a/spec/support/gitsh_runner.rb
+++ b/spec/support/gitsh_runner.rb
@@ -40,7 +40,7 @@ class GitshRunner
         runner.join
       end
     end
-  rescue RSpec::Expectations::ExpectationNotMetError => e
+  rescue RSpec::Expectations::ExpectationNotMetError
     runner.kill
     runner.join
     raise

--- a/spec/units/commands/git_command_spec.rb
+++ b/spec/units/commands/git_command_spec.rb
@@ -73,7 +73,7 @@ describe Gitsh::Commands::GitCommand do
           arguments("commit", "-m", "Some stuff"),
           shell_command_runner: mock_runner,
         )
-        result = command.execute(env)
+        command.execute(env)
 
         expect(mock_runner).to have_received(:run).with(
           ["/usr/bin/env", "git", "-c", "foo=1", "commit", "-m", "Some stuff"],
@@ -97,7 +97,7 @@ describe Gitsh::Commands::GitCommand do
           arguments("commit", "-m", "Some stuff"),
           shell_command_runner: mock_runner,
         )
-        result = command.execute(env)
+        command.execute(env)
 
         expect(mock_runner).to have_received(:run).with(
           ["/usr/bin/env", "git", "git", "commit", "-m", "Some stuff"],

--- a/spec/units/git_repository_spec.rb
+++ b/spec/units/git_repository_spec.rb
@@ -97,7 +97,7 @@ describe Gitsh::GitRepository do
           run 'git commit --allow-empty -m "Second"'
           run 'git checkout HEAD^'
 
-          expect(repo.current_head).to match /^[a-f0-9]{7}...$/
+          expect(repo.current_head).to match(/^[a-f0-9]{7}...$/)
         end
       end
     end

--- a/spec/units/interpreter_spec.rb
+++ b/spec/units/interpreter_spec.rb
@@ -36,7 +36,6 @@ describe Gitsh::Interpreter do
       parser = double(:parser)
       allow(parser).to receive(:parse).
         and_raise(RLTK::NotInLanguage.new([], double(:token), []))
-      lexer = double('Lexer', lex: tokens([:WORD, 'commit']))
       input_strategy = double(
         :input_strategy,
         setup: nil,


### PR DESCRIPTION
This PR is broken down into the commits that quells the following
warnings:

- character class has duplicated range: /X/.
  
  Where `/X/` is the regex.

- instance variable `@X` not initialized

  Where `@X` is the instance variable.

- assigned but unused variable - X

  Where `X` is the unused variable.

- ambiguous first argument; put parentheses or a space even after `/'
  operator

- character class has duplicated range: /X/

  Where `/X/` is the regex.
  `\s+` matches the output `[\n\r\s]+` does.

I leave it up to the reviewer to pick and choose the warnings that feel
applicable to cherry-pick in, that is why they are broken out into
small and concise commits.