### PR TITLE
Add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of conduct
+
+By participating in this project, you agree to abide by the [thoughtbot code of conduct][1].
+
+[1]: https://thoughtbot.com/open-source-code-of-conduct


### PR DESCRIPTION
GitHub has a new feature that indicates if a project has a code of conduct. We already had one, linked from `CONTRIBUTING.md`. This commit just duplicates that link in a place where GitHub can find it.