### PR TITLE
Improve variable lexing.

### DIFF
--- a/lib/gitsh/interpreter.rb
+++ b/lib/gitsh/interpreter.rb
@@ -44,7 +44,7 @@ module Gitsh
     end
 
     def incomplete_command?(tokens)
-      tokens.reverse_each.detect { |token| token.type == :MISSING }
+      tokens.reverse_each.detect { |token| token.type == :INCOMPLETE }
     end
 
     def build_multi_line_command(previous_lines, new_line)

--- a/spec/units/interpreter_spec.rb
+++ b/spec/units/interpreter_spec.rb
@@ -64,7 +64,7 @@ describe Gitsh::Interpreter do
       parser = double(:parser, parse: command)
       lexer = double('Lexer')
       allow(lexer).to receive(:lex).with('(commit').
-        and_return(tokens([:LEFT_PAREN], [:WORD, 'commit'], [:MISSING, ')']))
+        and_return(tokens([:LEFT_PAREN], [:WORD, 'commit'], [:INCOMPLETE, ')']))
       allow(lexer).to receive(:lex).with("(commit\n)").
         and_return(tokens([:LEFT_PAREN], [:WORD, 'commit'], [:RIGHT_PAREN]))
       input_strategy = double(
@@ -99,7 +99,7 @@ describe Gitsh::Interpreter do
       parser = double(:parser, parse: nil)
       lexer = double(
         'Lexer',
-        lex: tokens([:LEFT_PAREN], [:WORD, 'commit'], [:MISSING, ')']),
+        lex: tokens([:LEFT_PAREN], [:WORD, 'commit'], [:INCOMPLETE, ')']),
       )
       input_strategy = double(
         :input_strategy,

--- a/spec/units/lexer_spec.rb
+++ b/spec/units/lexer_spec.rb
@@ -171,34 +171,43 @@ describe Gitsh::Lexer do
 
     it 'adds an error token for unclosed strings' do
       expect('\'never ending').
-        to produce_tokens ['WORD(never ending)', 'MISSING(\')', 'EOS']
+        to produce_tokens ['WORD(never ending)', 'INCOMPLETE(\')', 'EOS']
 
       expect('"never ending').
-        to produce_tokens ['WORD(never ending)', 'MISSING(")', 'EOS']
+        to produce_tokens ['WORD(never ending)', 'INCOMPLETE(")', 'EOS']
     end
 
     it 'adds an error token for unclosed subshells' do
       expect('$(:echo Hello').to produce_tokens [
-        'SUBSHELL_START', 'WORD(:echo)', 'SPACE', 'WORD(Hello)', 'MISSING())', 'EOS'
+        'SUBSHELL_START', 'WORD(:echo)', 'SPACE', 'WORD(Hello)', 'INCOMPLETE())', 'EOS'
       ]
     end
 
     it 'adds an error token for trailing logical operators' do
       expect(':echo first &&').to produce_tokens [
-        'WORD(:echo)', 'SPACE', 'WORD(first)', 'AND', 'MISSING(command)', 'EOS'
+        'WORD(:echo)', 'SPACE', 'WORD(first)', 'AND', 'INCOMPLETE(command)', 'EOS'
       ]
       expect(':echo first ||').to produce_tokens [
-        'WORD(:echo)', 'SPACE', 'WORD(first)', 'OR', 'MISSING(command)', 'EOS'
+        'WORD(:echo)', 'SPACE', 'WORD(first)', 'OR', 'INCOMPLETE(command)', 'EOS'
       ]
     end
 
     it 'adds an error token for a trailing escape character' do
       expect('foo\\').
-        to produce_tokens ['WORD(foo)', 'MISSING(continuation)', 'EOS']
+        to produce_tokens ['WORD(foo)', 'INCOMPLETE(continuation)', 'EOS']
       expect('foo\\\\').
         to produce_tokens ['WORD(foo)', 'WORD(\\)', 'EOS']
       expect('foo\\\\\\').
-        to produce_tokens ['WORD(foo)', 'WORD(\\)', 'MISSING(continuation)', 'EOS']
+        to produce_tokens ['WORD(foo)', 'WORD(\\)', 'INCOMPLETE(continuation)', 'EOS']
+    end
+
+    it 'adds an error token for incomplete variable references' do
+      expect(':echo $').
+        to produce_tokens ['WORD(:echo)', 'SPACE', 'MISSING(var)', 'EOS']
+      expect(':echo ${').
+        to produce_tokens ['WORD(:echo)', 'SPACE', 'MISSING(var)', 'EOS']
+      expect(':echo ${x').
+        to produce_tokens ['WORD(:echo)', 'SPACE', 'VAR(x)', 'MISSING(})', 'EOS']
     end
 
     it 'ignores comments' do


### PR DESCRIPTION
Prior to this commit, an incomplete variable reference (a line ending with
an unescaped `$` character, or unclosed `${`) would produce a lexing error.
After this commit it produces a parse error instead.

We want to start using the lexer for understanding tab completion context,
which means we need to lex incomplete input. Having all legal-but-incomplete
input cause parse errors instead of lexing errors will make this much
easier.

Note that it's still possible to produce lexing errors with invalid input,
but it's more reasonable for the tab completion system to just ignore that
and not provide any completions.

A new `EXPECTED` token type was used instead of the existing `MISSING` token
type, because `MISSING` is used to determine that the user can enter another
line to complete the command.

---

**Notes for reviewers:**

- This was motivated by feedback from @mike-burns and @tabfugnic on #296, specifically the `Gitsh::TabCompletion::Context` class had some very complex code to work around incomplete input that caused lexing errors.

- I'm not wild about the distinction between `EXPECTED` and `MISSING`, maybe `MISSING` and `INCOMPLETE` would be better names.