### PR TITLE
Quell ruby warnings for unused variables

### DIFF
--- a/spec/units/tab_completion/automaton_spec.rb
+++ b/spec/units/tab_completion/automaton_spec.rb
@@ -116,7 +116,7 @@ describe Gitsh::TabCompletion::Automaton do
         visit_free_transition: nil,
       )
 
-      result = automaton.accept_visitor(visitor)
+      automaton.accept_visitor(visitor)
 
       expect(visitor).to have_received(:visit_state).with(state_0).once
       expect(visitor).to have_received(:visit_state).with(state_1).once

--- a/spec/units/tab_completion/matchers/command_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/command_matcher_spec.rb
@@ -63,7 +63,7 @@ describe Gitsh::TabCompletion::Matchers::CommandMatcher do
       matcher = described_class.new(double(:env), double(:internal_command))
       other = double(:not_a_matcher)
 
-      expect(matcher).not_to eql(double)
+      expect(matcher).not_to eql(other)
     end
   end
 

--- a/spec/units/tab_completion/matchers/path_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/path_matcher_spec.rb
@@ -40,7 +40,7 @@ describe Gitsh::TabCompletion::Matchers::PathMatcher do
       matcher = described_class.new
       other = double(:not_a_matcher)
 
-      expect(matcher).not_to eql(double)
+      expect(matcher).not_to eql(other)
     end
   end
 

--- a/spec/units/tab_completion/matchers/remote_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/remote_matcher_spec.rb
@@ -41,7 +41,7 @@ describe Gitsh::TabCompletion::Matchers::RemoteMatcher do
       matcher = described_class.new(double(:env))
       other = double(:not_a_matcher)
 
-      expect(matcher).not_to eql(double)
+      expect(matcher).not_to eql(other)
     end
   end
 

--- a/spec/units/tab_completion/matchers/revision_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/revision_matcher_spec.rb
@@ -65,7 +65,7 @@ describe Gitsh::TabCompletion::Matchers::RevisionMatcher do
       matcher = described_class.new(double(:env))
       other = double(:not_a_matcher)
 
-      expect(matcher).not_to eql(double)
+      expect(matcher).not_to eql(other)
     end
   end
 


### PR DESCRIPTION
This commit quells warnings along the likes of:

```
warning: assigned but unused variable - X
```

Where X is the variable in question.

This alongside https://github.com/thoughtbot/gitsh/pull/306 makes gitsh
warning free, and ensures that it stays warning free.