### PR TITLE
Tab completion NFA DSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ test-driver
 /gitsh
 src/gitsh.rb
 lib/gitsh/version.rb
+man/man1/gitsh.1
+man/man5/gitsh_completions.5
 gitsh-*.tar.gz
 vendor/gems
 *.o

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,38 @@ Style/StringLiterals:
   SupportedStyles:
     - single_quotes
     - double_quotes
+
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    find: detect
+    reduce: inject
+    collect: map
+    find_all: select
+
+Style/VariableNumber:
+  Description: Use normalcase for variable numbers.
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  Description: 'Checks for trailing comma in argument lists.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  EnforcedStyleForMultiline: consistent_comma
+  SupportedStylesForMultiline:
+    - comma
+    - consistent_comma
+    - no_comma
+  Enabled: true
+
+Style/TrailingCommaInLiteral:
+  Description: 'Checks for trailing comma in array and hash literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  EnforcedStyleForMultiline: consistent_comma
+  SupportedStylesForMultiline:
+    - comma
+    - consistent_comma
+    - no_comma
+  Enabled: true
+
+Style/EmptyMethod:
+  Enabled: false

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,17 +13,19 @@ bin_PROGRAMS = gitsh
 gitsh_SOURCES = src/gitsh.c
 AM_CPPFLAGS = -DGITSH_RB_PATH="\"$(rubydir)/$(PACKAGE).rb\""
 
-dist_man_MANS = man/man1/gitsh.1
+dist_man_MANS = man/man1/gitsh.1 man/man5/gitsh_completions.5
 nobase_dist_pkgdata_DATA = $(vendorfiles)
 nobase_dist_ruby_DATA = $(libfiles)
 pkgrubylib_DATA = lib/gitsh/version.rb
 ruby_SCRIPTS = src/gitsh.rb
+dist_pkgsysconf_DATA = etc/completions
 
 CLEANFILES = src/gitsh.rb lib/gitsh/version.rb
 
 substitute_values = sed \
 	-e 's|@RUBY[@]|$(RUBY)|g' \
 	-e 's|@rubylibdir[@]|$(rubylibdir)|g' \
+	-e 's|@pkgsysconfdir[@]|$(pkgsysconfdir)|g' \
 	-e 's|@gemsetuppath[@]|$(gemsetuppath)|g' \
 	-e 's|@PACKAGE_VERSION[@]|$(PACKAGE_VERSION)|g'
 
@@ -47,6 +49,12 @@ install-data-local:
 distclean-local:
 	rm -rf vendor/gems
 	rm -f ext/gitsh/Makefile
+
+man/man1/gitsh.1: Makefile man/man1/gitsh.1.in
+	$(substitute_values) $(srcdir)/$@.in > $@
+
+man/man5/gitsh_completions.5: Makefile man/man5/gitsh_completions.5.in
+	$(substitute_values) $(srcdir)/$@.in > $@
 
 
 # Test

--- a/bin/gitsh
+++ b/bin/gitsh
@@ -9,6 +9,10 @@ require 'bundler/setup'
   $LOAD_PATH.unshift(File.expand_path("../../#{directory}", __FILE__))
 end
 
+require 'gitsh/environment'
 require 'gitsh/cli'
 
-Gitsh::CLI.new.run
+env = Gitsh::Environment.new(
+  config_directory: File.expand_path('../../etc', __FILE__),
+)
+Gitsh::CLI.new(env: env).run

--- a/bin/tcviz
+++ b/bin/tcviz
@@ -9,7 +9,9 @@ require 'gitsh/environment'
 require 'gitsh/tab_completion/automaton_factory'
 require 'gitsh/tab_completion/visualization'
 
-env = Gitsh::Environment.new
+env = Gitsh::Environment.new(
+  config_directory: File.expand_path('../../etc', __FILE__),
+)
 automaton = Gitsh::TabCompletion::AutomatonFactory.build(env)
 viz = Gitsh::TabCompletion::Visualization.new(automaton)
 

--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,7 @@ cd "$current_dir"
 rubydir=$datadir/$PACKAGE/ruby
 rubylibdir=$rubydir/lib
 pkgrubylibdir=$rubylibdir/gitsh
+pkgsysconfdir=$sysconfdir/gitsh
 libfiles="$(echo $(find "$srcdir/lib/gitsh" -name \*.rb))"
 vendorfiles="$(echo $(find "$srcdir/vendor/gems" -type f))"
 testfiles="$(echo $(find "$srcdir/spec/integration" "$srcdir/spec/units" -type f -name \*rb))"
@@ -70,6 +71,7 @@ AC_SUBST([RUBY])
 AC_SUBST([rubydir])
 AC_SUBST([rubylibdir])
 AC_SUBST([pkgrubylibdir])
+AC_SUBST([pkgsysconfdir])
 AC_SUBST([libfiles])
 AC_SUBST([vendorfiles])
 AC_SUBST([testfiles])

--- a/etc/completions
+++ b/etc/completions
@@ -1,0 +1,1 @@
+$command ($revision|$path|$remote)+

--- a/lib/gitsh/environment.rb
+++ b/lib/gitsh/environment.rb
@@ -6,8 +6,9 @@ require 'gitsh/magic_variables'
 module Gitsh
   class Environment
     DEFAULT_GIT_COMMAND = '/usr/bin/env git'.freeze
+    DEFAULT_CONFIG_DIRECTORY = '/usr/local/etc/gitsh'.freeze
 
-    attr_reader :input_stream, :output_stream, :error_stream
+    attr_reader :input_stream, :output_stream, :error_stream, :config_directory
 
     def initialize(options={})
       @input_stream = options.fetch(:input_stream, $stdin)
@@ -16,6 +17,10 @@ module Gitsh
       @repo = options.fetch(:repository_factory, GitRepository).new(self)
       @variables = Hash.new
       @magic_variables = options.fetch(:magic_variables) { MagicVariables.new(@repo) }
+      @config_directory = options.fetch(
+        :config_directory,
+        DEFAULT_CONFIG_DIRECTORY,
+      )
     end
 
     def initialize_copy(original)

--- a/lib/gitsh/tab_completion/README.md
+++ b/lib/gitsh/tab_completion/README.md
@@ -10,6 +10,9 @@ has typed so far.
 The basis of gitsh's tab completion system is a slightly extended
 Non-deterministic Finite Automaton (NFA).
 
+The NFA's state graph is loaded from a configuration file that uses a
+Domain-Specific Language (DSL) similar to regular expressions.
+
 Completing variable names doesn't use the NFA, but all other types of completion
 do.
 
@@ -102,9 +105,18 @@ then hit <kbd>tab</kbd>. In this case, we'd pass `add` to the automaton and move
 from state `0` to state `4`. From state `4` the next thing we expect is a path,
 so we'd offer file paths from the current directory as completions.
 
-### Building the state graph
+### Loading the state graph
 
-The state graph is built by the `Gitsh::TabCompletion::AutomatonFactory` class.
+As you might imagine, the state graph for tab completing Git commands is fairly
+large. Instead of hard-coding this graph, we load it from a configuration file
+written in a custom DSL.
+
+The configuration file (in this repository's `etc` directory, and installed
+to `$(prefix)/etc/gitsh/completions`) provides standard completions for Git
+commands.
+
+Details of the DSL can be found in the gitsh\_completions(5) manual page in this
+repository's `man` directory.
 
 To help debug the state graph, the repository includes a visualisation tool.
 Running `bin/tcviz` will output the graph in [Graphviz's dot language][1].
@@ -144,3 +156,7 @@ Running this through Graphviz's dot(1) program produces an image file, e.g.
 - `Gitsh::TabCompletion::VariableCompleter` provides an alternative to
   `CommandCompleter`. This doesn't use the automaton, and only completes
   variable names.
+
+- `Gitsh::TabCompletion::DSL` contains various classes for loading the
+  automaton's state graph from configuration files. The `DSL` module acts as a
+  facade for the configuration loading system.

--- a/lib/gitsh/tab_completion/automaton_factory.rb
+++ b/lib/gitsh/tab_completion/automaton_factory.rb
@@ -1,9 +1,5 @@
-require 'gitsh/commands/internal_command'
 require 'gitsh/tab_completion/automaton'
-require 'gitsh/tab_completion/matchers/command_matcher'
-require 'gitsh/tab_completion/matchers/path_matcher'
-require 'gitsh/tab_completion/matchers/remote_matcher'
-require 'gitsh/tab_completion/matchers/revision_matcher'
+require 'gitsh/tab_completion/dsl'
 
 module Gitsh
   module TabCompletion
@@ -17,6 +13,7 @@ module Gitsh
       end
 
       def build
+        load_config(File.join(env.config_directory, 'completions'))
         Automaton.new(start_state)
       end
 
@@ -24,29 +21,12 @@ module Gitsh
 
       attr_reader :env
 
+      def load_config(path)
+        DSL.load(path, start_state, env)
+      end
+
       def start_state
-        start_state = Automaton::State.new('start')
-
-        command_state = Automaton::State.new('command')
-        start_state.add_transition(
-          Matchers::CommandMatcher.new(env, Commands::InternalCommand),
-          command_state
-        )
-
-        command_state.add_transition(
-          Matchers::RevisionMatcher.new(env),
-          command_state,
-        )
-        command_state.add_transition(
-          Matchers::PathMatcher.new,
-          command_state,
-        )
-        command_state.add_transition(
-          Matchers::RemoteMatcher.new(env),
-          command_state,
-        )
-
-        start_state
+        @start_state ||= Automaton::State.new('start')
       end
     end
   end

--- a/lib/gitsh/tab_completion/dsl.rb
+++ b/lib/gitsh/tab_completion/dsl.rb
@@ -1,0 +1,16 @@
+require 'gitsh/tab_completion/dsl/lexer'
+require 'gitsh/tab_completion/dsl/parser'
+
+module Gitsh
+  module TabCompletion
+    module DSL
+      def self.load(path, start_state, env)
+        source = File.read(path)
+        tokens = Lexer.lex(source)
+        factory = Parser.parse(tokens, gitsh_env: env)
+        factory.build(start_state)
+      rescue Errno::ENOENT
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/dsl/choice_factory.rb
+++ b/lib/gitsh/tab_completion/dsl/choice_factory.rb
@@ -1,0 +1,25 @@
+require 'gitsh/tab_completion/automaton'
+
+module Gitsh
+  module TabCompletion
+    module DSL
+      class ChoiceFactory
+        attr_reader :choices
+
+        def initialize(choices)
+          @choices = choices
+        end
+
+        def build(start_state, options = {})
+          end_state = options.fetch(:end_state) do
+            Automaton::State.new('choice')
+          end
+          choices.each do |choice|
+            choice.build(start_state, options.merge(end_state: end_state))
+          end
+          end_state
+        end
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/dsl/concatenation_factory.rb
+++ b/lib/gitsh/tab_completion/dsl/concatenation_factory.rb
@@ -1,0 +1,35 @@
+module Gitsh
+  module TabCompletion
+    module DSL
+      class ConcatenationFactory
+        attr_reader :parts
+
+        def initialize(parts)
+          @parts = parts
+        end
+
+        def build(start_state, options = {})
+          with_optional_end_state(options) do
+            parts.inject(start_state) do |state, part|
+              part.build(state, options)
+            end
+          end
+        end
+
+        private
+
+        def with_optional_end_state(options)
+          end_state = options.delete(:end_state)
+
+          if end_state
+            last_state = yield
+            last_state.add_free_transition(end_state)
+            end_state
+          else
+            yield
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/dsl/lexer.rb
+++ b/lib/gitsh/tab_completion/dsl/lexer.rb
@@ -1,0 +1,22 @@
+require 'rltk/lexer'
+
+module Gitsh
+  module TabCompletion
+    module DSL
+      class Lexer < RLTK::Lexer
+        rule(/\$[a-z_]+/) { |t| [:VAR, t[1..-1]] }
+        rule(/[^\s*+|()#]+/) { |t| [:WORD, t] }
+        rule(/\+/) { :PLUS }
+        rule(/\|/) { :OR }
+        rule(/\(/) { :LEFT_PAREN }
+        rule(/\)/) { :RIGHT_PAREN }
+        rule(/\s*\n\s*\n/) { :BLANK }
+        rule(/\s+/) {}
+
+        rule(/#/) { push_state :comment }
+        rule(/[^\n]+/, :comment) {}
+        rule(/(?=\n)/, :comment) { pop_state }
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/dsl/parser.rb
+++ b/lib/gitsh/tab_completion/dsl/parser.rb
@@ -1,0 +1,110 @@
+require 'rltk'
+require 'gitsh/tab_completion/dsl/choice_factory'
+require 'gitsh/tab_completion/dsl/concatenation_factory'
+require 'gitsh/tab_completion/dsl/plus_operation_factory'
+require 'gitsh/tab_completion/dsl/rule_factory'
+require 'gitsh/tab_completion/dsl/rule_set_factory'
+require 'gitsh/tab_completion/dsl/text_transition_factory'
+require 'gitsh/tab_completion/dsl/variable_transition_factory'
+require 'gitsh/tab_completion/matchers/command_matcher'
+require 'gitsh/tab_completion/matchers/path_matcher'
+require 'gitsh/tab_completion/matchers/remote_matcher'
+require 'gitsh/tab_completion/matchers/revision_matcher'
+
+module Gitsh
+  module TabCompletion
+    module DSL
+      class Parser < RLTK::Parser
+        VARIABLE_TO_MATCHER_CLASS = {
+          'command' => Matchers::CommandMatcher,
+          'path' => Matchers::PathMatcher,
+          'remote' => Matchers::RemoteMatcher,
+          'revision' => Matchers::RevisionMatcher,
+        }.freeze
+
+        class Environment < RLTK::Parser::Environment
+          def initialize(gitsh_env = nil)
+            @gitsh_env = gitsh_env
+            super()
+          end
+
+          def maybe_concatenate(factories)
+            if factories.length > 1
+              ConcatenationFactory.new(factories)
+            else
+              factories.first
+            end
+          end
+
+          def matcher_for_variable(var_name)
+            @_matchers ||= {}
+            @_matchers[var_name] ||= build_matcher(var_name)
+          end
+
+          private
+
+          attr_reader :gitsh_env
+
+          def build_matcher(var_name)
+            VARIABLE_TO_MATCHER_CLASS.fetch(var_name).new(gitsh_env)
+          end
+        end
+
+        def self.parse(tokens, opts = {})
+          super(
+            tokens,
+            opts.merge(env: Environment.new(opts.fetch(:gitsh_env))),
+          )
+        end
+
+        production(:rule_set) do
+          clause('rule') do |rule_factory|
+            RuleSetFactory.new([rule_factory])
+          end
+          clause('rules') do |rule_factories|
+            RuleSetFactory.new(rule_factories)
+          end
+        end
+
+        production(:rules) do
+          clause('.rule BLANK+ .rule') { |rule1, rule2| [rule1, rule2] }
+          clause('.rules BLANK+ .rule') { |rules, rule| rules + [rule] }
+        end
+
+        production(:rule, 'term+') do |factories|
+          RuleFactory.new(maybe_concatenate(factories))
+        end
+
+        production(:term) do
+          clause('item') { |factory| factory }
+          clause('.item PLUS') { |factory| PlusOperationFactory.new(factory) }
+        end
+
+        production(:item) do
+          clause('atom') { |factory| factory }
+          clause('LEFT_PAREN .choice RIGHT_PAREN') do |factories|
+            ChoiceFactory.new(factories)
+          end
+        end
+
+        production(:choice) do
+          clause('.atom+ OR .atom+') do |left_atoms, right_atoms|
+            [maybe_concatenate(left_atoms), maybe_concatenate(right_atoms)]
+          end
+          clause('.choice OR .atom+') do |choices, right_atoms|
+            choices + [maybe_concatenate(right_atoms)]
+          end
+        end
+
+        production(:atom) do
+          clause('WORD') { |word| TextTransitionFactory.new(word) }
+          clause('VAR') do |var_name|
+            VariableTransitionFactory.new(matcher_for_variable(var_name))
+          end
+        end
+
+        finalize
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/dsl/plus_operation_factory.rb
+++ b/lib/gitsh/tab_completion/dsl/plus_operation_factory.rb
@@ -1,0 +1,19 @@
+module Gitsh
+  module TabCompletion
+    module DSL
+      class PlusOperationFactory
+        attr_reader :child
+
+        def initialize(child)
+          @child = child
+        end
+
+        def build(start_state, options = {})
+          end_state = child.build(start_state, options)
+          end_state.add_free_transition(start_state)
+          end_state
+        end
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/dsl/rule_factory.rb
+++ b/lib/gitsh/tab_completion/dsl/rule_factory.rb
@@ -1,0 +1,17 @@
+module Gitsh
+  module TabCompletion
+    module DSL
+      class RuleFactory
+        attr_reader :root
+
+        def initialize(root)
+          @root = root
+        end
+
+        def build(start_state)
+          root.build(start_state)
+        end
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/dsl/rule_set_factory.rb
+++ b/lib/gitsh/tab_completion/dsl/rule_set_factory.rb
@@ -1,0 +1,17 @@
+module Gitsh
+  module TabCompletion
+    module DSL
+      class RuleSetFactory
+        attr_reader :rules
+
+        def initialize(rules)
+          @rules = rules
+        end
+
+        def build(start_state)
+          rules.each { |rule| rule.build(start_state) }
+        end
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/dsl/text_transition_factory.rb
+++ b/lib/gitsh/tab_completion/dsl/text_transition_factory.rb
@@ -1,0 +1,22 @@
+require 'gitsh/tab_completion/automaton'
+require 'gitsh/tab_completion/matchers/text_matcher'
+
+module Gitsh
+  module TabCompletion
+    module DSL
+      class TextTransitionFactory
+        attr_reader :word
+
+        def initialize(word)
+          @word = word
+        end
+
+        def build(start_state, options = {})
+          end_state = options.fetch(:end_state) { Automaton::State.new(word) }
+          start_state.add_transition(Matchers::TextMatcher.new(word), end_state)
+          end_state
+        end
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/dsl/variable_transition_factory.rb
+++ b/lib/gitsh/tab_completion/dsl/variable_transition_factory.rb
@@ -1,0 +1,23 @@
+require 'gitsh/tab_completion/automaton'
+
+module Gitsh
+  module TabCompletion
+    module DSL
+      class VariableTransitionFactory
+        attr_reader :matcher
+
+        def initialize(matcher)
+          @matcher = matcher
+        end
+
+        def build(start_state, options = {})
+          end_state = options.fetch(:end_state) do
+            Automaton::State.new(matcher.name)
+          end
+          start_state.add_transition(matcher, end_state)
+          end_state
+        end
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/matchers/command_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/command_matcher.rb
@@ -1,10 +1,11 @@
 require 'gitsh/tab_completion/matchers/base_matcher'
+require 'gitsh/commands/internal_command'
 
 module Gitsh
   module TabCompletion
     module Matchers
       class CommandMatcher < BaseMatcher
-        def initialize(env, internal_command)
+        def initialize(env, internal_command = Commands::InternalCommand)
           @env = env
           @internal_command = internal_command
         end

--- a/lib/gitsh/tab_completion/matchers/path_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/path_matcher.rb
@@ -4,6 +4,9 @@ module Gitsh
   module TabCompletion
     module Matchers
       class PathMatcher < BaseMatcher
+        def initialize(_env)
+        end
+
         def completions(token)
           prefix = normalize_path(token)
           paths(prefix).map { |option| option.sub(prefix, token) }

--- a/man/man1/gitsh.1.in
+++ b/man/man1/gitsh.1.in
@@ -1,4 +1,4 @@
-.Dd November 19, 2013
+.Dd June 29, 2017
 .Dt GITSH 1
 .Os
 .Sh NAME
@@ -406,6 +406,13 @@ The
 .Pa .gitshrc
 file will not be loaded for non-interactive sessions, e.g. when gitsh is
 invoked with the path to a script file.
+.It Pa @pkgsysconfdir@/completions
+System-wide tab completions file, which defines the tab completion options
+for popular Git commands.
+.Pp
+See
+.Xr gitsh_completions 5
+for details on the format of this file.
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width Ds
@@ -426,6 +433,7 @@ rebase master
 .Ed
 .
 .Sh SEE ALSO
+.Xr gitsh_completions 5
 .Xr git 1
 .Xr gittutorial 7
 .

--- a/man/man5/gitsh_completions.5.in
+++ b/man/man5/gitsh_completions.5.in
@@ -1,0 +1,204 @@
+.Dd June 29, 2017
+.Dt GITSH_COMPLETIONS 5
+.Os
+.Sh NAME
+.Nm gitsh_completions
+.Nd Defines options for tab completion
+.
+.Sh DESCRIPTION
+.Nm gitsh_completions
+files define the tab completions options that are available in interactive
+.Xr gitsh 1
+sessions.
+.Pp
+The content of a
+.Nm gitsh_completions
+file consists of rules defining the arguments that are expected
+by various commands.
+.Xr gitsh 1
+uses the rules to match the input before the word being completed
+and to generate completions that are relevant in the context.
+.Pp
+Each rule is separated from other rules by a blank line.
+.Pp
+The rule specifies the name of the command
+and the arguments it accepts. In the simplest case, these are just
+space-separated words. For example, the following
+.Nm gitsh_completions
+file defines three rules for the
+.Xr git-stash 1
+command:
+.Bd -literal -offset -indent
+stash list
+
+stash show
+
+stash drop
+.Ed
+.Pp
+With these rules in place,
+.Xr gitsh 1
+could tab complete the command
+.Ic stash ,
+or if the user had already entered
+.Ic stash
+it could tab complete the sub-commands
+.Ic list ,
+.Ic show ,
+and
+.Ic drop .
+.Pp
+In addition to literal words we expect to see in the command,
+we can use variables that represent particular types of argument.
+For example, the
+.Xr git-add 1
+command expects a file path as an argument:
+.Bd -literal -offset -indent
+add $path
+.Ed
+.Pp
+See the section on
+.Sx VARIABLES
+for a complete list of what's supported.
+.Pp
+Some arguments are optional, and others can be repeated.
+This can be specified using operators similar to those provided by
+regular expressions. To expand the previous example,
+.Xr git-add 1
+can accept one or more paths:
+.Bd -literal -offset -indent
+add  $path+
+.Ed
+.Pp
+In this example, the
+.Ic +
+operator modifies the meaning of the argument.
+See the section on
+.Sx OPERATORS
+for a complete list of what's supported.
+.Pp
+.
+.Sh OPERATORS
+The following operators are supported. They have similar semantics to regular
+expressions, except that they operate on an entire word instead of a single
+character.
+.Bl -tag -width Ds
+.It Ic word+
+Indicates that
+.Ic word
+can appear one or more times. In other words,
+.Ic word
+is required but can be repeated.
+.It Ic (first|second)
+Indicates that either
+.Ic first
+or
+.Ic second
+may appear. Unlike regular expressions, the surrounding parentheses are
+required, and this is the only context in which parentheses may be used.
+.El
+.Pp
+The post-fix
+.Ic +
+operator may be applied to a list of options, but the
+options inside the list must be literals or variables.
+.
+.Sh VARIABLES
+Variables represent types of arguments that we want to tab complete in a
+.Xr gitsh 1
+session.
+.Pp
+Variables are more permissive when they are matching the context before a
+completion than when they are generating completions. For example, consider
+the following rules:
+.Bd -literal -offset -indent
+diff $revision $path
+
+diff $path
+.Ed
+.Pp
+If the user enters
+.Ic diff ,
+followed by a space, and presses the tab key, then the
+.Ic $revision
+variable will produce the names of revisions in the repository as possible
+completions.
+However, if the user enters
+.Ic diff my-branch ,
+followed by a space, and presses the tab key, then the
+.Ic $revision
+variable will match the input
+.Ic my-branch
+regardless of whether or not it's a valid revision name.
+.Xr gitsh 1
+will assume the revision argument has been provided, and present completions
+for the
+.Ic $path
+variable.
+.Pp
+The role of the tab completion system is to understand the structure of
+commands and present useful options; it can leave the validation of the user's
+input to Git.
+.Pp
+The following variables are supported:
+.Bl -tag -width Ds
+.It Ic $command
+Produces the names of Git commands. This includes any custom Git commands found
+on the user's
+.Ev PATH ,
+the user's Git aliases, and internal gitsh commands.
+.It Ic $path
+Produces paths to files and directories, relative to the current working
+directory.
+.It Ic $remote
+Produces the names of Git remotes in the current repository.
+.It Ic $revision
+Produces various names for Git revisions, including the names of local
+branches, remote tracking branches, and tags.
+.Pp
+The completion options produced by this variable will also try to take
+punctuation into account. For example, if the word being completed is
+.Ic master..my-f ,
+and there is a local branch called
+.Ic my-feature ,
+then the completions would include
+.Ic master..my-feature .
+.El
+.
+.Sh FILES
+.Bl -tag -width Ds
+.It Pa @pkgsysconfdir@/completions
+System-wide tab completions file, which defines the tab completion options
+for popular Git commands.
+.El
+.
+.Sh EXAMPLES
+The
+.Xr git-add 1
+command takes one or more file system paths.
+.Pp
+This argument scheme is represented as:
+.Bd -literal -offset -indent
+add $path+
+.Ed
+.Pp
+I have a custom command called
+.Ic git browse ,
+which takes two arguments: an optional Git revision, followed by a single
+file system path.
+.Pp
+I can add this to my
+.Ic gitsh_completions
+file as:
+.Bd -literal -offset -indent
+browse $revision $path
+
+browse $path
+.Ed
+.
+.Sh SEE ALSO
+.Xr gitsh 1
+.
+.Sh AUTHORS
+.An George Brocklehurst Aq george@thoughtbot.com
+.An thoughtbot Aq hello@thoughtbot.com

--- a/spec/support/gitsh_runner.rb
+++ b/spec/support/gitsh_runner.rb
@@ -104,7 +104,8 @@ class GitshRunner
     @env ||= Gitsh::Environment.new(
       input_stream: input_stream,
       output_stream: output_stream,
-      error_stream: error_stream
+      error_stream: error_stream,
+      config_directory: File.expand_path('../../../etc', __FILE__),
     ).tap do |env|
       env['gitsh.historyFile'] = File.join(Dir.tmpdir, 'gitsh_test_history')
       options.fetch(:settings, {}).each do |key, value|

--- a/spec/support/produce_tokens_matcher.rb
+++ b/spec/support/produce_tokens_matcher.rb
@@ -1,0 +1,9 @@
+RSpec::Matchers.define(:produce_tokens) do |expected|
+  match do |actual|
+    @expected = expected.join("\n")
+    @actual = described_class.lex(actual).map(&:to_s).join("\n")
+    values_match? @expected, @actual
+  end
+
+  diffable
+end

--- a/spec/support/tab_completion.rb
+++ b/spec/support/tab_completion.rb
@@ -1,0 +1,12 @@
+module TabCompletionHelpers
+  def stub_text_matcher(text)
+    klass = Gitsh::TabCompletion::Matchers::TextMatcher
+    matcher = instance_double(klass)
+    allow(klass).to receive(:new).with(text).and_return(matcher)
+    matcher
+  end
+end
+
+RSpec.configure do |config|
+  config.include TabCompletionHelpers
+end

--- a/spec/units/environment_spec.rb
+++ b/spec/units/environment_spec.rb
@@ -174,6 +174,20 @@ describe Gitsh::Environment do
     end
   end
 
+  describe '#config_directory' do
+    it 'defaults to "/usr/local/etc/gitsh"' do
+      env = described_class.new
+
+      expect(env.config_directory).to eq '/usr/local/etc/gitsh'
+    end
+
+    it 'can be overridden with an initializer argument' do
+      env = described_class.new(config_directory: '/custom/prefix/etc/gitsh')
+
+      expect(env.config_directory).to eq '/custom/prefix/etc/gitsh'
+    end
+  end
+
   describe '#print' do
     it 'prints to the output stream' do
       output = StringIO.new

--- a/spec/units/lexer_spec.rb
+++ b/spec/units/lexer_spec.rb
@@ -1,16 +1,6 @@
 require 'spec_helper'
 require 'gitsh/lexer'
 
-RSpec::Matchers.define(:produce_tokens) do |expected|
-  match do |actual|
-    @expected = expected.join("\n")
-    @actual = Gitsh::Lexer.lex(actual).map(&:to_s).join("\n")
-    values_match? @expected, @actual
-  end
-
-  diffable
-end
-
 describe Gitsh::Lexer do
   describe '.lex' do
     it 'recognises space separated words' do

--- a/spec/units/tab_completion/automaton_factory_spec.rb
+++ b/spec/units/tab_completion/automaton_factory_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/automaton_factory'
+
+describe Gitsh::TabCompletion::AutomatonFactory do
+  describe '.build' do
+    it 'laods the tab completion DSL file' do
+      config_directory = '/tmp/etc/gitsh'
+      env = double(:env, config_directory: config_directory)
+      start_state = stub_automaton_state
+      automaton = stub_automaton
+      stub_dsl_loading
+      config_path = File.join(config_directory, 'completions')
+
+      result = described_class.build(env)
+
+      expect(result).to eq(automaton)
+      expect(Gitsh::TabCompletion::Automaton).
+        to have_received(:new).with(start_state)
+      expect(Gitsh::TabCompletion::DSL).
+        to have_received(:load).with(config_path, start_state, env)
+    end
+  end
+
+  def stub_automaton_state
+    stub_class(Gitsh::TabCompletion::Automaton::State)
+  end
+
+  def stub_automaton
+    stub_class(Gitsh::TabCompletion::Automaton)
+  end
+
+  def stub_dsl_loading
+    allow(Gitsh::TabCompletion::DSL).to receive(:load)
+  end
+
+  def stub_class(klass)
+    instance = instance_double(klass)
+    allow(klass).to receive(:new).and_return(instance)
+    instance
+  end
+end

--- a/spec/units/tab_completion/dsl/choice_factory_spec.rb
+++ b/spec/units/tab_completion/dsl/choice_factory_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl/choice_factory'
+
+describe Gitsh::TabCompletion::DSL::ChoiceFactory do
+  describe '#build' do
+    it 'applies all of the choice factories to the same end state' do
+      start_state = double(:start_state)
+      first_choice = double(:first_choice, build: nil)
+      second_choice = double(:second_choice, build: nil)
+      factory = described_class.new([first_choice, second_choice])
+
+      end_state = factory.build(start_state, option: 'baz')
+
+      expect(end_state).to be_a(Gitsh::TabCompletion::Automaton::State)
+      expect(first_choice).to have_received(:build).with(
+        start_state,
+        end_state: end_state,
+        option: 'baz',
+      )
+      expect(second_choice).to have_received(:build).with(
+        start_state,
+        end_state: end_state,
+        option: 'baz',
+      )
+    end
+
+    context 'given an end state' do
+      it 'applies all of the choice factories to the given end state' do
+        start_state = double(:start_state)
+        end_state = double(:end_state)
+        first_choice = double(:first_choice, build: nil)
+        second_choice = double(:second_choice, build: nil)
+        factory = described_class.new([first_choice, second_choice])
+
+        result = factory.build(start_state, option: 'baz', end_state: end_state)
+
+        expect(result).to eq(end_state)
+        expect(first_choice).to have_received(:build).with(
+          start_state,
+          end_state: end_state,
+          option: 'baz',
+        )
+        expect(second_choice).to have_received(:build).with(
+          start_state,
+          end_state: end_state,
+          option: 'baz',
+        )
+      end
+    end
+  end
+end

--- a/spec/units/tab_completion/dsl/concatenation_factory_spec.rb
+++ b/spec/units/tab_completion/dsl/concatenation_factory_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl/concatenation_factory'
+
+describe Gitsh::TabCompletion::DSL::ConcatenationFactory do
+  describe '#build' do
+    it 'connects the various parts in a sequence, and returns the end state' do
+      start_state = double(:start_state)
+      end_state_1 = double(:end_state_1)
+      part_1 = double(:factory, build: end_state_1)
+      end_state_2 = double(:end_state_2)
+      part_2 = double(:factory, build: end_state_2)
+      factory = described_class.new([part_1, part_2])
+
+      result = factory.build(start_state, option: 'foo')
+
+      expect(part_1).to have_received(:build).
+        with(start_state, option: 'foo')
+      expect(part_2).to have_received(:build).
+        with(end_state_1, option: 'foo')
+      expect(result).to eq(end_state_2)
+    end
+
+    context 'given an explicit end state' do
+      it 'connects the various parts in a sequence ending at the end state' do
+        start_state = double(:start_state)
+        end_state = double(:end_state)
+        end_state_1 = double(:end_state_1)
+        part_1 = double(:factory, build: end_state_1)
+        end_state_2 = double(:end_state_2, add_free_transition: nil)
+        part_2 = double(:factory, build: end_state_2)
+        factory = described_class.new([part_1, part_2])
+
+        result = factory.build(start_state, option: 'foo', end_state: end_state)
+
+        expect(part_1).to have_received(:build).
+          with(start_state, option: 'foo')
+        expect(part_2).to have_received(:build).
+          with(end_state_1, option: 'foo')
+        expect(end_state_2).to have_received(:add_free_transition).
+          with(end_state)
+        expect(result).to eq(end_state)
+      end
+    end
+  end
+end

--- a/spec/units/tab_completion/dsl/lexer_spec.rb
+++ b/spec/units/tab_completion/dsl/lexer_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl/lexer'
+
+describe Gitsh::TabCompletion::DSL::Lexer do
+  describe '.lex' do
+    it 'recognises space separated words' do
+      expect('stash pop').to produce_tokens ['WORD(stash)', 'WORD(pop)', 'EOS']
+    end
+
+    it 'recognises variables' do
+      expect('add $path').to produce_tokens ['WORD(add)', 'VAR(path)', 'EOS']
+    end
+
+    it 'recognises the plus operator' do
+      expect('add+ $path+').
+        to produce_tokens ['WORD(add)', 'PLUS', 'VAR(path)', 'PLUS', 'EOS']
+    end
+
+    it 'recognises the pipe operator' do
+      expect('stash pop|drop').to produce_tokens [
+        'WORD(stash)', 'WORD(pop)', 'OR', 'WORD(drop)', 'EOS',
+      ]
+    end
+
+    it 'recognises parentheses' do
+      expect('(add|commit)').to produce_tokens [
+        'LEFT_PAREN', 'WORD(add)', 'OR', 'WORD(commit)', 'RIGHT_PAREN', 'EOS',
+      ]
+    end
+
+    it 'recognises blank lines' do
+      expect("push\n\npull").
+        to produce_tokens ['WORD(push)', 'BLANK', 'WORD(pull)', 'EOS']
+      expect("push  \n  \npull").
+        to produce_tokens ['WORD(push)', 'BLANK', 'WORD(pull)', 'EOS']
+    end
+
+    it 'ignores comments' do
+      expect('# comment').to produce_tokens ['EOS']
+      expect("# comment\npush").to produce_tokens ['WORD(push)', 'EOS']
+      expect("push\n\n# comment\npull").
+        to produce_tokens ['WORD(push)', 'BLANK', 'WORD(pull)', 'EOS']
+    end
+  end
+end

--- a/spec/units/tab_completion/dsl/parser_spec.rb
+++ b/spec/units/tab_completion/dsl/parser_spec.rb
@@ -1,0 +1,133 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl/parser'
+
+describe Gitsh::TabCompletion::DSL::Parser do
+  describe '.parse' do
+    it 'parses single words' do
+      result = parse_single_rule(tokens([:WORD, 'stash'], [:EOS]))
+
+      expect(result).to be_a_text_transition
+      expect(result.word).to eq('stash')
+    end
+
+    it 'parses single variables' do
+      result = parse_single_rule(tokens([:VAR, 'revision'], [:EOS]))
+
+      expect(result).to be_a_variable_transition
+      expect(result.matcher).to be_a_revision_matcher
+    end
+
+    it 'parses rules with multiple words and variables' do
+      result = parse_single_rule(tokens(
+        [:WORD, 'stash'], [:WORD, 'pop'], [:VAR, 'revision'], [:EOS],
+      ))
+
+      expect(result).to be_a_concatenation
+      expect(result.parts.length).to eq(3)
+      expect(result.parts.first).to be_a_text_transition
+      expect(result.parts.first.word).to eq('stash')
+    end
+
+    it 'parses rules with the plus operator' do
+      result = parse_single_rule(tokens([:WORD, 'verbose'], [:PLUS], [:EOS]))
+
+      expect(result).to be_a_plus_operation
+      expect(result.child).to be_a_text_transition
+      expect(result.child.word).to eq('verbose')
+    end
+
+    it 'parses rules with the pipe operator' do
+      result = parse_single_rule(tokens(
+        [:LEFT_PAREN], [:WORD, 'commit'], [:OR],
+        [:WORD, 'add'], [:OR], [:VAR, 'path'], [:RIGHT_PAREN], [:EOS],
+      ))
+
+      expect(result).to be_a_choice
+      expect(result.choices.length).to eq(3)
+      expect(result.choices.first).to be_a_text_transition
+      expect(result.choices.first.word).to eq('commit')
+      expect(result.choices.last).to be_a_variable_transition
+      expect(result.choices.last.matcher).to be_a_path_matcher
+    end
+
+    it 'parses rules with the pipe operator and multiple words' do
+      result = parse_single_rule(tokens(
+        [:LEFT_PAREN], [:WORD, 'stash'], [:WORD, 'pop'], [:OR],
+        [:WORD, 'add'], [:RIGHT_PAREN], [:EOS],
+      ))
+
+      expect(result).to be_a_choice
+      expect(result.choices.length).to eq(2)
+      expect(result.choices.first).to be_a_concatenation
+      expect(result.choices.first.parts.first).to be_a_text_transition
+      expect(result.choices.first.parts.first.word).to eq('stash')
+    end
+
+    it 'parses rules combining the pipe operator and a post-fix operator' do
+      result = parse_single_rule(tokens(
+        [:LEFT_PAREN], [:WORD, 'add'], [:OR], [:WORD, 'commit'], [:RIGHT_PAREN],
+        [:PLUS], [:EOS],
+      ))
+
+      expect(result).to be_a_plus_operation
+      expect(result.child).to be_a_choice
+      expect(result.child.choices.length).to eq(2)
+    end
+
+    it 'parses multiple rules in the same input' do
+      result = described_class.parse(tokens(
+        [:WORD, 'push'], [:BLANK],
+        [:WORD, 'pull'], [:BLANK], [:BLANK],
+        [:WORD, 'fetch'], [:EOS],
+      ), gitsh_env: double(:env))
+
+      expect(result).to be_a_rule_set_factory
+      expect(result.rules.length).to eq(3)
+      expect(result.rules.first).to be_a_rule_factory
+      expect(result.rules.last).to be_a_rule_factory
+    end
+  end
+
+  def parse_single_rule(tokens)
+    env = double(:env)
+    result = described_class.parse(tokens, gitsh_env: env)
+    expect(result).to be_a_rule_set_factory
+    result.rules.first.root
+  end
+
+  def be_a_rule_set_factory
+    be_a(Gitsh::TabCompletion::DSL::RuleSetFactory)
+  end
+
+  def be_a_rule_factory
+    be_a(Gitsh::TabCompletion::DSL::RuleFactory)
+  end
+
+  def be_a_text_transition
+    be_a(Gitsh::TabCompletion::DSL::TextTransitionFactory)
+  end
+
+  def be_a_variable_transition
+    be_a(Gitsh::TabCompletion::DSL::VariableTransitionFactory)
+  end
+
+  def be_a_concatenation
+    be_a(Gitsh::TabCompletion::DSL::ConcatenationFactory)
+  end
+
+  def be_a_plus_operation
+    be_a(Gitsh::TabCompletion::DSL::PlusOperationFactory)
+  end
+
+  def be_a_choice
+    be_a(Gitsh::TabCompletion::DSL::ChoiceFactory)
+  end
+
+  def be_a_revision_matcher
+    be_a(Gitsh::TabCompletion::Matchers::RevisionMatcher)
+  end
+
+  def be_a_path_matcher
+    be_a(Gitsh::TabCompletion::Matchers::PathMatcher)
+  end
+end

--- a/spec/units/tab_completion/dsl/plus_operation_factory_spec.rb
+++ b/spec/units/tab_completion/dsl/plus_operation_factory_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl/plus_operation_factory'
+
+describe Gitsh::TabCompletion::DSL::PlusOperationFactory do
+  describe '#build' do
+    it 'calls the child factory and adds a free transition' do
+      start_state = double(:start_state)
+      end_state = double(:end_state, add_free_transition: nil)
+      child = double(:factory, build: end_state)
+      factory = described_class.new(child)
+
+      result = factory.build(start_state, option: 'bar')
+
+      expect(result).to eq(end_state)
+      expect(child).to have_received(:build).with(start_state, option: 'bar')
+      expect(end_state).to have_received(:add_free_transition).with(start_state)
+    end
+  end
+end

--- a/spec/units/tab_completion/dsl/rule_factory_spec.rb
+++ b/spec/units/tab_completion/dsl/rule_factory_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl/rule_factory'
+
+describe Gitsh::TabCompletion::DSL::RuleFactory do
+  describe '#build' do
+    it "delegates to the rule's root factory" do
+      start_state = double(:start_state)
+      root = double(:factory, build: nil)
+      factory = described_class.new(root)
+
+      factory.build(start_state)
+
+      expect(root).to have_received(:build).with(start_state)
+    end
+  end
+end

--- a/spec/units/tab_completion/dsl/rule_set_factory_spec.rb
+++ b/spec/units/tab_completion/dsl/rule_set_factory_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl/rule_set_factory'
+require 'gitsh/tab_completion/dsl/rule_factory'
+
+describe Gitsh::TabCompletion::DSL::RuleSetFactory do
+  describe '#build' do
+    it 'delegates to the various rule factories' do
+      start_state = double(:start_state)
+      rule_factory_1 = stub_rule_factory
+      rule_factory_2 = stub_rule_factory
+      factory = described_class.new([rule_factory_1, rule_factory_2])
+
+      factory.build(start_state)
+
+      expect(rule_factory_1).to have_received(:build).with(start_state).once
+      expect(rule_factory_2).to have_received(:build).with(start_state).once
+    end
+  end
+
+  def stub_rule_factory
+    instance_double(
+      Gitsh::TabCompletion::DSL::RuleFactory,
+      build: nil,
+    )
+  end
+end

--- a/spec/units/tab_completion/dsl/text_transition_factory_spec.rb
+++ b/spec/units/tab_completion/dsl/text_transition_factory_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl/text_transition_factory'
+
+describe Gitsh::TabCompletion::DSL::TextTransitionFactory do
+  describe '#build' do
+    it 'adds a transition to the start state and returns the end state' do
+      start_state = double(:start_state, add_transition: nil)
+      matcher = stub_text_matcher('commit')
+      factory = described_class.new('commit')
+
+      end_state = factory.build(start_state)
+
+      expect(end_state).to be_a(Gitsh::TabCompletion::Automaton::State)
+      expect(start_state).
+        to have_received(:add_transition).with(matcher, end_state)
+    end
+
+    context 'given an end state' do
+      it 'adds a transition between the start and end states' do
+        start_state = double(:start_state, add_transition: nil)
+        end_state = double(:end_state)
+        matcher = stub_text_matcher('commit')
+        factory = described_class.new('commit')
+
+        result = factory.build(start_state, end_state: end_state)
+
+        expect(result).to eq(end_state)
+        expect(start_state).
+          to have_received(:add_transition).with(matcher, end_state)
+      end
+    end
+  end
+end

--- a/spec/units/tab_completion/dsl/variable_transition_factory_spec.rb
+++ b/spec/units/tab_completion/dsl/variable_transition_factory_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl/variable_transition_factory'
+
+describe Gitsh::TabCompletion::DSL::VariableTransitionFactory do
+  describe '#build' do
+    it 'adds a transition to the start state and returns the end state' do
+      matcher = double(:matcher, name: 'my-matcher')
+      start_state = double(:start_state, add_transition: nil)
+      factory = described_class.new(matcher)
+
+      end_state = factory.build(start_state)
+
+      expect(end_state).to be_a(Gitsh::TabCompletion::Automaton::State)
+      expect(start_state).
+        to have_received(:add_transition).with(matcher, end_state)
+    end
+
+    context 'given an end state' do
+      it 'adds a transition between the start and end states' do
+        matcher = double(:matcher, name: 'my-matcher')
+        start_state = double(:start_state, add_transition: nil)
+        end_state = double(:end_state)
+        factory = described_class.new(matcher)
+
+        result = factory.build(start_state, end_state: end_state)
+
+        expect(result).to eq(end_state)
+        expect(start_state).
+          to have_received(:add_transition).with(matcher, end_state)
+      end
+    end
+  end
+end

--- a/spec/units/tab_completion/dsl_spec.rb
+++ b/spec/units/tab_completion/dsl_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl'
+
+describe Gitsh::TabCompletion::DSL do
+  describe '.load' do
+    it 'builds a graph of automaton states by reading the given file' do
+      path = write_temp_completions_file([
+        'stash (apply|drop|pop|show)',
+      ].join("\n"))
+      start_state = Gitsh::TabCompletion::Automaton::State.new('start')
+      env = Gitsh::Environment.new
+
+      described_class.load(path, start_state, env)
+
+      automaton = Gitsh::TabCompletion::Automaton.new(start_state)
+      expect(automaton.completions([], '')).
+        to match_array ['stash']
+      expect(automaton.completions(['stash'], '')).
+        to match_array ['apply', 'drop', 'pop', 'show']
+    end
+
+    context 'with a path to a file that does not exist' do
+      it 'does not explode' do
+        path = '/not/a/real/path'
+        start_state = Gitsh::TabCompletion::Automaton::State.new('start')
+        env = Gitsh::Environment.new
+
+        expect { described_class.load(path, start_state, env) }.
+          not_to raise_exception
+      end
+    end
+  end
+
+  def write_temp_completions_file(completions)
+    temp_file('gitsh_completions', completions).path
+  end
+end

--- a/spec/units/tab_completion/matchers/path_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/path_matcher_spec.rb
@@ -4,7 +4,7 @@ require 'gitsh/tab_completion/matchers/path_matcher'
 describe Gitsh::TabCompletion::Matchers::PathMatcher do
   describe '#match?' do
     it 'always returns true' do
-      matcher = described_class.new
+      matcher = described_class.new(double(:env))
 
       expect(matcher.match?('foo')).to be_truthy
       expect(matcher.match?('')).to be_truthy
@@ -18,7 +18,7 @@ describe Gitsh::TabCompletion::Matchers::PathMatcher do
         write_file('foo/first.txt')
         write_file('foo/second.txt')
         write_file('first.txt')
-        matcher = described_class.new
+        matcher = described_class.new(double(:env))
 
         expect(matcher.completions('f')).to match_array ['foo/', 'first.txt']
         expect(matcher.completions('foo')).to match_array ['foo/']
@@ -30,14 +30,14 @@ describe Gitsh::TabCompletion::Matchers::PathMatcher do
 
   describe '#eql?' do
     it 'returns true when given another instance of the same class' do
-      matcher1 = described_class.new
-      matcher2 = described_class.new
+      matcher1 = described_class.new(double(:env))
+      matcher2 = described_class.new(double(:env))
 
       expect(matcher1).to eql(matcher2)
     end
 
     it 'returns false when given an instance of any other class' do
-      matcher = described_class.new
+      matcher = described_class.new(double(:env))
       other = double(:not_a_matcher)
 
       expect(matcher).not_to eql(other)
@@ -46,8 +46,8 @@ describe Gitsh::TabCompletion::Matchers::PathMatcher do
 
   describe '#hash' do
     it 'returns the same value for all instances of the class' do
-      matcher1 = described_class.new
-      matcher2 = described_class.new
+      matcher1 = described_class.new(double(:env))
+      matcher2 = described_class.new(double(:env))
 
       expect(matcher1.hash).to eq(matcher2.hash)
     end

--- a/src/gitsh.rb.in
+++ b/src/gitsh.rb.in
@@ -3,10 +3,12 @@
 $LOAD_PATH.unshift('@rubylibdir@')
 
 require '@gemsetuppath@'
+require 'gitsh/environment'
 require 'gitsh/cli'
 
 begin
-  Gitsh::CLI.new.run
+  env = Gitsh::Environment.new(config_directory: '@pkgsysconfdir@')
+  Gitsh::CLI.new(env: env).run
 rescue => e
   $stderr.puts "gitsh: Error: #{e.message}"
   exit 1


### PR DESCRIPTION
#296 introduced a non-deterministic finite automaton as the basis of the tab completion system. This PR is the next step in my grand plan for tab completion: it introduces a DSL for loading the NFA's state graph from a configuration file.

The DSL format is described in the `gitsh_completions.5` manual page, which is added in this PR.

The configuration file included in this PR (`etc/completions`) results in a graph very similar to the one that was hard coded prior to the introduction of the DSL. Subsequent PRs will add features to the DSL so it can be used for more complex graphs that produce better tab completion behaviour.

Note that I'm not using DSL in the sense it's usually used with Ruby: this language has a lexer and a parser, it's not just a pretty looking Ruby API.