### PR TITLE
Add * and ? operators to git_completions(5)

### DIFF
--- a/etc/completions
+++ b/etc/completions
@@ -1,1 +1,1 @@
-$command ($revision|$path|$remote)+
+$command ($revision|$path|$remote)* --? $path+

--- a/lib/gitsh/tab_completion/automaton.rb
+++ b/lib/gitsh/tab_completion/automaton.rb
@@ -7,14 +7,14 @@ module Gitsh
         @start_state = start_state
       end
 
+      def completions(context, token)
+        match(context).flat_map { |state| state.completions(token) }.uniq
+      end
+
       def match(tokens)
         tokens.inject(start_states) do |current_states, token|
           current_states.map { |state| state.follow(token) }.inject(Set.new, :|)
         end
-      end
-
-      def completions(context, token)
-        match(context).flat_map { |state| state.completions(token) }
       end
 
       def accept_visitor(visitor)

--- a/lib/gitsh/tab_completion/dsl/lexer.rb
+++ b/lib/gitsh/tab_completion/dsl/lexer.rb
@@ -5,8 +5,10 @@ module Gitsh
     module DSL
       class Lexer < RLTK::Lexer
         rule(/\$[a-z_]+/) { |t| [:VAR, t[1..-1]] }
-        rule(/[^\s*+|()#]+/) { |t| [:WORD, t] }
+        rule(/[^\s*+?|()#]+/) { |t| [:WORD, t] }
+        rule(/\*/) { :STAR }
         rule(/\+/) { :PLUS }
+        rule(/\?/) { :MAYBE }
         rule(/\|/) { :OR }
         rule(/\(/) { :LEFT_PAREN }
         rule(/\)/) { :RIGHT_PAREN }

--- a/lib/gitsh/tab_completion/dsl/maybe_operation_factory.rb
+++ b/lib/gitsh/tab_completion/dsl/maybe_operation_factory.rb
@@ -1,0 +1,19 @@
+module Gitsh
+  module TabCompletion
+    module DSL
+      class MaybeOperationFactory
+        attr_reader :child
+
+        def initialize(child)
+          @child = child
+        end
+
+        def build(start_state, options = {})
+          end_state = child.build(start_state, options)
+          start_state.add_free_transition(end_state)
+          end_state
+        end
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/dsl/parser.rb
+++ b/lib/gitsh/tab_completion/dsl/parser.rb
@@ -1,9 +1,11 @@
 require 'rltk'
 require 'gitsh/tab_completion/dsl/choice_factory'
 require 'gitsh/tab_completion/dsl/concatenation_factory'
+require 'gitsh/tab_completion/dsl/maybe_operation_factory'
 require 'gitsh/tab_completion/dsl/plus_operation_factory'
 require 'gitsh/tab_completion/dsl/rule_factory'
 require 'gitsh/tab_completion/dsl/rule_set_factory'
+require 'gitsh/tab_completion/dsl/star_operation_factory'
 require 'gitsh/tab_completion/dsl/text_transition_factory'
 require 'gitsh/tab_completion/dsl/variable_transition_factory'
 require 'gitsh/tab_completion/matchers/command_matcher'
@@ -77,7 +79,9 @@ module Gitsh
 
         production(:term) do
           clause('item') { |factory| factory }
+          clause('.item STAR') { |factory| StarOperationFactory.new(factory) }
           clause('.item PLUS') { |factory| PlusOperationFactory.new(factory) }
+          clause('.item MAYBE') { |factory| MaybeOperationFactory.new(factory) }
         end
 
         production(:item) do

--- a/lib/gitsh/tab_completion/dsl/star_operation_factory.rb
+++ b/lib/gitsh/tab_completion/dsl/star_operation_factory.rb
@@ -1,0 +1,17 @@
+module Gitsh
+  module TabCompletion
+    module DSL
+      class StarOperationFactory
+        attr_reader :child
+
+        def initialize(child)
+          @child = child
+        end
+
+        def build(start_state, options = {})
+          child.build(start_state, options.merge(end_state: start_state))
+        end
+      end
+    end
+  end
+end

--- a/man/man5/gitsh_completions.5.in
+++ b/man/man5/gitsh_completions.5.in
@@ -1,4 +1,4 @@
-.Dd June 29, 2017
+.Dd July 3, 2017
 .Dt GITSH_COMPLETIONS 5
 .Os
 .Sh NAME
@@ -65,14 +65,18 @@ Some arguments are optional, and others can be repeated.
 This can be specified using operators similar to those provided by
 regular expressions. To expand the previous example,
 .Xr git-add 1
-can accept one or more paths:
+can accept one or more paths preceded by an optional
+.Ic "--"
+token:
 .Bd -literal -offset -indent
-add  $path+
+add --? $path+
 .Ed
 .Pp
 In this example, the
+.Ic ?
+and
 .Ic +
-operator modifies the meaning of the argument.
+operators modify the meaning of the literal and variable arguments.
 See the section on
 .Sx OPERATORS
 for a complete list of what's supported.
@@ -83,6 +87,18 @@ The following operators are supported. They have similar semantics to regular
 expressions, except that they operate on an entire word instead of a single
 character.
 .Bl -tag -width Ds
+.It Ic word?
+Indicates that
+.Ic word
+can appear zero or one times. In other words,
+.Ic word
+is optional.
+.It Ic word*
+Indicates that
+.Ic word
+can appear zero or more times. In other words,
+.Ic word
+is optional and can be repeated.
 .It Ic word+
 Indicates that
 .Ic word
@@ -98,9 +114,7 @@ may appear. Unlike regular expressions, the surrounding parentheses are
 required, and this is the only context in which parentheses may be used.
 .El
 .Pp
-The post-fix
-.Ic +
-operator may be applied to a list of options, but the
+The various post-fix operators may be applied to a list of options, but the
 options inside the list must be literals or variables.
 .
 .Sh VARIABLES
@@ -110,11 +124,9 @@ session.
 .Pp
 Variables are more permissive when they are matching the context before a
 completion than when they are generating completions. For example, consider
-the following rules:
+the following rule:
 .Bd -literal -offset -indent
-diff $revision $path
-
-diff $path
+diff $revision? $path
 .Ed
 .Pp
 If the user enters
@@ -175,11 +187,13 @@ for popular Git commands.
 .Sh EXAMPLES
 The
 .Xr git-add 1
-command takes one or more file system paths.
+command takes an optional
+.Ic -- ,
+followed by one or more file system paths.
 .Pp
 This argument scheme is represented as:
 .Bd -literal -offset -indent
-add $path+
+add --? $path+
 .Ed
 .Pp
 I have a custom command called
@@ -191,9 +205,7 @@ I can add this to my
 .Ic gitsh_completions
 file as:
 .Bd -literal -offset -indent
-browse $revision $path
-
-browse $path
+browse $revision? $path
 .Ed
 .
 .Sh SEE ALSO

--- a/spec/units/tab_completion/automaton_spec.rb
+++ b/spec/units/tab_completion/automaton_spec.rb
@@ -91,6 +91,24 @@ describe Gitsh::TabCompletion::Automaton do
         expect(automaton.completions(['foo'], '')).to eq []
       end
     end
+
+    it 'filters out duplicates' do
+      #       ,--- aa ---,
+      #       |          v
+      # ---> (0)        (1) --- aa ---> (2)
+      #       |          ^
+      #       '----------'
+
+      state_0 = described_class::State.new(0)
+      state_1 = described_class::State.new(1)
+      state_2 = described_class::State.new(2)
+      add_text_transition(state_0, 'aa', state_1)
+      state_0.add_free_transition(state_1)
+      add_text_transition(state_1, 'aa', state_2)
+      automaton = described_class.new(state_0)
+
+      expect(automaton.completions([], '')).to eq ['aa']
+    end
   end
 
   describe '#accept_visitor' do

--- a/spec/units/tab_completion/dsl/lexer_spec.rb
+++ b/spec/units/tab_completion/dsl/lexer_spec.rb
@@ -11,9 +11,19 @@ describe Gitsh::TabCompletion::DSL::Lexer do
       expect('add $path').to produce_tokens ['WORD(add)', 'VAR(path)', 'EOS']
     end
 
+    it 'recognises the asterisk operator' do
+      expect('add* $path*').
+        to produce_tokens ['WORD(add)', 'STAR', 'VAR(path)', 'STAR', 'EOS']
+    end
+
     it 'recognises the plus operator' do
       expect('add+ $path+').
         to produce_tokens ['WORD(add)', 'PLUS', 'VAR(path)', 'PLUS', 'EOS']
+    end
+
+    it 'recognises the question mark operator' do
+      expect('add? $path?').
+        to produce_tokens ['WORD(add)', 'MAYBE', 'VAR(path)', 'MAYBE', 'EOS']
     end
 
     it 'recognises the pipe operator' do

--- a/spec/units/tab_completion/dsl/maybe_operation_factory_spec.rb
+++ b/spec/units/tab_completion/dsl/maybe_operation_factory_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl/maybe_operation_factory'
+
+describe Gitsh::TabCompletion::DSL::MaybeOperationFactory do
+  describe '#build' do
+    it 'calls the child factory and adds a free transition' do
+      start_state = double(:start_state, add_free_transition: nil)
+      end_state = double(:end_state)
+      child = double(:factory, build: end_state)
+      factory = described_class.new(child)
+
+      result = factory.build(start_state, answer: 42)
+
+      expect(result).to eq(end_state)
+      expect(child).to have_received(:build).with(start_state, answer: 42)
+      expect(start_state).to have_received(:add_free_transition).with(end_state)
+    end
+  end
+end

--- a/spec/units/tab_completion/dsl/parser_spec.rb
+++ b/spec/units/tab_completion/dsl/parser_spec.rb
@@ -28,10 +28,26 @@ describe Gitsh::TabCompletion::DSL::Parser do
       expect(result.parts.first.word).to eq('stash')
     end
 
+    it 'parses rules with the asterisk operator' do
+      result = parse_single_rule(tokens([:WORD, 'verbose'], [:STAR], [:EOS]))
+
+      expect(result).to be_a_star_operation
+      expect(result.child).to be_a_text_transition
+      expect(result.child.word).to eq('verbose')
+    end
+
     it 'parses rules with the plus operator' do
       result = parse_single_rule(tokens([:WORD, 'verbose'], [:PLUS], [:EOS]))
 
       expect(result).to be_a_plus_operation
+      expect(result.child).to be_a_text_transition
+      expect(result.child.word).to eq('verbose')
+    end
+
+    it 'parses rules with the question mark operator' do
+      result = parse_single_rule(tokens([:WORD, 'verbose'], [:MAYBE], [:EOS]))
+
+      expect(result).to be_a_maybe_operation
       expect(result.child).to be_a_text_transition
       expect(result.child.word).to eq('verbose')
     end
@@ -115,8 +131,16 @@ describe Gitsh::TabCompletion::DSL::Parser do
     be_a(Gitsh::TabCompletion::DSL::ConcatenationFactory)
   end
 
+  def be_a_star_operation
+    be_a Gitsh::TabCompletion::DSL::StarOperationFactory
+  end
+
   def be_a_plus_operation
     be_a(Gitsh::TabCompletion::DSL::PlusOperationFactory)
+  end
+
+  def be_a_maybe_operation
+    be_a(Gitsh::TabCompletion::DSL::MaybeOperationFactory)
   end
 
   def be_a_choice

--- a/spec/units/tab_completion/dsl/star_operation_factory_spec.rb
+++ b/spec/units/tab_completion/dsl/star_operation_factory_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl/star_operation_factory'
+
+describe Gitsh::TabCompletion::DSL::StarOperationFactory do
+  describe '#build' do
+    it 'calls the child factory with the start state as the end state' do
+      start_state = double(:start_state)
+      child_result = double(:child_result)
+      child = double(:factory, build: child_result)
+      factory = described_class.new(child)
+
+      result = factory.build(start_state, option: 'foo')
+
+      expect(result).to eq child_result
+      expect(child).to have_received(:build).with(
+        start_state,
+        end_state: start_state,
+        option: 'foo',
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for the `*` operator (zero or more times), and the `?` operator (zero or one times) to the gitsh tab completion DSL.

It also adds filtering for duplicate options, otherwise the more complex graphs enabled by the DSL changes can cause problems with path completion (see commit message for more details).

---

In order to motivate this change with a failing test, this PR starts by updating the tab completion configuration file to read:

    $command ($revision|$path|$remote)* --? $path+

The resulting NFA state graph looks like this:

![tab_completion](https://user-images.githubusercontent.com/35861/27803968-4e1f22e6-5ffa-11e7-9f31-8b1b1cedd857.png)