### PR TITLE
Tab completion DSL: Options support

### DIFF
--- a/etc/completions
+++ b/etc/completions
@@ -1,1 +1,5 @@
-$command ($revision|$path|$remote)* --? $path+
+$command $opt* ($revision|$path|$remote)* --? $path+
+
+$opt
+  --version
+  --help

--- a/lib/gitsh/tab_completion/dsl/lexer.rb
+++ b/lib/gitsh/tab_completion/dsl/lexer.rb
@@ -4,15 +4,25 @@ module Gitsh
   module TabCompletion
     module DSL
       class Lexer < RLTK::Lexer
+        WORD_CHARACTERS = /[^\s*+?|()#]/
+
+        rule(/\$opt/) { :OPT_VAR }
         rule(/\$[a-z_]+/) { |t| [:VAR, t[1..-1]] }
-        rule(/[^\s*+?|()#]+/) { |t| [:WORD, t] }
+
+        rule(/-[A-Za-z0-9]/) { |t| [:OPTION, t] }
+        rule(/--#{WORD_CHARACTERS}+/) { |t| [:OPTION, t] }
+
+        rule(/#{WORD_CHARACTERS}+/) { |t| [:WORD, t] }
+
         rule(/\*/) { :STAR }
         rule(/\+/) { :PLUS }
         rule(/\?/) { :MAYBE }
         rule(/\|/) { :OR }
         rule(/\(/) { :LEFT_PAREN }
         rule(/\)/) { :RIGHT_PAREN }
+
         rule(/\s*\n\s*\n/) { :BLANK }
+        rule(/\s*\n\s+/) { :INDENT }
         rule(/\s+/) {}
 
         rule(/#/) { push_state :comment }

--- a/lib/gitsh/tab_completion/dsl/null_factory.rb
+++ b/lib/gitsh/tab_completion/dsl/null_factory.rb
@@ -1,0 +1,10 @@
+module Gitsh
+  module TabCompletion
+    module DSL
+      class NullFactory
+        def build(*_)
+        end
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/dsl/option_transition_factory.rb
+++ b/lib/gitsh/tab_completion/dsl/option_transition_factory.rb
@@ -1,0 +1,51 @@
+require 'gitsh/tab_completion/automaton'
+require 'gitsh/tab_completion/matchers/unknown_option_matcher'
+
+module Gitsh
+  module TabCompletion
+    module DSL
+      class OptionTransitionFactory
+        def build(start_state, options = {})
+          @start_state = start_state
+          @options = options
+
+          invoke
+        end
+
+        private
+
+        attr_reader :start_state, :options
+
+        def invoke
+          add_transitions_for_known_options
+          add_transitions_for_unknown_options
+          end_state
+        end
+
+        def add_transitions_for_known_options
+          known_options_factory.build(
+            start_state,
+            options.merge(end_state: end_state),
+          )
+        end
+
+        def add_transitions_for_unknown_options
+          start_state.add_transition(
+            Matchers::UnknownOptionMatcher.new,
+            end_state,
+          )
+        end
+
+        def end_state
+          @end_state ||= options.fetch(:end_state) do
+            Automaton::State.new('option')
+          end
+        end
+
+        def known_options_factory
+          options.fetch(:known_options_factory)
+        end
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/dsl/rule_factory.rb
+++ b/lib/gitsh/tab_completion/dsl/rule_factory.rb
@@ -2,14 +2,15 @@ module Gitsh
   module TabCompletion
     module DSL
       class RuleFactory
-        attr_reader :root
+        attr_reader :root, :options
 
-        def initialize(root)
+        def initialize(root, options)
           @root = root
+          @options = options
         end
 
         def build(start_state)
-          root.build(start_state)
+          root.build(start_state, known_options_factory: options)
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/unknown_option_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/unknown_option_matcher.rb
@@ -1,0 +1,17 @@
+require 'gitsh/tab_completion/matchers/base_matcher'
+
+module Gitsh
+  module TabCompletion
+    module Matchers
+      class UnknownOptionMatcher < BaseMatcher
+        def match?(word)
+          word =~ /\A--?[^-]/
+        end
+
+        def name
+          'opt'
+        end
+      end
+    end
+  end
+end

--- a/man/man5/gitsh_completions.5.in
+++ b/man/man5/gitsh_completions.5.in
@@ -13,7 +13,7 @@ sessions.
 .Pp
 The content of a
 .Nm gitsh_completions
-file consists of rules defining the arguments that are expected
+file consists of rules defining the options and arguments that are expected
 by various commands.
 .Xr gitsh 1
 uses the rules to match the input before the word being completed
@@ -21,7 +21,7 @@ and to generate completions that are relevant in the context.
 .Pp
 Each rule is separated from other rules by a blank line.
 .Pp
-The rule specifies the name of the command
+The first line of a rule specifies the name of the command
 and the arguments it accepts. In the simplest case, these are just
 space-separated words. For example, the following
 .Nm gitsh_completions
@@ -81,6 +81,51 @@ See the section on
 .Sx OPERATORS
 for a complete list of what's supported.
 .Pp
+Subsequent lines of each rule specify the options that the command accepts.
+These lines start with a whitespace indent,
+followed by the option name which must start with a
+.Ic -
+character,
+optionally followed by an argument the option takes.
+.Pp
+The special
+.Ic $opt
+variable is used in the first line of the rule to specify where the options are
+expected to appear. For example,
+.Xr git-add 1
+accepts options like
+.Ic --all
+and
+.Ic --edit :
+.Bd -literal -offset -indent
+add $opt* --? $path+
+  --all
+  --edit
+.Ed
+.Pp
+Some options are followed by an argument. This argument is specified in the
+same way as a positional argument would be specified in the first line of the
+completion rule, including support for the same variables and operators.
+For example, the
+.Xr git-init 1
+command can be passed a template directory via the
+.Ic --template
+option:
+.Bd -literal -offset -indent
+init $opt*
+  --template $path
+.Ed
+.Pp
+It is usually not useful to list short options (i.e. single character options)
+in a completion rule, except when they expect an argument. For example, the
+.Xr git-commit 1
+command can be passed a file containing the commit message via the
+.Ic -F
+option:
+.Bd -literal -offset -indent
+commit $opt*
+  -F $path
+.Ed
 .
 .Sh OPERATORS
 The following operators are supported. They have similar semantics to regular
@@ -115,7 +160,14 @@ required, and this is the only context in which parentheses may be used.
 .El
 .Pp
 The various post-fix operators may be applied to a list of options, but the
-options inside the list must be literals or variables.
+options inside the list must be literals or variables. For example, various
+commands take a
+.Ic --recurse-submodules
+option with an optional argument:
+.Bd -literal -offset -indent
+fetch $opt*
+  --recurse-submodules (yes|on-demand|no)?
+.Ed
 .
 .Sh VARIABLES
 Variables represent types of arguments that we want to tab complete in a
@@ -175,6 +227,26 @@ and there is a local branch called
 .Ic my-feature ,
 then the completions would include
 .Ic master..my-feature .
+.It Ic $opt
+Produces the options specified on subsequent lines of the current rule.
+See the
+.Sx DESCRIPTION
+section above for more details.
+.Pp
+Unlike other variables listed here,
+.Ic $opt
+only matches input that begins with a
+.Ic -
+character and is followed by one or more other characters.
+For example,
+.Ic -a
+and
+.Ic --all
+would match, but
+.Ic example.txt
+and
+.Ic --
+wouldn't.
 .El
 .
 .Sh FILES
@@ -187,13 +259,18 @@ for popular Git commands.
 .Sh EXAMPLES
 The
 .Xr git-add 1
-command takes an optional
+command takes zero or more options,
+followed by an optional
 .Ic -- ,
 followed by one or more file system paths.
 .Pp
 This argument scheme is represented as:
 .Bd -literal -offset -indent
-add --? $path+
+add $opt* --? $path+
+  --all
+  --edit
+  --force
+  --update
 .Ed
 .Pp
 I have a custom command called

--- a/spec/integration/tab_completion_spec.rb
+++ b/spec/integration/tab_completion_spec.rb
@@ -86,6 +86,15 @@ describe 'Completing things with tab' do
     end
   end
 
+  it 'completes options' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type("--ver\t")
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to output(/\d+/)
+    end
+  end
+
   it 'completes paths' do
     GitshRunner.interactive do |gitsh|
       gitsh.type('init')

--- a/spec/units/tab_completion/dsl/lexer_spec.rb
+++ b/spec/units/tab_completion/dsl/lexer_spec.rb
@@ -7,8 +7,22 @@ describe Gitsh::TabCompletion::DSL::Lexer do
       expect('stash pop').to produce_tokens ['WORD(stash)', 'WORD(pop)', 'EOS']
     end
 
+    it 'recognises the special $opt variable' do
+      expect('add $opt').to produce_tokens ['WORD(add)', 'OPT_VAR', 'EOS']
+    end
+
     it 'recognises variables' do
       expect('add $path').to produce_tokens ['WORD(add)', 'VAR(path)', 'EOS']
+      expect('add $optish').
+        to produce_tokens ['WORD(add)', 'VAR(optish)', 'EOS']
+    end
+
+    it 'recognises long options' do
+      expect('--foo').to produce_tokens ['OPTION(--foo)', 'EOS']
+    end
+
+    it 'recognises short options' do
+      expect('-S').to produce_tokens ['OPTION(-S)', 'EOS']
     end
 
     it 'recognises the asterisk operator' do
@@ -38,6 +52,15 @@ describe Gitsh::TabCompletion::DSL::Lexer do
       ]
     end
 
+    it 'recognises indented lines' do
+      expect("push\n  --force \n  --all").to produce_tokens [
+        'WORD(push)',
+        'INDENT', 'OPTION(--force)',
+        'INDENT', 'OPTION(--all)',
+        'EOS',
+      ]
+    end
+
     it 'recognises blank lines' do
       expect("push\n\npull").
         to produce_tokens ['WORD(push)', 'BLANK', 'WORD(pull)', 'EOS']
@@ -50,6 +73,14 @@ describe Gitsh::TabCompletion::DSL::Lexer do
       expect("# comment\npush").to produce_tokens ['WORD(push)', 'EOS']
       expect("push\n\n# comment\npull").
         to produce_tokens ['WORD(push)', 'BLANK', 'WORD(pull)', 'EOS']
+      expect(
+        "push\n  --force   # caution!\n  --force-with-lease",
+      ).to produce_tokens [
+        'WORD(push)',
+        'INDENT', 'OPTION(--force)',
+        'INDENT', 'OPTION(--force-with-lease)',
+        'EOS',
+      ]
     end
   end
 end

--- a/spec/units/tab_completion/dsl/option_transition_factory_spec.rb
+++ b/spec/units/tab_completion/dsl/option_transition_factory_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl/option_transition_factory'
+
+describe Gitsh::TabCompletion::DSL::OptionTransitionFactory do
+  describe '#build' do
+    it 'adds transitions for known and unknown options' do
+      unknown_option_matcher = stub_unknown_option_matcher
+      start_state = double(:start_state, add_transition: nil)
+      known_options_factory = double(:factory, build: nil)
+      factory = described_class.new
+
+      end_state = factory.build(
+        start_state,
+        known_options_factory: known_options_factory,
+      )
+
+      expect(known_options_factory).to have_received(:build).with(
+        start_state,
+        known_options_factory: known_options_factory,
+        end_state: end_state,
+      )
+      expect(start_state).to have_received(:add_transition).with(
+        unknown_option_matcher,
+        end_state,
+      )
+    end
+
+    context 'with an explicit end state' do
+      it 'adds transitions for known and unknown options' do
+        unknown_option_matcher = stub_unknown_option_matcher
+        start_state = double(:start_state, add_transition: nil)
+        end_state = double(:end_state)
+        known_options_factory = double(:factory, build: nil)
+        factory = described_class.new
+
+        result = factory.build(
+          start_state,
+          known_options_factory: known_options_factory,
+          end_state: end_state,
+        )
+
+        expect(result).to eq(end_state)
+        expect(known_options_factory).to have_received(:build).with(
+          start_state,
+          known_options_factory: known_options_factory,
+          end_state: end_state,
+        )
+        expect(start_state).to have_received(:add_transition).with(
+          unknown_option_matcher,
+          end_state,
+        )
+      end
+    end
+  end
+
+  def stub_unknown_option_matcher
+    klass = Gitsh::TabCompletion::Matchers::UnknownOptionMatcher
+    matcher = instance_double(klass)
+    allow(klass).to receive(:new).and_return(matcher)
+    matcher
+  end
+end

--- a/spec/units/tab_completion/dsl/rule_factory_spec.rb
+++ b/spec/units/tab_completion/dsl/rule_factory_spec.rb
@@ -6,11 +6,13 @@ describe Gitsh::TabCompletion::DSL::RuleFactory do
     it "delegates to the rule's root factory" do
       start_state = double(:start_state)
       root = double(:factory, build: nil)
-      factory = described_class.new(root)
+      options = double(:options)
+      factory = described_class.new(root, options)
 
       factory.build(start_state)
 
-      expect(root).to have_received(:build).with(start_state)
+      expect(root).to have_received(:build).
+        with(start_state, known_options_factory: options)
     end
   end
 end

--- a/spec/units/tab_completion/matchers/unknown_option_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/unknown_option_matcher_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/matchers/unknown_option_matcher'
+
+describe Gitsh::TabCompletion::Matchers::UnknownOptionMatcher do
+  describe '#match?' do
+    it 'returns true for input starting with "-"' do
+      matcher = described_class.new
+
+      expect(matcher.match?('-a')).to be_truthy
+      expect(matcher.match?('--force')).to be_truthy
+      expect(matcher.match?('--untracked-files')).to be_truthy
+    end
+
+    it 'returns false for "-" and "--"' do
+      matcher = described_class.new
+
+      expect(matcher.match?('-')).to be_falsey
+      expect(matcher.match?('--')).to be_falsey
+    end
+
+    it 'returns false for input not starting with "-"' do
+      matcher = described_class.new
+
+      expect(matcher.match?('')).to be_falsey
+      expect(matcher.match?('push')).to be_falsey
+    end
+  end
+
+  describe '#completions' do
+    it 'returns an empty array for any input' do
+      matcher = described_class.new
+
+      expect(matcher.completions('')).to eq([])
+      expect(matcher.completions('--')).to eq([])
+      expect(matcher.completions('--force')).to eq([])
+    end
+  end
+
+  describe '#eql?' do
+    it 'returns true when given another instance of the same class' do
+      matcher1 = described_class.new
+      matcher2 = described_class.new
+
+      expect(matcher1).to eql(matcher2)
+    end
+
+    it 'returns false when given an instance of any other class' do
+      matcher = described_class.new
+      other = double(:not_a_matcher)
+
+      expect(matcher).not_to eql(other)
+    end
+  end
+
+  describe '#hash' do
+    it 'returns the same value for all instances of the class' do
+      matcher1 = described_class.new
+      matcher2 = described_class.new
+
+      expect(matcher1.hash).to eq(matcher2.hash)
+    end
+  end
+end


### PR DESCRIPTION
This PR further expands the tab completion DSL with the ability to define options like `-f` or `--force`.

- Rules can contain an `$opt` variable, which indicates where options may appear. This will match on anything beginning with `-` or `--`, and complete to any known options.
- Rules can list known options, and the arguments expected by those options.

### Examples

The config file in the repo is still pretty simple, but after this PR rules like this become possible:

```
commit $opt* --? $path+
  --all
  --fixup $revision
  --file $path
  --untracked-files (no|normal|all)?
```

Producing this state graph:

![tab_completion](https://user-images.githubusercontent.com/35861/27976099-1713cc02-6333-11e7-8f82-4f2185c0112e.png)

---

Visualisation of `etc/completions` after this PR:

![tab_completion](https://user-images.githubusercontent.com/35861/27975742-74271e14-6331-11e7-9daa-46c0bc31e7c4.png)
