### PR TITLE
Implement git_command placeholder in prompt

### DIFF
--- a/lib/gitsh/prompter.rb
+++ b/lib/gitsh/prompter.rb
@@ -31,13 +31,15 @@ module Gitsh
       end
 
       def to_s
-        padded_prompt_format.gsub(/%[bBcdDw#]/) do |match|
+        padded_prompt_format.gsub(/%[bBcdDgGw#]/) do |match|
           case match
           when "%b" then branch_name
           when "%B" then shortened_branch_name
           when "%c" then status_color
           when "%d" then working_directory
           when "%D" then File.basename(working_directory)
+          when "%g" then git_command
+          when "%G" then File.basename(git_command)
           when "%w" then clear_color
           when "%#" then terminator
           end
@@ -78,6 +80,10 @@ module Gitsh
         else
           'uninitialized'
         end
+      end
+
+      def git_command
+        env.git_command
       end
 
       def terminator

--- a/man/man1/gitsh.1.in
+++ b/man/man1/gitsh.1.in
@@ -144,6 +144,8 @@ command. The following placeholders can be used in the custom prompt:
 .It \&%B            Ta current HEAD, limited to 15 characters
 .It %d              Ta absolute path to current working directory
 .It \&%D            Ta basename of the current working directory
+.It %g              Ta absolute path of git binary in use
+.It %G              Ta basename of git binary in use
 .It %c              Ta start coloring based on status (see previous table)
 .It %w              Ta return to default color (e.g. after using %c)
 .El

--- a/spec/units/prompter_spec.rb
+++ b/spec/units/prompter_spec.rb
@@ -166,6 +166,26 @@ describe Gitsh::Prompter do
           "#{File.basename(Dir.getwd.sub(/\A#{Dir.home}/, '~'))} "
         )
       end
+
+      it 'replaces %g with the absolute path of the current git binary' do
+        env = env_double(
+          format: '%g',
+          git_command: '/usr/local/bin/my-custom-git',
+        )
+        prompter = Gitsh::Prompter.new(env: env)
+
+        expect(prompter.prompt).to eq '/usr/local/bin/my-custom-git '
+      end
+
+      it 'replaces %G with the basename of the current git binary' do
+        env = env_double(
+          format: '%G',
+          git_command: '/usr/local/bin/my-custom-git',
+        )
+        prompter = Gitsh::Prompter.new(env: env)
+
+        expect(prompter.prompt).to eq 'my-custom-git '
+      end
     end
 
     def env_double(attrs={})
@@ -179,6 +199,7 @@ describe Gitsh::Prompter do
         ),
         repo_current_head: 'master',
         repo_config_color: red,
+        git_command: '/usr/local/bin/my-custom-git',
       }
       double('Environment', default_attrs.merge(attrs)).tap do |env|
         allow(env).to receive(:[]).with('gitsh.prompt').and_return(format)


### PR DESCRIPTION
See #323 

This required a fairly minimal change to the pattern-matching substitution when generating the prompt string. I also updated the relevant section of the man page.

The tests fail without my code and pass with it, though it should be noted that this was my first experience with ruby and spec.