### PR TITLE
Custom completions file

### DIFF
--- a/lib/gitsh/tab_completion/automaton_factory.rb
+++ b/lib/gitsh/tab_completion/automaton_factory.rb
@@ -13,7 +13,10 @@ module Gitsh
       end
 
       def build
-        load_config(File.join(env.config_directory, 'completions'))
+        start_state = Automaton::State.new('start')
+        config_paths.each do |path|
+          DSL.load(path, start_state, env)
+        end
         Automaton.new(start_state)
       end
 
@@ -21,12 +24,11 @@ module Gitsh
 
       attr_reader :env
 
-      def load_config(path)
-        DSL.load(path, start_state, env)
-      end
-
-      def start_state
-        @start_state ||= Automaton::State.new('start')
+      def config_paths
+        [
+          File.join(env.config_directory, 'completions'),
+          File.join(ENV.fetch('HOME', '/'), '.gitsh_completions'),
+        ]
       end
     end
   end

--- a/man/man1/gitsh.1.in
+++ b/man/man1/gitsh.1.in
@@ -17,8 +17,7 @@
 is a language for interacting with a
 .Xr git 1
 repository. It supports all git subcommands, custom aliases, and custom
-commands for interacting with the shell itself. Commands, path names,
-branch names, and tag names can all be completed using tab completion.
+commands for interacting with the shell itself.
 .Pp
 Running gitsh with no arguments will start an interactive session. Quit by
 either typing
@@ -30,6 +29,13 @@ or sending an EOF character.
 Passing the path to a file containing a series of commands or sending a series
 of commands to gitsh's standard input will run each of those commands in
 sequence.
+.Pp
+In interactive mode, commands and their arguments can be completed using tab
+completion.
+The rules for what can be completed are defined in configuration files;
+see
+.Xr gitsh_completions 5
+for details.
 .Pp
 It supports these options and arguments:
 .
@@ -415,6 +421,14 @@ for popular Git commands.
 See
 .Xr gitsh_completions 5
 for details on the format of this file.
+.It Pa $HOME/.gitsh_completions
+User-defined tab completions file, which can be used to add additional
+completion rules, for example to add tab completion support for custom
+commands and aliases.
+.Pp
+As with the system-wide completions file,
+this file uses the format described in
+.Xr gitsh_completions 5 .
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width Ds

--- a/man/man5/gitsh_completions.5.in
+++ b/man/man5/gitsh_completions.5.in
@@ -258,6 +258,9 @@ wouldn't.
 .It Pa @pkgsysconfdir@/completions
 System-wide tab completions file, which defines the tab completion options
 for popular Git commands.
+.It Pa $HOME/.gitsh_completions
+User-defined completions file, which can be used to add completions for custom
+commands or aliases.
 .El
 .
 .Sh EXAMPLES

--- a/spec/integration/tab_completion_spec.rb
+++ b/spec/integration/tab_completion_spec.rb
@@ -155,4 +155,19 @@ describe 'Completing things with tab' do
       expect(gitsh).to output(/\AThird\nSecond\n\Z/)
     end
   end
+
+  it 'completes with custom rules' do
+    with_a_temporary_home_directory do |home|
+      write_file("#{home}/.gitsh_completions", 'recho $revision')
+      GitshRunner.interactive do |gitsh|
+        gitsh.type('init')
+        gitsh.type('commit --allow-empty -m First')
+        gitsh.type('config --local alias.recho "!echo"')
+        gitsh.type("recho m\t")
+
+        expect(gitsh).to output_no_errors
+        expect(gitsh).to output(/master/)
+      end
+    end
+  end
 end

--- a/spec/support/file_system.rb
+++ b/spec/support/file_system.rb
@@ -25,7 +25,7 @@ module FileSystemHelper
 
   def with_a_temporary_home_directory(&block)
     if ENV['TEMP_HOME']
-      block.call
+      block.call(ENV['TEMP_HOME'])
     else
       switch_home_directory(&block)
     end
@@ -52,7 +52,7 @@ module FileSystemHelper
       ENV['HOME'] = path
       write_file("#{path}/.inputrc", DEFAULT_READLINE_CONFIG)
       write_file("#{path}/.gitconfig", DEFAULT_GIT_CONFIG)
-      block.call
+      block.call(path)
     end
   ensure
     ENV['HOME'] = original_home

--- a/spec/units/tab_completion/automaton_factory_spec.rb
+++ b/spec/units/tab_completion/automaton_factory_spec.rb
@@ -3,7 +3,7 @@ require 'gitsh/tab_completion/automaton_factory'
 
 describe Gitsh::TabCompletion::AutomatonFactory do
   describe '.build' do
-    it 'laods the tab completion DSL file' do
+    it 'loads the tab completion DSL file' do
       config_directory = '/tmp/etc/gitsh'
       env = double(:env, config_directory: config_directory)
       start_state = stub_automaton_state


### PR DESCRIPTION
This PR adds support for a `$HOME/.gitsh_completions` file, so that users can add tab completion rules for their custom Git commands and aliases.

Resolves #315 