### PR TITLE
Git 2 20 tab complete

### DIFF
--- a/lib/gitsh/git_command_list.rb
+++ b/lib/gitsh/git_command_list.rb
@@ -1,0 +1,29 @@
+module Gitsh
+  class GitCommandList
+    def initialize(env)
+      @env = env
+    end
+
+    def to_a
+      git_output('help -a').
+        lines.
+        select { |line| line =~ /^  [a-z]/ }.
+        map { |line| line.split(/\s+/) }.
+        flatten.
+        reject { |cmd| cmd.empty? || cmd =~ /--/ }.
+        sort
+    end
+
+    private
+
+    attr_accessor :env
+
+    def git_output(command)
+      Open3.capture3(git_command(command)).first.chomp
+    end
+
+    def git_command(sub_command)
+      "#{env.git_command} #{sub_command}"
+    end
+  end
+end

--- a/lib/gitsh/git_command_list.rb
+++ b/lib/gitsh/git_command_list.rb
@@ -5,8 +5,33 @@ module Gitsh
     end
 
     def to_a
-      git_output('help -a').
-        lines.
+      try_using(commands_from_list_cmds) do
+        try_using(commands_from_help('help -a --no-verbose')) do
+          try_using(commands_from_help('help -a'))
+        end
+      end
+    end
+
+    private
+
+    attr_accessor :env
+
+    def try_using(result, default: [])
+      if result && result.any?
+        result
+      elsif block_given?
+        yield
+      else
+        default
+      end
+    end
+
+    def commands_from_list_cmds
+      git_output('--list-cmds=main,nohelpers').sort
+    end
+
+    def commands_from_help(command)
+      git_output(command).
         select { |line| line =~ /^  [a-z]/ }.
         map { |line| line.split(/\s+/) }.
         flatten.
@@ -14,12 +39,14 @@ module Gitsh
         sort
     end
 
-    private
-
-    attr_accessor :env
-
     def git_output(command)
-      Open3.capture3(git_command(command)).first.chomp
+      output, _, status = Open3.capture3(git_command(command))
+
+      if status.success?
+        output.chomp.lines.map(&:chomp)
+      else
+        []
+      end
     end
 
     def git_command(sub_command)

--- a/lib/gitsh/git_repository.rb
+++ b/lib/gitsh/git_repository.rb
@@ -1,6 +1,7 @@
 require 'open3'
 require 'shellwords'
 require 'gitsh/git_repository/status'
+require 'gitsh/git_command_list'
 
 module Gitsh
   class GitRepository
@@ -32,13 +33,7 @@ module Gitsh
     end
 
     def commands
-      git_output('help -a').
-        lines.
-        select { |line| line =~ /^  [a-z]/ }.
-        map { |line| line.split(/\s+/) }.
-        flatten.
-        reject { |cmd| cmd.empty? || cmd =~ /--/ }.
-        sort
+      GitCommandList.new(env).to_a
     end
 
     def aliases

--- a/spec/units/git_command_list_spec.rb
+++ b/spec/units/git_command_list_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require 'gitsh/git_command_list'
+
+describe Gitsh::GitCommandList do
+  describe '#to_a' do
+    it 'produces the list of porcelain commands' do
+      commands = Gitsh::GitCommandList.new(env).to_a
+
+      expect(commands).to include %(add)
+      expect(commands).to include %(commit)
+      expect(commands).to include %(checkout)
+      expect(commands).to include %(status)
+      expect(commands).not_to include %(add--interactive)
+      expect(commands).not_to include ''
+    end
+  end
+
+  def env
+    double(git_command: '/usr/bin/env git')
+  end
+end

--- a/spec/units/git_command_list_spec.rb
+++ b/spec/units/git_command_list_spec.rb
@@ -2,6 +2,11 @@ require 'spec_helper'
 require 'gitsh/git_command_list'
 
 describe Gitsh::GitCommandList do
+  GIT_COMMAND = '/usr/bin/env git'.freeze
+  MODERN_LIST_COMMAND = "#{GIT_COMMAND} --list-cmds=main,nohelpers".freeze
+  MODERN_HELP_COMMAND = "#{GIT_COMMAND} help -a --no-verbose".freeze
+  LEGACY_HELP_COMMAND = "#{GIT_COMMAND} help -a".freeze
+
   describe '#to_a' do
     it 'produces the list of porcelain commands' do
       commands = Gitsh::GitCommandList.new(env).to_a
@@ -13,9 +18,66 @@ describe Gitsh::GitCommandList do
       expect(commands).not_to include %(add--interactive)
       expect(commands).not_to include ''
     end
+
+    context 'with a Git version that supports --list-cmds' do
+      it 'uses that command list' do
+        stub_command(MODERN_LIST_COMMAND, output: "commit\nstatus\nadd\n")
+
+        commands = Gitsh::GitCommandList.new(env).to_a
+
+        expect(commands).to eq ['add', 'commit', 'status']
+      end
+    end
+
+    context 'with a Git version that supports `help --no-verbose`' do
+      it 'parses the help output' do
+        stub_command(MODERN_LIST_COMMAND, success: false)
+        stub_command(
+          MODERN_HELP_COMMAND,
+          output: "Commands:\n  commit   status\n  add\n",
+        )
+
+        commands = Gitsh::GitCommandList.new(env).to_a
+
+        expect(commands).to eq ['add', 'commit', 'status']
+      end
+    end
+
+    context 'with an old Git version' do
+      it 'parses the help output' do
+        stub_command(MODERN_LIST_COMMAND, success: false)
+        stub_command(MODERN_HELP_COMMAND, success: false)
+        stub_command(
+          LEGACY_HELP_COMMAND,
+          output: "Commands:\n  commit   status\n  add\n",
+        )
+
+        commands = Gitsh::GitCommandList.new(env).to_a
+
+        expect(commands).to eq ['add', 'commit', 'status']
+      end
+    end
+
+    context 'when nothing we try works' do
+      it 'returns an empty array' do
+        stub_command(MODERN_LIST_COMMAND, success: false)
+        stub_command(MODERN_HELP_COMMAND, success: false)
+        stub_command(LEGACY_HELP_COMMAND, success: false)
+
+        commands = Gitsh::GitCommandList.new(env).to_a
+
+        expect(commands).to eq []
+      end
+    end
   end
 
   def env
-    double(git_command: '/usr/bin/env git')
+    double(git_command: GIT_COMMAND)
+  end
+
+  def stub_command(command, success: true, output: '')
+    status = instance_double(Process::Status, success?: success)
+    allow(Open3).to receive(:capture3).with(command).
+      and_return([output, '', status])
   end
 end

--- a/spec/units/git_repository_spec.rb
+++ b/spec/units/git_repository_spec.rb
@@ -127,14 +127,13 @@ describe Gitsh::GitRepository do
   end
 
   context '#commands' do
-    it 'produces the list of porcelain commands' do
+    it 'delegates to the GitCommandList class' do
+      commands = double(:commands)
+      command_list = instance_double(Gitsh::GitCommandList, to_a: commands)
+      allow(Gitsh::GitCommandList).to receive(:new).and_return(command_list)
       repo = Gitsh::GitRepository.new(env)
-      expect(repo.commands).to include %(add)
-      expect(repo.commands).to include %(commit)
-      expect(repo.commands).to include %(checkout)
-      expect(repo.commands).to include %(status)
-      expect(repo.commands).not_to include %(add--interactive)
-      expect(repo.commands).not_to include ''
+
+      expect(repo.commands).to eq(commands)
     end
   end
 


### PR DESCRIPTION
This PR changes how gitsh builds a full list of available commands for tab
completion.

This list was originally built by parsing the output of `git help -a`, which
was based on the approach taken by the tab completion scripts distributed
with Git for various general-purpose shells.

In Git version 2.20, the output of `git help -a` changed in ways that
weren't compatible with our existing parsing code. Passing `--no-verbose`
continues to provide the old output format. Meanwhile, a new `--list-cmds`
argument was added, which outputs commands as a simple list, but is also
described in the git(1) manual page as being experimental and subject to
change.

To make sure we continue supporting a range of Git versions, and we won't
have major problems if the `--list-cmds` argument is removed, this PR
introduces the following strategy for getting a full list of Git commands:

1. Try `git --list-cmds`
2. Try `git help -a --no-verbose`
3. Try `git help -a`
4. Fail with an empty array

Since this is much more complex to the previous approach, we first extract
an object to handle this one responsibility.