### PR TITLE
Fix tab completion with no input.

### DIFF
--- a/lib/gitsh/tab_completion/context.rb
+++ b/lib/gitsh/tab_completion/context.rb
@@ -17,7 +17,11 @@ module Gitsh
       end
 
       def completing_variable?
-        [:VAR, :MISSING].include?(last_meaningful_token.type)
+        if meaningful_tokens.any?
+          [:VAR, :MISSING].include?(meaningful_tokens.last.type)
+        else
+          false
+        end
       end
 
       private
@@ -60,9 +64,10 @@ module Gitsh
           reverse
       end
 
-      def last_meaningful_token
-        tokens.reverse_each.
-          detect { |token| !NOT_MEANINGFUL.include?(token.type) }
+      def meaningful_tokens
+        @_meaningful_tokens ||= tokens.reject do |token|
+          NOT_MEANINGFUL.include?(token.type)
+        end
       end
 
       def tokens

--- a/spec/units/tab_completion/context_spec.rb
+++ b/spec/units/tab_completion/context_spec.rb
@@ -62,6 +62,7 @@ describe Gitsh::TabCompletion::Context do
       expect(described_class.new(':echo $my_var ')).not_to be_completing_variable
       expect(described_class.new(':echo \'$varish')).not_to be_completing_variable
       expect(described_class.new(':echo \'$')).not_to be_completing_variable
+      expect(described_class.new('')).not_to be_completing_variable
     end
   end
 end


### PR DESCRIPTION
When there is no input, hitting tab twice should complete a list of all available commands.

There was a bug in the `Gitsh::TabCompletion::Context#completing_variable?` method which caused a crash in this case, because it would try to read the type of the last token, which was `nil`.