### PR TITLE
Change process name to gitsh by embedding Ruby in C

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,15 @@ rvm:
   - "2.4"
   - "2.5"
   - "2.6"
-install: bundle install && ./autogen.sh && git config --global user.name 'Travis' && git config --global user.email 'travis@example.com'
-script: RUBY=$(which ruby) ./configure && make && bundle exec rspec
+install:
+  - bundle install
+  - ./autogen.sh
+  - git config --global user.name 'Travis'
+  - git config --global user.email 'travis@example.com'
+  - export LD_LIBRARY_PATH="${MY_RUBY_HOME}/lib"
+script:
+  - RUBY=$(which ruby) ./configure --prefix=$PWD/tmp
+  - make
+  - make install
+  - echo :help | ./tmp/bin/gitsh
+  - bundle exec rspec

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,7 @@ EXTRA_DIST = \
 	LICENSE \
 	README.md \
 	INSTALL \
+	configure.rb \
 	vendor/vendorize \
 	ext/gitsh/extconf.rb \
 	ext/gitsh/src/line_editor.c \
@@ -13,13 +14,16 @@ EXTRA_DIST = \
 
 bin_PROGRAMS = gitsh
 gitsh_SOURCES = src/gitsh.c
-AM_CPPFLAGS = -DGITSH_RB_PATH="\"$(rubydir)/$(PACKAGE).rb\""
+gitsh_CPPFLAGS = $(RUBY_CFLAGS) \
+	-DGITSH_RB_PATH="\"$(rubydir)/$(PACKAGE).rb\""
+gitsh_LDFLAGS = $(RUBY_LIBS)
+LDADD = $(RUBY_LDADD)
 
 man_MANS = man/man1/gitsh.1 man/man5/gitsh_completions.5
 nobase_dist_pkgdata_DATA = $(vendorfiles)
 nobase_dist_ruby_DATA = $(libfiles)
 pkgrubylib_DATA = lib/gitsh/version.rb
-ruby_SCRIPTS = src/gitsh.rb
+ruby_DATA = src/gitsh.rb
 dist_pkgsysconf_DATA = etc/completions
 
 CLEANFILES = src/gitsh.rb lib/gitsh/version.rb
@@ -33,7 +37,6 @@ substitute_values = sed \
 
 src/gitsh.rb: Makefile src/gitsh.rb.in
 	$(substitute_values) $(srcdir)/$@.in > $@
-	chmod +x $@
 
 lib/gitsh/version.rb: Makefile lib/gitsh/version.rb.in
 	$(substitute_values) $(srcdir)/$@.in > $@

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,13 @@ AX_PROG_RUBY_VERSION(
   AC_MSG_ERROR(Ruby 2.3.0 or later is required to install gitsh)
 )
 
+RUBY_CFLAGS=$($RUBY ./configure.rb '-I$(rubyarchhdrdir) -I$(rubyhdrdir)')
+RUBY_LIBS=$($RUBY ./configure.rb '-L$($(libdirname)) $(LIBRUBYARG) $(LIBS)')
+RUBY_LDADD=$($RUBY ./configure.rb '$($(libdirname))/$(LIBRUBY)')
+AC_SUBST([RUBY_CFLAGS])
+AC_SUBST([RUBY_LIBS])
+AC_SUBST([RUBY_LDADD])
+
 VENDOR_DIRECTORY="vendor/gems"
 
 test -d $VENDOR_DIRECTORY || mkdir -p $VENDOR_DIRECTORY

--- a/configure.rb
+++ b/configure.rb
@@ -1,0 +1,18 @@
+require 'rbconfig'
+
+VAR_PATTERN = /\$\((?<name>[a-z_]+)\)/i
+
+REPLACEMENTS = Hash[RbConfig::MAKEFILE_CONFIG.map do |key, value|
+  ["$(#{key})", value]
+end]
+
+def expand_config(path)
+  if path =~ VAR_PATTERN
+    new_path = path.gsub(VAR_PATTERN, REPLACEMENTS)
+    expand_config(new_path)
+  else
+    path
+  end
+end
+
+puts expand_config(ARGV[0])

--- a/src/gitsh.c
+++ b/src/gitsh.c
@@ -1,12 +1,27 @@
 #include <err.h>
+#include <ruby.h>
 #include <sysexits.h>
-#include <unistd.h>
 
 int
 main(int argc, char *argv[])
 {
-    if (execv(GITSH_RB_PATH, argv) == -1) {
-        err(EX_SOFTWARE, GITSH_RB_PATH);
+    int ruby_argc;
+    char **ruby_argv;
+
+    ruby_argc = argc + 2;
+    ruby_argv = calloc(ruby_argc + 1, sizeof(char *));
+
+    if (!ruby_argv) {
+        err(EX_OSERR, GITSH_RB_PATH);
     }
-    return EX_OK;
+
+    ruby_argv[0] = argv[0];
+    ruby_argv[1] = "--disable-gems";
+    ruby_argv[2] = GITSH_RB_PATH;
+    memcpy(&ruby_argv[3], &argv[1], argc * sizeof(char *));
+
+    ruby_sysinit(&argc, &argv);
+    ruby_init();
+
+    return ruby_run_node(ruby_options(ruby_argc, ruby_argv));
 }

--- a/src/gitsh.rb.in
+++ b/src/gitsh.rb.in
@@ -1,5 +1,3 @@
-#!@RUBY@ --disable-gems
-
 $LOAD_PATH.unshift('@rubylibdir@')
 
 require '@gemsetuppath@'


### PR DESCRIPTION
Fixes #41.

This resolves the process name issue by running a Ruby interpreter in-process instead of via `ruby(1)`. The implementation is inspired by the article [Running Ruby in C](https://silverhammermba.github.io/emberb/embed/) and [Ruby's own `main` function](https://github.com/ruby/ruby/blob/bdbc8a8f1214b601ca409f66f2fe00ac06f2e99a/main.c). Instead of invoking `ruby(1)` as a subprocess, we use `ruby.h` and `libruby` to perform the same function directly.

In order to test this, I hard-coded the paths to `ruby.h`, `ruby/config.h` and `libruby` on my machine. The full set of compiler flags, including the platform-specific location of `ruby/config.h`, are available via `pkg-config(1)`. I'm not very familiar with Autotools, so I could use some help figuring out how to correctly include those flags at build time.