### PR TITLE
Set `rl_readline_name` to "gitsh"

### DIFF
--- a/ext/gitsh/src/line_editor.c
+++ b/ext/gitsh/src/line_editor.c
@@ -1544,7 +1544,7 @@ Init_line_editor_native(void)
     VALUE history, fcomp, ucomp, version;
 
     /* Allow conditional parsing of the ~/.inputrc file. */
-    rl_readline_name = (char *)"Ruby";
+    rl_readline_name = (char *)"gitsh";
 
 #if defined HAVE_RL_GETC_FUNCTION
     /* libedit check rl_getc_function only when rl_initialize() is called, */

--- a/man/man1/gitsh.1.in
+++ b/man/man1/gitsh.1.in
@@ -429,6 +429,23 @@ commands and aliases.
 As with the system-wide completions file,
 this file uses the format described in
 .Xr gitsh_completions 5 .
+.It Pa $HOME/.inputrc
+gitsh uses
+.Xr readline 3
+for interactive input, and therefore uses the settings in the user's
+.Pa .inputrc
+file.
+.Pp
+Settings can be conditionally loaded by specific applications.
+The following example, adapted from the
+.Xr readline 3
+documentation, demonstrates how to apply a setting only to gitsh:
+.Bd -literal -offset indent
+$if gitsh
+  # Quote the current or previous word
+  "\\C-xq": "\\eb\\"\\ef\\""
+$endif
+.Ed
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width Ds
@@ -452,6 +469,7 @@ rebase master
 .Xr gitsh_completions 5
 .Xr git 1
 .Xr gittutorial 7
+.Xr readline 3
 .
 .Sh HISTORY
 Written by

--- a/spec/integration/inputrc_spec.rb
+++ b/spec/integration/inputrc_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'A .inputrc file in the home directory' do
+  RELOAD_INPUTRC = "\cx\cr".freeze
+
+  it 'is used by gitsh' do
+    with_a_temporary_home_directory do
+      write_file(inputrc_path, <<-INPUTRC)
+        $if gitsh
+          "\C-xx": ":echo this is a test"
+        $endif
+      INPUTRC
+
+      GitshRunner.interactive do |gitsh|
+        gitsh.type 'init'
+        gitsh.type "#{RELOAD_INPUTRC}\cxx"
+
+        expect(gitsh).to output_no_errors
+        expect(gitsh).to output(/this is a test/)
+      end
+    end
+  end
+
+  def inputrc_path
+    "#{ENV['HOME']}/.inputrc"
+  end
+end


### PR DESCRIPTION
Fixes #294.

This change allows users to set conditional rules in their `.inputrc` that only apply to gitsh.

See: http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC10