### PR TITLE
Expand aliases

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,9 @@ Naming/VariableNumber:
   Description: Use normalcase for variable numbers.
   Enabled: false
 
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: required
+
 Style/TrailingCommaInArguments:
   Description: 'Checks for trailing comma in argument lists.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'

--- a/lib/gitsh/tab_completion/alias_expander.rb
+++ b/lib/gitsh/tab_completion/alias_expander.rb
@@ -1,0 +1,45 @@
+require 'gitsh/error'
+require 'gitsh/tab_completion/tokens_to_words'
+
+module Gitsh
+  module TabCompletion
+    class AliasExpander
+      def initialize(words, env)
+        @words = words
+        @env = env
+      end
+
+      def call
+        if expandable?
+          expanded_alias_words + words.drop(1)
+        else
+          words
+        end
+      end
+
+      private
+
+      attr_reader :words, :env
+
+      def expandable?
+        !expanded_alias.start_with?('!')
+      rescue Gitsh::UnsetVariableError
+        false
+      end
+
+      def expanded_alias_words
+        TokensToWords.call(expanded_alias_tokens)
+      end
+
+      def expanded_alias_tokens
+        Lexer.lex(expanded_alias)
+      rescue RLTK::LexingError
+        []
+      end
+
+      def expanded_alias
+        @_expanded_alias ||= env.fetch("alias.#{words.first}")
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/context.rb
+++ b/lib/gitsh/tab_completion/context.rb
@@ -1,4 +1,5 @@
 require 'gitsh/lexer'
+require 'gitsh/tab_completion/tokens_to_words'
 
 module Gitsh
   module TabCompletion
@@ -29,36 +30,10 @@ module Gitsh
       attr_reader :input
 
       def words
-        combine_words(split_by_spaces(last_command(tokens)))
+        TokensToWords.call(last_command_tokens)
       end
 
-      def combine_words(token_groups)
-        token_groups.map do |tokens|
-          tokens.inject("") do |result, token|
-            if token.type == :WORD
-              result + token.value
-            elsif token.type == :VAR
-              result + "${#{token.value}}"
-            else
-              result
-            end
-          end
-        end
-      end
-
-      def split_by_spaces(command_tokens)
-        command_tokens.
-          chunk { |token| token.type == :SPACE }.
-          inject([]) do |result, (is_space, token_group)|
-            if is_space
-              result
-            else
-              result + [token_group]
-            end
-          end
-      end
-
-      def last_command(tokens)
+      def last_command_tokens
         tokens.reverse_each.
           take_while { |token| !COMMAND_SEPARATORS.include?(token.type) }.
           reverse

--- a/lib/gitsh/tab_completion/facade.rb
+++ b/lib/gitsh/tab_completion/facade.rb
@@ -1,3 +1,4 @@
+require 'gitsh/tab_completion/alias_expander'
 require 'gitsh/tab_completion/automaton_factory'
 require 'gitsh/tab_completion/command_completer'
 require 'gitsh/tab_completion/context'
@@ -28,7 +29,7 @@ module Gitsh
       def command_completions(context, input)
         CommandCompleter.new(
           line_editor,
-          context.prior_words,
+          AliasExpander.new(context.prior_words, env).call,
           input,
           automaton,
           escaper,

--- a/lib/gitsh/tab_completion/tokens_to_words.rb
+++ b/lib/gitsh/tab_completion/tokens_to_words.rb
@@ -1,0 +1,48 @@
+module Gitsh
+  module TabCompletion
+    class TokensToWords
+      def self.call(tokens)
+        new(tokens).call
+      end
+
+      def initialize(tokens)
+        @tokens = tokens
+      end
+
+      def call
+        words
+      end
+
+      private
+
+      attr_reader :tokens
+
+      def words
+        token_groups.map do |tokens|
+          tokens.inject('') do |result, token|
+            case token.type
+            when :WORD
+              result + token.value
+            when :VAR
+              result + "${#{token.value}}"
+            else
+              result
+            end
+          end
+        end
+      end
+
+      def token_groups
+        tokens.
+          chunk { |token| token.type == :SPACE }.
+          inject([]) do |result, (is_space, token_group)|
+            if is_space
+              result
+            else
+              [*result, token_group]
+            end
+          end
+      end
+    end
+  end
+end

--- a/man/man1/gitsh.1.in
+++ b/man/man1/gitsh.1.in
@@ -424,7 +424,7 @@ for details on the format of this file.
 .It Pa $HOME/.gitsh_completions
 User-defined tab completions file, which can be used to add additional
 completion rules, for example to add tab completion support for custom
-commands and aliases.
+commands and some aliases.
 .Pp
 As with the system-wide completions file,
 this file uses the format described in

--- a/man/man5/gitsh_completions.5.in
+++ b/man/man5/gitsh_completions.5.in
@@ -126,6 +126,15 @@ option:
 commit $opt*
   -F $path
 .Ed
+.Pp
+Aliases for Git commands are expanded before applying tab completion rules,
+allowing users to benefit from the standard completion rules even when they
+are using an alias.
+.Pp
+Aliases for shell commands, i.e. aliases whose command begins with the
+.Ic !
+character, are not expanded, allowing users to define custom completion
+rules.
 .
 .Sh OPERATORS
 The following operators are supported. They have similar semantics to regular

--- a/spec/integration/tab_completion_spec.rb
+++ b/spec/integration/tab_completion_spec.rb
@@ -170,4 +170,17 @@ describe 'Completing things with tab' do
       end
     end
   end
+
+  it 'completes arguments to aliases' do
+    GitshRunner.interactive do |gitsh|
+      write_file('file.txt')
+      gitsh.type('init')
+      gitsh.type('config --local alias.a "add"')
+
+      gitsh.type("a --ver\t fil\t")
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to output(/file\.txt/)
+    end
+  end
 end

--- a/spec/units/tab_completion/alias_expander_spec.rb
+++ b/spec/units/tab_completion/alias_expander_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/alias_expander'
+
+describe Gitsh::TabCompletion::AliasExpander do
+  describe '#call' do
+    context 'when the first word is an alias for a Git command' do
+      it 'expands the alias' do
+        env = double(:env)
+        allow(env).to receive(:fetch).with('alias.alias').
+          and_return('expanded command')
+
+        expect(expand(['alias', 'argument'], env)).
+          to eq ['expanded', 'command', 'argument']
+      end
+    end
+
+    context 'when the first word is an alias for a shell command' do
+      it 'does not expand the alias' do
+        env = double(:env)
+        allow(env).to receive(:fetch).with('alias.alias').
+          and_return('!shell command')
+
+        expect(expand(['alias', 'argument'], env)).
+          to eq ['alias', 'argument']
+      end
+    end
+
+    context 'when the first word is not an alias' do
+      it 'returns the words' do
+        env = double(:env)
+        allow(env).to receive(:fetch).with('alias.foo').
+          and_raise(Gitsh::UnsetVariableError)
+        words = ['foo', 'bar']
+
+        expect(expand(words, env)).to eq(words)
+      end
+    end
+  end
+
+  def expand(words, env)
+    Gitsh::TabCompletion::AliasExpander.new(words, env).call
+  end
+end

--- a/spec/units/tab_completion/facade_spec.rb
+++ b/spec/units/tab_completion/facade_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'gitsh/error'
 require 'gitsh/tab_completion/facade'
 
 describe Gitsh::TabCompletion::Facade do
@@ -11,7 +12,7 @@ describe Gitsh::TabCompletion::Facade do
         stub_variable_completer
         automaton = stub_automaton_factory
         escaper = stub_escaper
-        facade = described_class.new(line_editor, double(:env))
+        facade = described_class.new(line_editor, stub_env)
 
         facade.call('lib/')
 
@@ -75,5 +76,11 @@ describe Gitsh::TabCompletion::Facade do
     command_completer = instance_double(klass)
     allow(klass).to receive(method).and_return(command_completer)
     command_completer
+  end
+
+  def stub_env
+    env = double(:env)
+    allow(env).to receive(:fetch).and_raise(Gitsh::UnsetVariableError)
+    env
   end
 end

--- a/spec/units/tab_completion/tokens_to_words_spec.rb
+++ b/spec/units/tab_completion/tokens_to_words_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/tokens_to_words'
+
+describe Gitsh::TabCompletion::TokensToWords do
+  describe '#call' do
+    it 'converts an array of tokens to an array of words' do
+      expect(call(
+        [:WORD, 'foo'], [:SPACE], [:WORD, 'bar'],
+      )).to eq ['foo', 'bar']
+
+      expect(call(
+        [:WORD, 'foo'], [:WORD, 'bar'],
+      )).to eq ['foobar']
+    end
+
+    it 'supports variables' do
+      expect(call(
+        [:WORD, 'foo'], [:VAR, 'bar'], [:WORD, 'baz'],
+      )).to eq ['foo${bar}baz']
+    end
+  end
+
+  def call(*token_descriptions)
+    Gitsh::TabCompletion::TokensToWords.call(tokens(*token_descriptions))
+  end
+end


### PR DESCRIPTION
Fixes #340.

When a user attempts to tab complete the arguments of an alias, they would previously (since v0.13) need a custom tab completion rule. This commit expands the alias behind the scenes, so that the tab completion system is using all available context, e.g. with `alias.a = add` the tab completion system will treat `a foo<TAB>` as if it were `add foo<TAB>`, allowing the standard tab completion rules for `add` to be used without any additional configuration. This also applied to more complex aliases, e.g. `alias.rmbranch = branch -d` would allow for `rmbranch <TAB>` to complete revision names.

A potential downside here is that it's no longer possible to define a custom tab completion rule for Git command aliases, which could be annoying in some situations. It seems like getting context-aware tab completion “out of the box” for aliases is a higher priority though.

Only aliases to Git commands are expanded. Aliases to shell commands (i.e. aliases starting with a `!`) are not expanded, so it's still possible to define custom tab completion rules for those.