### PR TITLE
Tab completion fallbacks

### DIFF
--- a/etc/completions
+++ b/etc/completions
@@ -922,4 +922,4 @@ $opt
 # fallbacks
 # =========
 
-$command
+fallback::$command $opt* ($revision|$path|$remote)* -- $path*

--- a/lib/gitsh/tab_completion/README.md
+++ b/lib/gitsh/tab_completion/README.md
@@ -59,8 +59,9 @@ consider the transitions from both of those states when we see the next input.
 
 The implementation in gitsh is slightly different from the NFAs used by regular
 expressions. We're not interested in just matching things, we're interested in
-what should come next after the input we've seen so far. That means our
-implementation has two differences:
+what should come next after the input we've seen so far. We also want to make
+sure we can provide good defaults in situations where we don't recognise the
+context. That means our implementation has three differences:
 
 1. There are no end states. We just run the automaton until we run out of input,
    and then use the current states the automaton is in to understand what might
@@ -70,6 +71,11 @@ implementation has two differences:
    completions. The matching behaviour is usually more permissive than the
    generating behaviour, e.g. if we're expecting a file system path we'd match
    on any input, but only generate valid paths to files that really exist.
+
+3. We introduce the concept of a _fallback transition_, which is a transition
+   that will only be used if there is no matching transition. This allows us
+   to define fallback rules for generic argument completion that will apply
+   only when a more specific rule isn't available.
 
 Before we run it through the NFA, the user's input gets split into a series of
 tokens. We're interested in matching everything before the word we're trying to

--- a/lib/gitsh/tab_completion/dsl/fallback_transition_factory.rb
+++ b/lib/gitsh/tab_completion/dsl/fallback_transition_factory.rb
@@ -1,0 +1,23 @@
+require 'gitsh/tab_completion/automaton'
+
+module Gitsh
+  module TabCompletion
+    module DSL
+      class FallbackTransitionFactory
+        attr_reader :matcher
+
+        def initialize(matcher)
+          @matcher = matcher
+        end
+
+        def build(start_state, options = {})
+          end_state = options.fetch(:end_state) do
+            Automaton::State.new('fallback')
+          end
+          start_state.add_fallback_transition(matcher, end_state)
+          end_state
+        end
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/dsl/lexer.rb
+++ b/lib/gitsh/tab_completion/dsl/lexer.rb
@@ -4,10 +4,12 @@ module Gitsh
   module TabCompletion
     module DSL
       class Lexer < RLTK::Lexer
-        WORD_CHARACTERS = /[^\s*+?|()#]/
+        WORD_CHARACTERS = /[^\s*+?|()#\$]/
 
         rule(/\$opt/) { :OPT_VAR }
         rule(/\$[a-z_]+/) { |t| [:VAR, t[1..-1]] }
+
+        rule(/[a-z_]+::/) { |t| [:MODIFIER, t[0..-3]] }
 
         rule(/-[A-Za-z0-9]/) { |t| [:OPTION, t] }
         rule(/--#{WORD_CHARACTERS}+/) { |t| [:OPTION, t] }

--- a/man/man5/gitsh_completions.5.in
+++ b/man/man5/gitsh_completions.5.in
@@ -126,7 +126,8 @@ option:
 commit $opt*
   -F $path
 .Ed
-.Pp
+.
+.Sh ALIASES
 Aliases for Git commands are expanded before applying tab completion rules,
 allowing users to benefit from the standard completion rules even when they
 are using an alias.
@@ -135,6 +136,43 @@ Aliases for shell commands, i.e. aliases whose command begins with the
 .Ic !
 character, are not expanded, allowing users to define custom completion
 rules.
+.
+.Sh FALLBACKS
+The
+.Ic fallback::
+modifier can be used before a variable to indicate that it should only
+be used if no other rule applies. This allows for the specification of
+generic rules that will only be applied if no other, more specific rule
+is available.
+.Pp
+To illustrate how this is useful, consider the following rules:
+.Bd -literal -offset -indent
+add $path+
+
+$command ($path|$revision|$remote)
+.Ed
+.Pp
+A user trying to tab complete arguments to
+.Xr git-add 1
+will match both rules: the input will match the
+.Ic add
+rule, and correctly be offered paths to complete, but will also match the
+.Ic $command
+rule, and so they will also be offered revisions and remotes.
+.Pp
+We can solve the problem by modifying the more generic rule to act as a
+fallback:
+.Bd -literal -offset -indent
+add $path+
+
+fallback::$command ($path|$revision|$remote)
+.Ed
+.Pp
+Now we get the best of both worlds: tab completing arguments for
+.Xr git-add 1
+will match the specific rule and only be offered paths, but any other
+command will use the fallback rule and be given a generic set of completions
+including paths, revisions, and remotes.
 .
 .Sh OPERATORS
 The following operators are supported. They have similar semantics to regular
@@ -265,6 +303,18 @@ would match, but
 and
 .Ic --
 wouldn't.
+.El
+.
+.Sh MODIFIERS
+The meaning of variables can be modified by adding a prefix.
+.Pp
+The following modifiers are supported:
+.Bl -tag -width Ds
+.It Ic fallback::
+Indicates that the variable should only be matched if no other rule is
+available. See the
+.Sx FALLBACKS
+section above for more details.
 .El
 .
 .Sh FILES

--- a/spec/integration/tab_completion_spec.rb
+++ b/spec/integration/tab_completion_spec.rb
@@ -193,4 +193,18 @@ describe 'Completing things with tab' do
       expect(gitsh).to output(/file\.txt/)
     end
   end
+
+  it 'generically completes arguments to commands with no specific rule' do
+    GitshRunner.interactive do |gitsh|
+      write_file('a-file.txt')
+      write_file('b-file.txt')
+
+      gitsh.type("!rm a-f\t")
+      gitsh.type('!ls')
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).not_to output(/a-file\.txt/)
+      expect(gitsh).to output(/b-file\.txt/)
+    end
+  end
 end

--- a/spec/units/tab_completion/dsl/fallback_transition_factory_spec.rb
+++ b/spec/units/tab_completion/dsl/fallback_transition_factory_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl/fallback_transition_factory'
+
+describe Gitsh::TabCompletion::DSL::FallbackTransitionFactory do
+  describe '#build' do
+    it 'adds a fallback transition to the start state and returns the end state' do
+      start_state = double(:start_state, add_fallback_transition: nil)
+      matcher = double(:matcher)
+      factory = described_class.new(matcher)
+
+      end_state = factory.build(start_state)
+
+      expect(end_state).to be_a(Gitsh::TabCompletion::Automaton::State)
+      expect(start_state).
+        to have_received(:add_fallback_transition).with(matcher, end_state)
+    end
+
+    context 'given an end state' do
+      it 'adds a fallback transition between the start and end states' do
+        start_state = double(:start_state, add_fallback_transition: nil)
+        end_state = double(:end_state)
+        matcher = double(:matcher)
+        factory = described_class.new(matcher)
+
+        result = factory.build(start_state, end_state: end_state)
+
+        expect(result).to eq(end_state)
+        expect(start_state).
+          to have_received(:add_fallback_transition).with(matcher, end_state)
+      end
+    end
+  end
+end

--- a/spec/units/tab_completion/dsl/lexer_spec.rb
+++ b/spec/units/tab_completion/dsl/lexer_spec.rb
@@ -7,6 +7,10 @@ describe Gitsh::TabCompletion::DSL::Lexer do
       expect('stash pop').to produce_tokens ['WORD(stash)', 'WORD(pop)', 'EOS']
     end
 
+    it 'recognises colon-prefixed words' do
+      expect(':cd').to produce_tokens ['WORD(:cd)', 'EOS']
+    end
+
     it 'recognises the special $opt variable' do
       expect('add $opt').to produce_tokens ['WORD(add)', 'OPT_VAR', 'EOS']
     end
@@ -15,6 +19,11 @@ describe Gitsh::TabCompletion::DSL::Lexer do
       expect('add $path').to produce_tokens ['WORD(add)', 'VAR(path)', 'EOS']
       expect('add $optish').
         to produce_tokens ['WORD(add)', 'VAR(optish)', 'EOS']
+    end
+
+    it 'recognises modifiers' do
+      expect('fallback::$command').
+        to produce_tokens ['MODIFIER(fallback)', 'VAR(command)', 'EOS']
     end
 
     it 'recognises long options' do

--- a/spec/units/tab_completion/dsl/parser_spec.rb
+++ b/spec/units/tab_completion/dsl/parser_spec.rb
@@ -154,6 +154,18 @@ describe Gitsh::TabCompletion::DSL::Parser do
       expect(result).to be_a_text_transition
       expect(result.word).to eq('stash')
     end
+
+    it 'parses fallback rules' do
+      result = parse_single_rule(tokens(
+        [:MODIFIER, 'fallback'], [:VAR, 'command'], [:VAR, 'revision'], [:EOS],
+      ))
+
+      expect(result).to be_a_concatenation
+      expect(result.parts.length).to eq(2)
+      expect(result.parts[0]).to be_a_fallback_transition
+      expect(result.parts[0].matcher).to be_a_command_matcher
+      expect(result.parts[1]).to be_a_variable_transition
+    end
   end
 
   def parse_single_rule(tokens)
@@ -183,6 +195,10 @@ describe Gitsh::TabCompletion::DSL::Parser do
     be_a(Gitsh::TabCompletion::DSL::OptionTransitionFactory)
   end
 
+  def be_a_fallback_transition
+    be_a(Gitsh::TabCompletion::DSL::FallbackTransitionFactory)
+  end
+
   def be_a_concatenation
     be_a(Gitsh::TabCompletion::DSL::ConcatenationFactory)
   end
@@ -201,6 +217,10 @@ describe Gitsh::TabCompletion::DSL::Parser do
 
   def be_a_choice
     be_a(Gitsh::TabCompletion::DSL::ChoiceFactory)
+  end
+
+  def be_a_command_matcher
+    be_a(Gitsh::TabCompletion::Matchers::CommandMatcher)
   end
 
   def be_a_revision_matcher


### PR DESCRIPTION
Fixes #317.

This PR adds fallback rules to the default tab completion configuration, which will only be used when no other rule applies. These provide sensible defaults for things that aren't covered by a specific rule, e.g. non-Git commands like `!rm`, or custom Git commands that have not been configured.

### The problem

Providing generic fallbacks wasn't possible without adding some new features to the tab completion DSL.

To illustrate why the existing DSL was insufficient, consider the following rules:

```
add $path+

$command ($path|$revision|$remote)+
```

A user trying to tab complete arguments to git-add(1) will match both rules: the input will match the `add` rule, and the user will correctly be offered paths to complete, but it will also match the `$command` rule, and so they will also be offered revisions and remotes.

The generic rule provides us with sensible tab completion defaults in situations where we don't have a specific rule, but by matching widely it also undermines the usefulness of a context-aware system.

### The solution

This PR solves the problem by introducing a `~fallback` modifier which indicates a variable should only be used when there's no other applicable rule. In terms of the finite state automaton that's built from the DSL, a variable with a `~fallback` modifier represents a state transition that will be followed if and only if there's no other appropriate transition from the current state.

We can use this modifier to fix the problems with the example above:

```
add $path+

$command~fallback ($path|$revision|$remote)+
```

Now we get the best of both worlds: tab completing arguments for git-add(1) will match the specific rule and only be offered paths, but any other command will use the fallback rule and be given a generic set of completions including paths, revisions, and remotes.