### PR TITLE
Add a $branch variable to tab completion

### DIFF
--- a/etc/completions
+++ b/etc/completions
@@ -36,7 +36,6 @@ blame $opt* $revision? --? $path
   --porcelain
   --progress
   --reverse $revision
-  --reverse $revision
   --root
   --score-debug
   --show-email

--- a/etc/completions
+++ b/etc/completions
@@ -77,21 +77,21 @@ branch $opt* $anything $revision?
   --track
 
 # Modifying
-branch $opt $anything?
+branch $opt $branch?
   --edit-description
   --set-upstream-to $anything
   --unset-upstream
   -u $anything
 
 # Renaming
-branch $opt+ $anything? $anything
+branch $opt+ $branch? $anything
   --force
   --move
   -M
   -m
 
 # Deleting
-branch $opt* $anything+
+branch $opt* $branch+
   --delete
   --force
   --quiet
@@ -388,7 +388,7 @@ log $opt* $revision? --? $path*
   --binary
   --bisect
   --boundary
-  --branches $anything?
+  --branches $branch?
   --break-rewrites $anything?
   --cc
   --check
@@ -831,12 +831,12 @@ status $opt* --? $path*
   -u (no|normal|all)?
 
 submodule --quiet? add $opt* --? $remote $path
-  --branch $revision
+  --branch $branch
   --depth $anything
   --force
   --name $anything
   --reference $remote
-  -b $revision
+  -b $branch
 
 submodule --quiet? status $opt* --? $path+
   --cached

--- a/etc/completions
+++ b/etc/completions
@@ -61,7 +61,7 @@ branch $opt* $anything*
   --no-column
   --no-contains $revision
   --no-merged $revision
-  --points-at $anything
+  --points-at $revision
   --remotes
   --sort $anything
   --verbose

--- a/lib/gitsh/environment.rb
+++ b/lib/gitsh/environment.rb
@@ -83,6 +83,10 @@ module Gitsh
       input_stream.tty?
     end
 
+    def repo_branches
+      repo.branches
+    end
+
     def repo_remotes
       repo.remotes
     end

--- a/lib/gitsh/git_repository.rb
+++ b/lib/gitsh/git_repository.rb
@@ -26,6 +26,10 @@ module Gitsh
       status_factory.new(git_output('status --porcelain'), git_dir)
     end
 
+    def branches
+      git_output(%{branch --format='%(refname:short)'}).lines.map(&:chomp)
+    end
+
     def heads
       git_output(%{for-each-ref --format='%(refname:short)'}).
         lines.

--- a/lib/gitsh/tab_completion/dsl/parser.rb
+++ b/lib/gitsh/tab_completion/dsl/parser.rb
@@ -11,6 +11,7 @@ require 'gitsh/tab_completion/dsl/star_operation_factory'
 require 'gitsh/tab_completion/dsl/text_transition_factory'
 require 'gitsh/tab_completion/dsl/variable_transition_factory'
 require 'gitsh/tab_completion/matchers/anything_matcher'
+require 'gitsh/tab_completion/matchers/branch_matcher'
 require 'gitsh/tab_completion/matchers/command_matcher'
 require 'gitsh/tab_completion/matchers/path_matcher'
 require 'gitsh/tab_completion/matchers/remote_matcher'
@@ -22,6 +23,7 @@ module Gitsh
       class Parser < RLTK::Parser
         VARIABLE_TO_MATCHER_CLASS = {
           'anything' => Matchers::AnythingMatcher,
+          'branch' => Matchers::BranchMatcher,
           'command' => Matchers::CommandMatcher,
           'path' => Matchers::PathMatcher,
           'remote' => Matchers::RemoteMatcher,

--- a/lib/gitsh/tab_completion/matchers/branch_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/branch_matcher.rb
@@ -1,0 +1,25 @@
+require 'gitsh/tab_completion/matchers/base_matcher'
+
+module Gitsh
+  module TabCompletion
+    module Matchers
+      class BranchMatcher < BaseMatcher
+        def initialize(env)
+          @env = env
+        end
+
+        def name
+          'branch'
+        end
+
+        private
+
+        attr_reader :env
+
+        def all_completions
+          env.repo_branches
+        end
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/matchers/revision_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/revision_matcher.rb
@@ -16,14 +16,16 @@ module Gitsh
 
         def completions(token)
           prefix, partial_name = split(token)
-          env.repo_heads.
-            select { |option| option.start_with?(partial_name) }.
-            map { |option| prefix + option }
+          super(partial_name).map { |option| prefix + option }
         end
 
         private
 
         attr_reader :env
+
+        def all_completions
+          env.repo_heads
+        end
 
         def split(token)
           parts = token.rpartition(SEPARATORS)

--- a/man/man5/gitsh_completions.5.in
+++ b/man/man5/gitsh_completions.5.in
@@ -219,6 +219,11 @@ The following variables are supported:
 Produces no completion options, but matches any user input. This is useful
 for situations where we know Git requires an argument, but we're unable to
 produce useful completions for it.
+.It Ic $branch
+Produces the names of Git branches in the repository. Note that the more
+permissive
+.Ic $revision
+variable could be more appropriate.
 .It Ic $command
 Produces the names of Git commands. This includes any custom Git commands found
 on the user's

--- a/spec/integration/tab_completion_spec.rb
+++ b/spec/integration/tab_completion_spec.rb
@@ -83,6 +83,16 @@ describe 'Completing things with tab' do
       gitsh.type("checkout my-\t")
 
       expect(gitsh).to prompt_with "#{cwd_basename} my-feature@ "
+
+      gitsh.type('checkout master')
+      gitsh.type("branch -D my-\t")
+
+      expect(gitsh).to output_no_errors
+
+      gitsh.type('branch')
+
+      expect(gitsh).to output(/\bmaster\b/)
+      expect(gitsh).not_to output(/\bmy-feature\b/)
     end
   end
 

--- a/spec/units/environment_spec.rb
+++ b/spec/units/environment_spec.rb
@@ -253,6 +253,12 @@ describe Gitsh::Environment do
     let(:repo_factory) { double('RepositoryFactory', new: repo) }
     let(:env) { described_class.new(repository_factory: repo_factory) }
 
+    describe '#repo_branches' do
+      it 'is delegated to the GitRepository' do
+        expect(env).to delegate(:repo_branches).to(repo, :branches)
+      end
+    end
+
     describe '#repo_heads' do
       it 'is delegated to the GitRepository' do
         expect(env).to delegate(:repo_heads).to(repo, :heads)

--- a/spec/units/git_repository_spec.rb
+++ b/spec/units/git_repository_spec.rb
@@ -110,6 +110,25 @@ describe Gitsh::GitRepository do
     end
   end
 
+  describe '#branches' do
+    it 'produces all the branch names' do
+      with_a_temporary_home_directory do
+        in_a_temporary_directory do
+          repo = Gitsh::GitRepository.new(env)
+          run 'git init'
+          run 'git commit --allow-empty -m "Something swell"'
+
+          expect(repo.branches).to eq %w(master)
+
+          run 'git checkout -b awesome-sauce'
+          run 'git tag v2.0'
+
+          expect(repo.branches).to eq %w(awesome-sauce master)
+        end
+      end
+    end
+  end
+
   context '#heads' do
     it 'produces all the branches and tags' do
       with_a_temporary_home_directory do

--- a/spec/units/tab_completion/matchers/branch_matchers_spec.rb
+++ b/spec/units/tab_completion/matchers/branch_matchers_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/matchers/branch_matcher'
+
+describe Gitsh::TabCompletion::Matchers::BranchMatcher do
+  describe '#match?' do
+    it 'always returns true' do
+      matcher = described_class.new(double(:env))
+
+      expect(matcher.match?('foo')).to be_truthy
+      expect(matcher.match?('')).to be_truthy
+    end
+  end
+
+  describe '#completions' do
+    context 'given blank input' do
+      it 'returns the names of all branches' do
+        env = double(:env, repo_branches: ['master', 'my-feature'])
+        matcher = described_class.new(env)
+
+        expect(matcher.completions('')).to match_array ['master', 'my-feature']
+      end
+    end
+
+    context 'given a partial branch name' do
+      it 'returns all branch names matching the input' do
+        env = double(:env, repo_branches: ['master', 'my-feature'])
+        matcher = described_class.new(env)
+
+        expect(matcher.completions('m')).
+          to match_array ['master', 'my-feature']
+        expect(matcher.completions('my')).
+          to match_array ['my-feature']
+        expect(matcher.completions('foo')).
+          to match_array []
+      end
+    end
+  end
+
+  describe '#eql?' do
+    it 'returns true when given another instance of the same class' do
+      env = double(:env)
+      matcher1 = described_class.new(env)
+      matcher2 = described_class.new(env)
+
+      expect(matcher1).to eql(matcher2)
+    end
+
+    it 'returns false when given an instance of any other class' do
+      matcher = described_class.new(double(:env))
+      other = double(:not_a_matcher)
+
+      expect(matcher).not_to eql(other)
+    end
+  end
+
+  describe '#hash' do
+    it 'returns the same value for all instances of the class' do
+      env = double(:env)
+      matcher1 = described_class.new(env)
+      matcher2 = described_class.new(env)
+
+      expect(matcher1.hash).to eq(matcher2.hash)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #352

The tab completion DSL had a `$revision` variable which produces branch names, tag names, etc. In some contexts it's too general, e.g. `branch -D` accepts a branch name but not a tag. In those contexts we were using `$anything` to avoid producing invalid tab completion options.

This PR introduces a more specific `$branch` variable that can be used when we want to only tab complete branch names.