### PR TITLE
Introduce $tag matcher for tab completion.

### DIFF
--- a/etc/completions
+++ b/etc/completions
@@ -506,7 +506,7 @@ log $opt* $revision? --? $path*
   --stdin
   --submodule $anything
   --summary
-  --tags $anything?
+  --tags $tag?
   --text
   --textconv
   --topo-order
@@ -866,17 +866,17 @@ submodule --quiet? foreach $opt* $anything
 submodule --quiet? sync $opt* --? $path+
   --recursive
 
-tag $opt* $anything $revision
+tag $opt* $tag $revision
   --annotate
   --cleanup (strip|whitespace|verbatim)
   --column $anything
   --contains $revision
   --create-reflog
-  --delete
+  --delete $tag+
   --file $path
   --force
   --ignore-case
-  --list $anything
+  --list $tag
   --local-user $anything
   --merged $revision
   --merged $revision?

--- a/lib/gitsh/environment.rb
+++ b/lib/gitsh/environment.rb
@@ -87,6 +87,10 @@ module Gitsh
       repo.branches
     end
 
+    def repo_tags
+      repo.tags
+    end
+
     def repo_remotes
       repo.remotes
     end

--- a/lib/gitsh/git_repository.rb
+++ b/lib/gitsh/git_repository.rb
@@ -30,6 +30,10 @@ module Gitsh
       git_output(%{branch --format='%(refname:short)'}).lines.map(&:chomp)
     end
 
+    def tags
+      git_output(%{tag --format='%(refname:short)'}).lines.map(&:chomp)
+    end
+
     def heads
       git_output(%{for-each-ref --format='%(refname:short)'}).
         lines.

--- a/lib/gitsh/tab_completion/dsl/parser.rb
+++ b/lib/gitsh/tab_completion/dsl/parser.rb
@@ -17,6 +17,7 @@ require 'gitsh/tab_completion/matchers/command_matcher'
 require 'gitsh/tab_completion/matchers/path_matcher'
 require 'gitsh/tab_completion/matchers/remote_matcher'
 require 'gitsh/tab_completion/matchers/revision_matcher'
+require 'gitsh/tab_completion/matchers/tag_matcher'
 
 module Gitsh
   module TabCompletion
@@ -29,6 +30,7 @@ module Gitsh
           'path' => Matchers::PathMatcher,
           'remote' => Matchers::RemoteMatcher,
           'revision' => Matchers::RevisionMatcher,
+          'tag' => Matchers::TagMatcher,
         }.freeze
 
         MODIFER_TO_TRANSITION_CLASS = {

--- a/lib/gitsh/tab_completion/matchers/tag_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/tag_matcher.rb
@@ -1,0 +1,25 @@
+require 'gitsh/tab_completion/matchers/base_matcher'
+
+module Gitsh
+  module TabCompletion
+    module Matchers
+      class TagMatcher < BaseMatcher
+        def initialize(env)
+          @env = env
+        end
+
+        def name
+          'tag'
+        end
+
+        private
+
+        attr_reader :env
+
+        def all_completions
+          env.repo_tags
+        end
+      end
+    end
+  end
+end

--- a/man/man5/gitsh_completions.5.in
+++ b/man/man5/gitsh_completions.5.in
@@ -261,7 +261,7 @@ produce useful completions for it.
 Produces the names of Git branches in the repository. Note that the more
 permissive
 .Ic $revision
-variable could be more appropriate.
+variable could be more appropriate in some situations.
 .It Ic $command
 Produces the names of Git commands. This includes any custom Git commands found
 on the user's
@@ -283,6 +283,12 @@ and there is a local branch called
 .Ic my-feature ,
 then the completions would include
 .Ic master..my-feature .
+.Pp
+Note that the more specific
+.Ic $branch
+or
+.Ic $tag
+variables could be more appropriate in some situations.
 .It Ic $opt
 Produces the options specified on subsequent lines of the current rule.
 See the
@@ -303,6 +309,11 @@ would match, but
 and
 .Ic --
 wouldn't.
+.It Ic $tag
+Produces the names of Git tags in the repository. Note that the more
+permissive
+.Ic $revision
+variable could be more appropriate in some situations.
 .El
 .
 .Sh MODIFIERS

--- a/spec/integration/tab_completion_spec.rb
+++ b/spec/integration/tab_completion_spec.rb
@@ -96,6 +96,24 @@ describe 'Completing things with tab' do
     end
   end
 
+  it 'completes tag names' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type('init')
+      gitsh.type('commit --allow-empty -m "Some commit"')
+      gitsh.type('tag v0.1')
+      gitsh.type('tag initial')
+
+      gitsh.type("tag --delete v\t")
+
+      expect(gitsh).to output_no_errors
+
+      gitsh.type('tag')
+
+      expect(gitsh).to output(/initial/)
+      expect(gitsh).not_to output(/v0\.1/)
+    end
+  end
+
   it 'completes options' do
     GitshRunner.interactive do |gitsh|
       gitsh.type("--ver\t")

--- a/spec/units/environment_spec.rb
+++ b/spec/units/environment_spec.rb
@@ -259,6 +259,12 @@ describe Gitsh::Environment do
       end
     end
 
+    describe '#repo_tags' do
+      it 'is delegated to the GitRepository' do
+        expect(env).to delegate(:repo_tags).to(repo, :tags)
+      end
+    end
+
     describe '#repo_heads' do
       it 'is delegated to the GitRepository' do
         expect(env).to delegate(:repo_heads).to(repo, :heads)

--- a/spec/units/git_repository_spec.rb
+++ b/spec/units/git_repository_spec.rb
@@ -129,6 +129,26 @@ describe Gitsh::GitRepository do
     end
   end
 
+  describe '#tags' do
+    it 'produces all the tag names' do
+      with_a_temporary_home_directory do
+        in_a_temporary_directory do
+          repo = Gitsh::GitRepository.new(env)
+          run 'git init'
+          run 'git commit --allow-empty -m "Something swell"'
+          run 'git tag v1.0'
+
+          expect(repo.tags).to eq %w(v1.0)
+
+          run 'git checkout -b awesome-sauce'
+          run 'git tag v2.0'
+
+          expect(repo.tags).to eq %w(v1.0 v2.0)
+        end
+      end
+    end
+  end
+
   context '#heads' do
     it 'produces all the branches and tags' do
       with_a_temporary_home_directory do

--- a/spec/units/tab_completion/matchers/tag_matchers_spec.rb
+++ b/spec/units/tab_completion/matchers/tag_matchers_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/matchers/tag_matcher'
+
+describe Gitsh::TabCompletion::Matchers::TagMatcher do
+  describe '#match?' do
+    it 'always returns true' do
+      matcher = described_class.new(double(:env))
+
+      expect(matcher.match?('foo')).to be_truthy
+      expect(matcher.match?('')).to be_truthy
+    end
+  end
+
+  describe '#completions' do
+    context 'given blank input' do
+      it 'returns the names of all tags' do
+        env = double(:env, repo_tags: ['v1.0', 'v1.1'])
+        matcher = described_class.new(env)
+
+        expect(matcher.completions('')).to match_array ['v1.0', 'v1.1']
+      end
+    end
+
+    context 'given a partial tag name' do
+      it 'returns all tag names matching the input' do
+        env = double(:env, repo_tags: ['v1.0', 'v2.0'])
+        matcher = described_class.new(env)
+
+        expect(matcher.completions('v')).
+          to match_array ['v1.0', 'v2.0']
+        expect(matcher.completions('v1')).
+          to match_array ['v1.0']
+        expect(matcher.completions('foo')).
+          to match_array []
+      end
+    end
+  end
+
+  describe '#eql?' do
+    it 'returns true when given another instance of the same class' do
+      env = double(:env)
+      matcher1 = described_class.new(env)
+      matcher2 = described_class.new(env)
+
+      expect(matcher1).to eql(matcher2)
+    end
+
+    it 'returns false when given an instance of any other class' do
+      matcher = described_class.new(double(:env))
+      other = double(:not_a_matcher)
+
+      expect(matcher).not_to eql(other)
+    end
+  end
+
+  describe '#hash' do
+    it 'returns the same value for all instances of the class' do
+      env = double(:env)
+      matcher1 = described_class.new(env)
+      matcher2 = described_class.new(env)
+
+      expect(matcher1.hash).to eq(matcher2.hash)
+    end
+  end
+end


### PR DESCRIPTION
The `$tag` matchers produces tag names, and can be used in places where the `$revision` matcher is too permissive, e.g. `tag -d` only accepts a tag name, not a branch name etc.

Checks off one of the items in #314