### PR TITLE
Completion config file error handling

### DIFF
--- a/lib/gitsh/tab_completion/dsl.rb
+++ b/lib/gitsh/tab_completion/dsl.rb
@@ -6,7 +6,7 @@ module Gitsh
     module DSL
       def self.load(path, start_state, env)
         source = File.read(path)
-        tokens = Lexer.lex(source)
+        tokens = Lexer.lex(source, path)
         factory = Parser.parse(tokens, gitsh_env: env)
         factory.build(start_state)
       rescue Errno::ENOENT

--- a/lib/gitsh/tab_completion/dsl/parse_error.rb
+++ b/lib/gitsh/tab_completion/dsl/parse_error.rb
@@ -1,0 +1,60 @@
+require 'gitsh/error'
+
+module Gitsh
+  module TabCompletion
+    module DSL
+      class ParseError < Gitsh::Error
+        TOKEN_TO_DESCRIPTION = {
+          BLANK: 'blank line',
+          INDENT: 'indent',
+
+          LEFT_PAREN: 'opening paren',
+          RIGHT_PAREN: 'closing paren',
+
+          MAYBE: 'operator (?)',
+          OR: 'operator (|)',
+          PLUS: 'operator (+)',
+          STAR: 'operator (*)',
+
+          OPTION: 'option (%{value})',
+          VAR: 'variable ($%{value})',
+          OPT_VAR: 'variable ($opt)',
+          WORD: 'word (%{value})',
+        }.freeze
+
+        def initialize(reason, token)
+          @reason = reason
+          @token = token
+        end
+
+        def to_s
+          'Tab completion configuration error: '\
+            "#{reason} #{token_description} at line #{line}, column #{column} "\
+            "in file #{path}"
+        end
+
+        private
+
+        attr_reader :reason, :token
+
+        def token_description
+          TOKEN_TO_DESCRIPTION.fetch(token.type, token.type) % {
+            value: token.value,
+          }
+        end
+
+        def line
+          token.position.line_number
+        end
+
+        def column
+          token.position.line_offset + 1
+        end
+
+        def path
+          token.position.file_name
+        end
+      end
+    end
+  end
+end

--- a/lib/gitsh/tab_completion/dsl/parser.rb
+++ b/lib/gitsh/tab_completion/dsl/parser.rb
@@ -2,6 +2,7 @@ require 'rltk'
 require 'gitsh/tab_completion/dsl/choice_factory'
 require 'gitsh/tab_completion/dsl/concatenation_factory'
 require 'gitsh/tab_completion/dsl/fallback_transition_factory'
+require 'gitsh/tab_completion/dsl/parse_error'
 require 'gitsh/tab_completion/dsl/maybe_operation_factory'
 require 'gitsh/tab_completion/dsl/null_factory'
 require 'gitsh/tab_completion/dsl/option_transition_factory'
@@ -74,6 +75,8 @@ module Gitsh
             tokens,
             opts.merge(env: Environment.new(opts.fetch(:gitsh_env))),
           )
+        rescue RLTK::NotInLanguage => error
+          raise ParseError.new('Unexpected', error.current)
         end
 
         production(:rule_set) do

--- a/lib/gitsh/tab_completion/dsl/parser.rb
+++ b/lib/gitsh/tab_completion/dsl/parser.rb
@@ -67,6 +67,11 @@ module Gitsh
 
           def build_matcher(var_name)
             VARIABLE_TO_MATCHER_CLASS.fetch(var_name).new(gitsh_env)
+          rescue KeyError
+            raise ParseError.new(
+              'Invalid',
+              RLTK::Token.new(:VAR, var_name, pos(0)),
+            )
           end
         end
 

--- a/lib/gitsh/tab_completion/facade.rb
+++ b/lib/gitsh/tab_completion/facade.rb
@@ -11,6 +11,7 @@ module Gitsh
       def initialize(line_editor, env)
         @line_editor = line_editor
         @env = env
+        @automaton = AutomatonFactory.build(env)
       end
 
       def call(input)
@@ -24,7 +25,7 @@ module Gitsh
 
       private
 
-      attr_reader :line_editor, :env
+      attr_reader :line_editor, :env, :automaton
 
       def command_completions(context, input)
         CommandCompleter.new(
@@ -38,10 +39,6 @@ module Gitsh
 
       def variable_completions(input)
         VariableCompleter.new(line_editor, input, env).call
-      end
-
-      def automaton
-        @automaton ||= AutomatonFactory.build(env)
       end
 
       def escaper

--- a/spec/integration/completion_errors_spec.rb
+++ b/spec/integration/completion_errors_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'gitsh/tab_completion/dsl/parse_error'
+
+describe 'Completion file with syntax errors' do
+  it 'fails to start up in interactive mode' do
+    with_a_temporary_home_directory do |home|
+      config_path = "#{home}/.gitsh_completions"
+      write_file(config_path, "??????\n******\n+++++++")
+
+      expect { starting_gitsh }.to raise_exception(
+        Gitsh::TabCompletion::DSL::ParseError,
+        /Unexpected operator \(\?\) at line 1, column 1 in file #{config_path}/,
+      )
+    end
+  end
+
+  it 'is not a problem in non-interactive mode'
+
+  def starting_gitsh
+    GitshRunner.new.start_interactive
+  end
+end

--- a/spec/integration/completion_errors_spec.rb
+++ b/spec/integration/completion_errors_spec.rb
@@ -1,20 +1,34 @@
 require 'spec_helper'
 require 'gitsh/tab_completion/dsl/parse_error'
 
-describe 'Completion file with syntax errors' do
-  it 'fails to start up in interactive mode' do
-    with_a_temporary_home_directory do |home|
-      config_path = "#{home}/.gitsh_completions"
-      write_file(config_path, "??????\n******\n+++++++")
+describe 'Invalid completion file' do
+  context 'with syntax errors' do
+    it 'fails to start up in interactive mode' do
+      with_a_temporary_home_directory do |home|
+        config_path = "#{home}/.gitsh_completions"
+        write_file(config_path, "??????\n******\n+++++++")
 
-      expect { starting_gitsh }.to raise_exception(
-        Gitsh::TabCompletion::DSL::ParseError,
-        /Unexpected operator \(\?\) at line 1, column 1 in file #{config_path}/,
-      )
+        expect { starting_gitsh }.to raise_exception(
+          Gitsh::TabCompletion::DSL::ParseError,
+          /Unexpected operator \(\?\) at line 1, column 1 in file #{config_path}/,
+        )
+      end
     end
   end
 
-  it 'is not a problem in non-interactive mode'
+  context 'with invalid variables' do
+    it 'fails to start up in interactive mode' do
+      with_a_temporary_home_directory do |home|
+        config_path = "#{home}/.gitsh_completions"
+        write_file(config_path, 'add $path $invalid_variable')
+
+        expect { starting_gitsh }.to raise_exception(
+          Gitsh::TabCompletion::DSL::ParseError,
+          /Invalid variable \(\$invalid_variable\) at line 1, column 11 in file #{config_path}/,
+        )
+      end
+    end
+  end
 
   def starting_gitsh
     GitshRunner.new.start_interactive

--- a/spec/support/gitsh_runner.rb
+++ b/spec/support/gitsh_runner.rb
@@ -16,7 +16,7 @@ class GitshRunner
     new(options).run_interactive(&block)
   end
 
-  def initialize(options)
+  def initialize(options = {})
     @input_stream = RSpec::Mocks::Double.new('STDIN', tty?: true)
     @output_stream = Tempfile.new('stdout')
     @error_stream = Tempfile.new('stderr')
@@ -44,6 +44,15 @@ class GitshRunner
     runner.kill
     runner.join
     raise
+  end
+
+  def start_interactive
+    with_a_temporary_home_directory do
+      in_a_temporary_directory do
+        setup_unix_env
+        cli.run
+      end
+    end
   end
 
   def type(string)

--- a/spec/units/input_strategies/interactive_spec.rb
+++ b/spec/units/input_strategies/interactive_spec.rb
@@ -165,12 +165,13 @@ describe Gitsh::InputStrategies::Interactive do
 
   def env
     @env ||= double('Environment', {
+      config_directory: '/tmp/gitsh/',
+      fetch: '',
       print: nil,
       puts: nil,
       puts_error: nil,
       repo_config_color: '',
-      fetch: '',
-      :[] => nil
+      :[] => nil,
     })
   end
 

--- a/spec/units/tab_completion/dsl/parse_error_spec.rb
+++ b/spec/units/tab_completion/dsl/parse_error_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'rltk'
+require 'gitsh/tab_completion/dsl/parse_error'
+
+describe Gitsh::TabCompletion::DSL::ParseError do
+  describe '#to_s' do
+    it 'describes the token where the problem occurred' do
+      position = instance_double(
+        RLTK::StreamPosition,
+        line_number: 2,
+        line_offset: 3,
+        file_name: 'example.txt',
+      )
+      token = instance_double(
+        RLTK::Token,
+        type: :MAYBE,
+        position: position,
+        value: nil,
+      )
+      exception = described_class.new('Unexpected', token)
+
+      expect(exception.to_s).to eq(
+        'Tab completion configuration error: Unexpected operator (?) '\
+        'at line 2, column 4 in file example.txt'
+      )
+    end
+  end
+end

--- a/spec/units/tab_completion/dsl/parser_spec.rb
+++ b/spec/units/tab_completion/dsl/parser_spec.rb
@@ -185,7 +185,7 @@ describe Gitsh::TabCompletion::DSL::Parser do
       )
 
       expect { parse_single_rule(bad_tokens) }.
-        to raise_exception(RLTK::NotInLanguage)
+        to raise_exception(Gitsh::TabCompletion::DSL::ParseError)
     end
 
     it 'does not parse an option in the definition of another option' do
@@ -196,7 +196,7 @@ describe Gitsh::TabCompletion::DSL::Parser do
       )
 
       expect { parse_single_rule(bad_tokens) }.
-        to raise_exception(RLTK::NotInLanguage)
+        to raise_exception(Gitsh::TabCompletion::DSL::ParseError)
     end
   end
 

--- a/spec/units/tab_completion/facade_spec.rb
+++ b/spec/units/tab_completion/facade_spec.rb
@@ -35,7 +35,7 @@ describe Gitsh::TabCompletion::Facade do
         line_editor = double(:line_editor, line_buffer: input)
         stub_command_completer
         variable_completer = stub_variable_completer
-        env = double(:env)
+        env = double(:env, config_directory: '/tmp/gitsh/')
         facade = described_class.new(line_editor, env)
 
         facade.call('name=$g')


### PR DESCRIPTION
This PR adds error reporting for problems with the tab completion. It covers several of the issues raised in #316.

Specifically:

- Load the completion files on start up, so that errors happen immediately and not when the user first tries to use completion.
- Output useful errors when the file fails to parse (i.e. valid tokens in an invalid order, like `??`).
- Output useful errors when the file contains an invalid variable (e.g. `$foo`)