### PR TITLE
Handle empty tab completion config files

### DIFF
--- a/lib/gitsh/tab_completion/dsl/parser.rb
+++ b/lib/gitsh/tab_completion/dsl/parser.rb
@@ -77,16 +77,13 @@ module Gitsh
         end
 
         production(:rule_set) do
-          clause('BLANK* .rule BLANK*') do |rule_factory|
-            RuleSetFactory.new([rule_factory])
-          end
           clause('BLANK* .rules BLANK*') do |rule_factories|
             RuleSetFactory.new(rule_factories)
           end
         end
 
         production(:rules) do
-          clause('.rule BLANK+ .rule') { |rule1, rule2| [rule1, rule2] }
+          clause('.rule') { |rule| [rule] }
           clause('.rules BLANK+ .rule') { |rules, rule| rules + [rule] }
         end
 

--- a/lib/gitsh/tab_completion/dsl/parser.rb
+++ b/lib/gitsh/tab_completion/dsl/parser.rb
@@ -80,6 +80,9 @@ module Gitsh
           clause('BLANK* .rules BLANK*') do |rule_factories|
             RuleSetFactory.new(rule_factories)
           end
+          clause('BLANK*') do |_|
+            RuleSetFactory.new([])
+          end
         end
 
         production(:rules) do

--- a/spec/units/tab_completion/dsl/parser_spec.rb
+++ b/spec/units/tab_completion/dsl/parser_spec.rb
@@ -146,6 +146,16 @@ describe Gitsh::TabCompletion::DSL::Parser do
       expect(result.rules.last).to be_a_rule_factory
     end
 
+    it 'parses empty input' do
+      result = described_class.parse(
+        tokens([:EOS]),
+        gitsh_env: double(:env),
+      )
+
+      expect(result).to be_a_rule_set_factory
+      expect(result.rules).to be_empty
+    end
+
     it 'parses rules with leading and trailing blank lines' do
       result = parse_single_rule(tokens(
         [:BLANK], [:BLANK], [:WORD, 'stash'], [:BLANK], [:BLANK], [:EOS],


### PR DESCRIPTION
If the file is empty, or contains only comments, it should be interpreted as "no rules". Previously it caused a parse error and would crash.

Ticks off one of the items in #316