### PR TITLE
Prevent invalid option definitions.

### DIFF
--- a/man/man5/gitsh_completions.5.in
+++ b/man/man5/gitsh_completions.5.in
@@ -105,7 +105,10 @@ add $opt* --? $path+
 .Pp
 Some options are followed by an argument. This argument is specified in the
 same way as a positional argument would be specified in the first line of the
-completion rule, including support for the same variables and operators.
+completion rule, including support for the same variables and operators
+(with the exception of the
+.Ic $opt
+variable).
 For example, the
 .Xr git-init 1
 command can be passed a template directory via the

--- a/spec/units/tab_completion/dsl/parser_spec.rb
+++ b/spec/units/tab_completion/dsl/parser_spec.rb
@@ -176,6 +176,28 @@ describe Gitsh::TabCompletion::DSL::Parser do
       expect(result.parts[0].matcher).to be_a_command_matcher
       expect(result.parts[1]).to be_a_variable_transition
     end
+
+    it 'does not parse an $opt variable in the definition of an option' do
+      bad_tokens = tokens(
+        [:WORD, 'add'], [:OPT_VAR],
+        [:INDENT], [:OPTION, '--broken'], [:OPT_VAR],
+        [:EOS],
+      )
+
+      expect { parse_single_rule(bad_tokens) }.
+        to raise_exception(RLTK::NotInLanguage)
+    end
+
+    it 'does not parse an option in the definition of another option' do
+      bad_tokens = tokens(
+        [:WORD, 'add'], [:OPT_VAR],
+        [:INDENT], [:OPTION, '--broken'], [:OPTION, '--nested'],
+        [:EOS],
+      )
+
+      expect { parse_single_rule(bad_tokens) }.
+        to raise_exception(RLTK::NotInLanguage)
+    end
   end
 
   def parse_single_rule(tokens)


### PR DESCRIPTION
Before this commit, the following tab completion rule was considered valid, but would cause an infinite loop when used:

    add $opt
      --example $opt

This was also considered valid, but doesn't really make sense:

    add $opt
      --example --nested

This commit resolved the situation by modifying the parser to not accept the `$opt` token or another option token (e.g. `--nested`) in the definition of an option.

Unfortunately this complicates the parser somewhat, because the tokens permitted in a rule and in an option definition have diverged.

Checks off the final item in #316