### PR TITLE
Fix subshell bugs

### DIFF
--- a/lib/gitsh/capturing_environment.rb
+++ b/lib/gitsh/capturing_environment.rb
@@ -11,6 +11,14 @@ module Gitsh
       writer
     end
 
+    def print(*args)
+      output_stream.print(*args)
+    end
+
+    def puts(*args)
+      output_stream.puts(*args)
+    end
+
     def captured_output
       writer.close
       reader.read

--- a/lib/gitsh/lexer.rb
+++ b/lib/gitsh/lexer.rb
@@ -49,7 +49,7 @@ module Gitsh
       right_paren_stack.push(:RIGHT_PAREN)
       :LEFT_PAREN
     end
-    rule(/\s*\)\s*/) do
+    rule(/\s*\)/) do
       pop_state
       right_paren_stack.pop || :RIGHT_PAREN
     end

--- a/lib/gitsh/parser.rb
+++ b/lib/gitsh/parser.rb
@@ -31,7 +31,7 @@ module Gitsh
 
     production(:commands) do
       clause('command') { |c| c }
-      clause('LEFT_PAREN .commands RIGHT_PAREN') { |c| c }
+      clause('LEFT_PAREN .commands RIGHT_PAREN SPACE?') { |c| c }
       clause('.commands EOL .commands') { |c1, c2| Commands::Tree::Multi.new(c1, c2) }
       clause('.commands SEMICOLON .commands') { |c1, c2| Commands::Tree::Multi.new(c1, c2) }
       clause('.commands OR .commands') { |c1, c2| Commands::Tree::Or.new(c1, c2) }

--- a/spec/integration/subshell_spec.rb
+++ b/spec/integration/subshell_spec.rb
@@ -37,7 +37,7 @@ describe 'Subshell' do
       gitsh.type ':echo $(:echo foo)$(:echo bar)'
 
       expect(gitsh).to output_no_errors
-      expect(gitsh).to output(/\bfoo\nbar\b/)
+      expect(gitsh).to output(/\bfoobar\b/)
     end
   end
 

--- a/spec/integration/subshell_spec.rb
+++ b/spec/integration/subshell_spec.rb
@@ -41,6 +41,15 @@ describe 'Subshell' do
     end
   end
 
+  it 'supports subshells in larger argument lists' do
+    GitshRunner.interactive do |gitsh|
+      gitsh.type ':echo 1 $(:echo 2) 3'
+
+      expect(gitsh).to output_no_errors
+      expect(gitsh).to output(/\b1 2 3\b/)
+    end
+  end
+
   it 'is not confused by quoted parens in a subshell' do
     GitshRunner.interactive do |gitsh|
       gitsh.type ':echo $(:echo ")))")'

--- a/spec/units/capturing_environment_spec.rb
+++ b/spec/units/capturing_environment_spec.rb
@@ -3,13 +3,31 @@ require 'gitsh/capturing_environment'
 
 describe Gitsh::CapturingEnvironment do
   describe '#captured_output' do
-    it 'returns any output written to the output stream' do
+    it 'returns any output written to the output stream directly' do
       env = double('env')
       capturing_env = described_class.new(env)
       capturing_env.output_stream.puts 'Hello, world'
       capturing_env.output_stream.puts 'Goodbye'
 
       expect(capturing_env.captured_output).to eq "Hello, world\nGoodbye\n"
+    end
+
+    it 'returns any output written to the output stream via #puts' do
+      env = double('env')
+      capturing_env = described_class.new(env)
+      capturing_env.puts 'Hello, world'
+      capturing_env.puts 'Goodbye'
+
+      expect(capturing_env.captured_output).to eq "Hello, world\nGoodbye\n"
+    end
+
+    it 'returns any output written to the output stream via #print' do
+      env = double('env')
+      capturing_env = described_class.new(env)
+      capturing_env.print 'Hello, world. '
+      capturing_env.print 'Goodbye.'
+
+      expect(capturing_env.captured_output).to eq 'Hello, world. Goodbye.'
     end
   end
 

--- a/spec/units/lexer_spec.rb
+++ b/spec/units/lexer_spec.rb
@@ -37,10 +37,12 @@ describe Gitsh::Lexer do
     end
 
     it 'recognises parentheses' do
-      expect('(foo)').
-        to produce_tokens ['LEFT_PAREN', 'WORD(foo)', 'RIGHT_PAREN', 'EOS']
-      expect(' ( foo ) ').
-        to produce_tokens ['LEFT_PAREN', 'WORD(foo)', 'RIGHT_PAREN', 'EOS']
+      expect('(foo)').to produce_tokens [
+        'LEFT_PAREN', 'WORD(foo)', 'RIGHT_PAREN', 'EOS',
+      ]
+      expect(' ( foo ) ').to produce_tokens [
+        'LEFT_PAREN', 'WORD(foo)', 'RIGHT_PAREN', 'SPACE', 'EOS',
+      ]
     end
 
     [' ', "\t", "\f", '\'', '"', '\\', '$', '#', ';', '&', '|', '(', ')'].each do |char|


### PR DESCRIPTION
This PR fixes two related bugs with subshells:

1. Using the `:echo` command in a subshell would be output to standard output, instead of being captured by the subshell. This was because the `CapturingEnvironment` would override the `Environment#output_stream` method, but not the convenience `#puts` and `#print` methods.

2. The space between a subshell argument and the next argument was lost. This was because the lexer considered any space following a `)` character to be part of the `RIGHT_PAREN` or `SUBSHELL_END` token. For `RIGHT_PAREN` that's fine; for `SUBSHELL_END` it isn't.

Fixes #328.