### PR TITLE
git-show(1) takes one or more revisions.

### DIFF
--- a/etc/completions
+++ b/etc/completions
@@ -753,7 +753,7 @@ rm $opt* --? $path+
   --ignore-unmatch
   --quiet
 
-show $opt* $anything
+show $opt* $revision+
   --abbrev-commit
   --encoding $anything
   --expand-tabs $anything?


### PR DESCRIPTION
This commit updates the default tab completion configuration to handle things like `git show mas<tab>`

(Probably doesn't need review, just opening a PR to set CI run)