### PR TITLE
Fix tab completing paths with no prefix.

### DIFF
--- a/lib/gitsh/tab_completion/matchers/path_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/path_matcher.rb
@@ -19,7 +19,7 @@ module Gitsh
         private
 
         def normalize_path(token)
-          if token.end_with?('/')
+          if token == '' || token.end_with?('/')
             File.expand_path(token) + '/'
           else
             File.expand_path(token)

--- a/spec/units/tab_completion/matchers/path_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/path_matcher_spec.rb
@@ -20,6 +20,7 @@ describe Gitsh::TabCompletion::Matchers::PathMatcher do
         write_file('first.txt')
         matcher = described_class.new(double(:env))
 
+        expect(matcher.completions('')).to match_array ['foo/', 'first.txt']
         expect(matcher.completions('f')).to match_array ['foo/', 'first.txt']
         expect(matcher.completions('foo')).to match_array ['foo/']
         expect(matcher.completions('foo/')).


### PR DESCRIPTION
When tab completing a path argument without entering the beginning of the
path we expect the completion options to be the files in the current
directory.

Prior to this commit the only option would be `/`, until the user entered at
least the first letter of the path to be completed.

Fixes #362 