### PR TITLE
Revision argument to git-reset is optional

### DIFF
--- a/etc/completions
+++ b/etc/completions
@@ -722,7 +722,7 @@ remote prune $opt* $remote+
 remote (--verbose|-v)? update $opt* $remote+
   --prune
 
-reset $opt* $revision --? $path*
+reset $opt* $revision? --? $path*
   --hard
   --keep
   --merge


### PR DESCRIPTION
`git reset` without specifying a revision defaults to using `HEAD`.

I guessed at the syntax based on the examples nearby.