### PR TITLE
Support installing gitsh from HEAD via Homebrew

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,9 @@ AC_PREREQ([2.68])
 AC_INIT(gitsh, 0.14, hello@thoughtbot.com)
 AM_INIT_AUTOMAKE([subdir-objects])
 
+AC_ARG_VAR([VERSION_SUFFIX])
+AS_IF([test -n "$VERSION_SUFFIX"], [AC_SUBST([PACKAGE_VERSION], ["$PACKAGE_VERSION$VERSION_SUFFIX"])])
+
 AC_ARG_VAR([RUBY],[The path of the Ruby binary to use])
 AC_ARG_VAR(
   [READLINE_LIB],

--- a/homebrew/gitsh.rb.in
+++ b/homebrew/gitsh.rb.in
@@ -9,6 +9,12 @@ class Gitsh < Formula
   url 'https://thoughtbot.github.io/@PACKAGE@/@DIST_ARCHIVES@'
   sha256 '@DIST_SHA@'
 
+  head do
+    url 'https://github.com/thoughtbot/@PACKAGE@.git'
+    depends_on 'autoconf' => :build
+    depends_on 'automake' => :build
+  end
+
   def self.old_system_ruby?
     system_ruby_version = `#{SYSTEM_RUBY_PATH} -e "puts RUBY_VERSION"`.chomp
     system_ruby_version < '2.3.0'
@@ -22,6 +28,13 @@ class Gitsh < Formula
   def install
     set_ruby_path
     set_architecture
+
+    if build.head?
+      system "./autogen.sh"
+      git_sha = %x(git log -1 --format=%h).chomp
+      ENV["VERSION_SUFFIX"] = "-head+#{git_sha}"
+    end
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
Supersedes [thoughtbot/homebrew-formulae#60](https://github.com/thoughtbot/homebrew-formulae/pull/60).

Adds a `head` configuration block to the Homebrew formula to support top-of-tree builds.

Additionally adds a VERSION_SUFFIX variable to configure.ac, which is appended to PACKAGE_VERSION on `./configure`. This is used to produce a SemVer-compatible version number such as 0.14-head+5d9484d, in order to differentiate pre-release builds from official releases.