### PR TITLE
Add note about `man gitsh` to Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 The `gitsh` program is an interactive shell for git. From within `gitsh` you can
 issue any git command, even using your local aliases and configuration.
 
-For a quick introduction to `gitsh`, watch [our video on Upcase][].
+For a quick introduction to `gitsh`, watch [our video on Upcase][]. For further
+documentation, you can view the man page by running `man gitsh` in your
+terminal.
 
 [![Build Status](https://travis-ci.org/thoughtbot/gitsh.png?branch=master)](https://travis-ci.org/thoughtbot/gitsh)
 [![Code Climate](https://codeclimate.com/github/thoughtbot/gitsh.png)](https://codeclimate.com/github/thoughtbot/gitsh)


### PR DESCRIPTION
I wasn't entirely sure where to view all the documentation for `gitsh`
when I first started using it. I soon found the man page, but wanted to
make it more obvious for anyone just starting out.