### PR TITLE
Introduce an object registry

### DIFF
--- a/bin/gitsh
+++ b/bin/gitsh
@@ -24,4 +24,4 @@ Gitsh::Registry[:line_editor] = Gitsh::LineEditorHistoryFilter.new(
   Gitsh::LineEditor,
 )
 
-Gitsh::CLI.new.run
+Gitsh::CLI.new(ARGV).run

--- a/bin/gitsh
+++ b/bin/gitsh
@@ -12,11 +12,16 @@ end
 require 'gitsh/cli'
 require 'gitsh/environment'
 require 'gitsh/git_repository'
+require 'gitsh/line_editor_history_filter'
+require 'gitsh/line_editor'
 require 'gitsh/registry'
 
 Gitsh::Registry[:repo] = Gitsh::GitRepository.new
 Gitsh::Registry[:env] = Gitsh::Environment.new(
   config_directory: File.expand_path('../../etc', __FILE__),
+)
+Gitsh::Registry[:line_editor] = Gitsh::LineEditorHistoryFilter.new(
+  Gitsh::LineEditor,
 )
 
 Gitsh::CLI.new.run

--- a/bin/gitsh
+++ b/bin/gitsh
@@ -14,9 +14,9 @@ require 'gitsh/environment'
 require 'gitsh/git_repository'
 require 'gitsh/registry'
 
+Gitsh::Registry[:repo] = Gitsh::GitRepository.new
 Gitsh::Registry[:env] = Gitsh::Environment.new(
   config_directory: File.expand_path('../../etc', __FILE__),
 )
-Gitsh::Registry[:repo] = Gitsh::GitRepository.new
 
 Gitsh::CLI.new.run

--- a/bin/gitsh
+++ b/bin/gitsh
@@ -10,18 +10,7 @@ require 'bundler/setup'
 end
 
 require 'gitsh/cli'
-require 'gitsh/environment'
-require 'gitsh/git_repository'
-require 'gitsh/line_editor_history_filter'
-require 'gitsh/line_editor'
 require 'gitsh/registry'
 
-Gitsh::Registry[:repo] = Gitsh::GitRepository.new
-Gitsh::Registry[:env] = Gitsh::Environment.new(
-  config_directory: File.expand_path('../../etc', __FILE__),
-)
-Gitsh::Registry[:line_editor] = Gitsh::LineEditorHistoryFilter.new(
-  Gitsh::LineEditor,
-)
-
+Gitsh::Registry.populate(conf_dir: File.expand_path('../../etc', __FILE__))
 Gitsh::CLI.new(ARGV).run

--- a/bin/gitsh
+++ b/bin/gitsh
@@ -11,9 +11,12 @@ end
 
 require 'gitsh/cli'
 require 'gitsh/environment'
+require 'gitsh/git_repository'
 require 'gitsh/registry'
 
 Gitsh::Registry[:env] = Gitsh::Environment.new(
   config_directory: File.expand_path('../../etc', __FILE__),
 )
+Gitsh::Registry[:repo] = Gitsh::GitRepository.new
+
 Gitsh::CLI.new.run

--- a/bin/gitsh
+++ b/bin/gitsh
@@ -9,10 +9,11 @@ require 'bundler/setup'
   $LOAD_PATH.unshift(File.expand_path("../../#{directory}", __FILE__))
 end
 
-require 'gitsh/environment'
 require 'gitsh/cli'
+require 'gitsh/environment'
+require 'gitsh/registry'
 
-env = Gitsh::Environment.new(
+Gitsh::Registry[:env] = Gitsh::Environment.new(
   config_directory: File.expand_path('../../etc', __FILE__),
 )
-Gitsh::CLI.new(env: env).run
+Gitsh::CLI.new.run

--- a/bin/tcviz
+++ b/bin/tcviz
@@ -5,14 +5,11 @@ require 'bundler/setup'
   $LOAD_PATH.unshift(File.expand_path("../../#{directory}", __FILE__))
 end
 
-require 'gitsh/environment'
 require 'gitsh/registry'
 require 'gitsh/tab_completion/automaton_factory'
 require 'gitsh/tab_completion/visualization'
 
-Gitsh::Registry[:env] = Gitsh::Environment.new(
-  config_directory: File.expand_path('../../etc', __FILE__),
-)
+Gitsh::Registry.populate(conf_dir: File.expand_path('../../etc', __FILE__))
 automaton = Gitsh::TabCompletion::AutomatonFactory.build
 viz = Gitsh::TabCompletion::Visualization.new(automaton)
 

--- a/bin/tcviz
+++ b/bin/tcviz
@@ -6,13 +6,14 @@ require 'bundler/setup'
 end
 
 require 'gitsh/environment'
+require 'gitsh/registry'
 require 'gitsh/tab_completion/automaton_factory'
 require 'gitsh/tab_completion/visualization'
 
-env = Gitsh::Environment.new(
+Gitsh::Registry[:env] = Gitsh::Environment.new(
   config_directory: File.expand_path('../../etc', __FILE__),
 )
-automaton = Gitsh::TabCompletion::AutomatonFactory.build(env)
+automaton = Gitsh::TabCompletion::AutomatonFactory.build
 viz = Gitsh::TabCompletion::Visualization.new(automaton)
 
 $stdout.puts viz.to_dot

--- a/lib/gitsh/arguments/subshell.rb
+++ b/lib/gitsh/arguments/subshell.rb
@@ -3,7 +3,7 @@ require 'gitsh/capturing_environment'
 module Gitsh
   module Arguments
     class Subshell
-      def initialize(command, options = {})
+      def initialize(command)
         @command = command
       end
 

--- a/lib/gitsh/cli.rb
+++ b/lib/gitsh/cli.rb
@@ -13,9 +13,6 @@ module Gitsh
 
     def initialize(opts={})
       @unparsed_args = opts.fetch(:args, ARGV).clone
-      @interactive_input_strategy = opts.fetch(:interactive_input_strategy) do
-        InputStrategies::Interactive.new
-      end
     end
 
     def run
@@ -29,8 +26,7 @@ module Gitsh
 
     private
 
-    attr_reader :unparsed_args, :script_file_argument,
-      :interactive_input_strategy
+    attr_reader :unparsed_args, :script_file_argument
 
     def interpreter
       Interpreter.new(env: env, input_strategy: input_strategy)
@@ -40,7 +36,7 @@ module Gitsh
       if script_file
         InputStrategies::File.new(path: script_file)
       else
-        interactive_input_strategy
+        InputStrategies::Interactive.new
       end
     end
 

--- a/lib/gitsh/cli.rb
+++ b/lib/gitsh/cli.rb
@@ -11,8 +11,8 @@ module Gitsh
     extend Registry::Client
     use_registry_for :env
 
-    def initialize(opts={})
-      @unparsed_args = opts.fetch(:args, ARGV).clone
+    def initialize(args)
+      @unparsed_args = args.clone
     end
 
     def run

--- a/lib/gitsh/cli.rb
+++ b/lib/gitsh/cli.rb
@@ -3,10 +3,14 @@ require 'gitsh/exit_statuses'
 require 'gitsh/input_strategies/file'
 require 'gitsh/input_strategies/interactive'
 require 'gitsh/interpreter'
+require 'gitsh/registry'
 require 'gitsh/version'
 
 module Gitsh
   class CLI
+    extend Registry::Client
+    use_registry_for :env
+
     def initialize(opts={})
       @unparsed_args = opts.fetch(:args, ARGV).clone
       @interactive_input_strategy = opts.fetch(:interactive_input_strategy) do
@@ -98,10 +102,6 @@ module Gitsh
         'executable',
       )
       exit EX_UNAVAILABLE
-    end
-
-    def env
-      Registry.env
     end
   end
 end

--- a/lib/gitsh/cli.rb
+++ b/lib/gitsh/cli.rb
@@ -10,7 +10,7 @@ module Gitsh
     def initialize(opts={})
       @unparsed_args = opts.fetch(:args, ARGV).clone
       @interactive_input_strategy = opts.fetch(:interactive_input_strategy) do
-        InputStrategies::Interactive.new(env: env)
+        InputStrategies::Interactive.new
       end
     end
 

--- a/lib/gitsh/cli.rb
+++ b/lib/gitsh/cli.rb
@@ -1,5 +1,4 @@
 require 'optparse'
-require 'gitsh/environment'
 require 'gitsh/exit_statuses'
 require 'gitsh/input_strategies/file'
 require 'gitsh/input_strategies/interactive'
@@ -9,10 +8,9 @@ require 'gitsh/version'
 module Gitsh
   class CLI
     def initialize(opts={})
-      @env = opts.fetch(:env, Environment.new)
       @unparsed_args = opts.fetch(:args, ARGV).clone
       @interactive_input_strategy = opts.fetch(:interactive_input_strategy) do
-        InputStrategies::Interactive.new(env: @env)
+        InputStrategies::Interactive.new(env: env)
       end
     end
 
@@ -27,8 +25,12 @@ module Gitsh
 
     private
 
-    attr_reader :env, :unparsed_args, :script_file_argument,
+    attr_reader :unparsed_args, :script_file_argument,
       :interactive_input_strategy
+
+    def env
+      Registry.env
+    end
 
     def interpreter
       Interpreter.new(env: env, input_strategy: input_strategy)

--- a/lib/gitsh/cli.rb
+++ b/lib/gitsh/cli.rb
@@ -28,17 +28,13 @@ module Gitsh
     attr_reader :unparsed_args, :script_file_argument,
       :interactive_input_strategy
 
-    def env
-      Registry.env
-    end
-
     def interpreter
       Interpreter.new(env: env, input_strategy: input_strategy)
     end
 
     def input_strategy
       if script_file
-        InputStrategies::File.new(env: env, path: script_file)
+        InputStrategies::File.new(path: script_file)
       else
         interactive_input_strategy
       end
@@ -102,6 +98,10 @@ module Gitsh
         'executable',
       )
       exit EX_UNAVAILABLE
+    end
+
+    def env
+      Registry.env
     end
   end
 end

--- a/lib/gitsh/commands/git_command.rb
+++ b/lib/gitsh/commands/git_command.rb
@@ -4,22 +4,18 @@ require 'gitsh/shell_command_runner'
 module Gitsh
   module Commands
     class GitCommand
-      def initialize(command, arg_values, options = {})
+      def initialize(command, arg_values)
         @command = command
         @arg_values = arg_values
-        @shell_command_runner = options.fetch(
-          :shell_command_runner,
-          ShellCommandRunner,
-        )
       end
 
       def execute(env)
-        shell_command_runner.run(command_with_arguments(env), env)
+        ShellCommandRunner.run(command_with_arguments(env), env)
       end
 
       private
 
-      attr_reader :command, :arg_values, :shell_command_runner
+      attr_reader :command, :arg_values
 
       def command_with_arguments(env)
         if autocorrect_enabled?(env) && command == 'git'

--- a/lib/gitsh/commands/shell_command.rb
+++ b/lib/gitsh/commands/shell_command.rb
@@ -13,7 +13,7 @@ module Gitsh
       end
 
       def execute(env)
-        ShellCommandRunner.run(command_with_arguments(env), env)
+        ShellCommandRunner.run(command_with_arguments, env)
       end
 
       private

--- a/lib/gitsh/commands/shell_command.rb
+++ b/lib/gitsh/commands/shell_command.rb
@@ -10,19 +10,15 @@ module Gitsh
       def initialize(command, arg_values, options = {})
         @command = command
         @arg_values = arg_values
-        @shell_command_runner = options.fetch(
-          :shell_command_runner,
-          ShellCommandRunner,
-        )
       end
 
       def execute(env)
-        shell_command_runner.run(command_with_arguments, env)
+        ShellCommandRunner.run(command_with_arguments(env), env)
       end
 
       private
 
-      attr_reader :command, :arg_values, :shell_command_runner
+      attr_reader :command, :arg_values
 
       def command_with_arguments
         [

--- a/lib/gitsh/environment.rb
+++ b/lib/gitsh/environment.rb
@@ -14,16 +14,15 @@ module Gitsh
 
     attr_reader :input_stream, :output_stream, :error_stream, :config_directory
 
-    def initialize(options={})
-      @input_stream = options.fetch(:input_stream, $stdin)
-      @output_stream = options.fetch(:output_stream, $stdout)
-      @error_stream = options.fetch(:error_stream, $stderr)
+    def initialize(
+      input_stream: $stdin, output_stream: $stdout, error_stream: $stderr,
+      config_directory: DEFAULT_CONFIG_DIRECTORY
+    )
+      @input_stream = input_stream
+      @output_stream = output_stream
+      @error_stream = error_stream
+      @config_directory = config_directory
       @variables = Hash.new
-      @magic_variables = options.fetch(:magic_variables) { MagicVariables.new }
-      @config_directory = options.fetch(
-        :config_directory,
-        DEFAULT_CONFIG_DIRECTORY,
-      )
     end
 
     def initialize_copy(original)
@@ -94,6 +93,10 @@ module Gitsh
 
     private
 
-    attr_reader :variables, :magic_variables
+    attr_reader :variables
+
+    def magic_variables
+      @_magic_variables ||= MagicVariables.new
+    end
   end
 end

--- a/lib/gitsh/environment.rb
+++ b/lib/gitsh/environment.rb
@@ -14,7 +14,7 @@ module Gitsh
       @input_stream = options.fetch(:input_stream, $stdin)
       @output_stream = options.fetch(:output_stream, $stdout)
       @error_stream = options.fetch(:error_stream, $stderr)
-      @repo = options.fetch(:repository_factory, GitRepository).new(self)
+      @repo = options.fetch(:repository_factory, GitRepository).new
       @variables = Hash.new
       @magic_variables = options.fetch(:magic_variables) { MagicVariables.new(@repo) }
       @config_directory = options.fetch(

--- a/lib/gitsh/environment.rb
+++ b/lib/gitsh/environment.rb
@@ -19,7 +19,7 @@ module Gitsh
       @output_stream = options.fetch(:output_stream, $stdout)
       @error_stream = options.fetch(:error_stream, $stderr)
       @variables = Hash.new
-      @magic_variables = options.fetch(:magic_variables) { MagicVariables.new(repo) }
+      @magic_variables = options.fetch(:magic_variables) { MagicVariables.new }
       @config_directory = options.fetch(
         :config_directory,
         DEFAULT_CONFIG_DIRECTORY,
@@ -86,54 +86,14 @@ module Gitsh
       input_stream.tty?
     end
 
-    def repo_branches
-      repo.branches
-    end
-
-    def repo_tags
-      repo.tags
-    end
-
-    def repo_remotes
-      repo.remotes
-    end
-
-    def repo_heads
-      repo.heads
-    end
-
-    def repo_current_head
-      repo.current_head
-    end
-
-    def repo_status
-      repo.status
-    end
-
-    def repo_config_color(name, default)
-      if color_override = fetch(name) { false }
-        repo.color(color_override)
-      else
-        repo.config_color(name, default)
-      end
-    end
-
-    def git_commands
-      repo.commands
-    end
-
-    def git_aliases
-      (repo.aliases + local_aliases).sort
-    end
-
-    private
-
-    attr_reader :variables, :magic_variables
-
     def local_aliases
       variables.keys.
         select { |key| key.to_s.start_with?('alias.') }.
         map { |key| key.to_s.sub('alias.', '') }
     end
+
+    private
+
+    attr_reader :variables, :magic_variables
   end
 end

--- a/lib/gitsh/environment.rb
+++ b/lib/gitsh/environment.rb
@@ -2,9 +2,13 @@ require 'gitsh/error'
 require 'gitsh/git_repository'
 require 'gitsh/line_editor'
 require 'gitsh/magic_variables'
+require 'gitsh/registry'
 
 module Gitsh
   class Environment
+    extend Registry::Client
+    use_registry_for :repo
+
     DEFAULT_GIT_COMMAND = '/usr/bin/env git'.freeze
     DEFAULT_CONFIG_DIRECTORY = '/usr/local/etc/gitsh'.freeze
 
@@ -14,9 +18,8 @@ module Gitsh
       @input_stream = options.fetch(:input_stream, $stdin)
       @output_stream = options.fetch(:output_stream, $stdout)
       @error_stream = options.fetch(:error_stream, $stderr)
-      @repo = options.fetch(:repository_factory, GitRepository).new
       @variables = Hash.new
-      @magic_variables = options.fetch(:magic_variables) { MagicVariables.new(@repo) }
+      @magic_variables = options.fetch(:magic_variables) { MagicVariables.new(repo) }
       @config_directory = options.fetch(
         :config_directory,
         DEFAULT_CONFIG_DIRECTORY,
@@ -125,7 +128,7 @@ module Gitsh
 
     private
 
-    attr_reader :variables, :magic_variables, :repo
+    attr_reader :variables, :magic_variables
 
     def local_aliases
       variables.keys.

--- a/lib/gitsh/file_runner.rb
+++ b/lib/gitsh/file_runner.rb
@@ -7,9 +7,9 @@ module Gitsh
       new(opts).run
     end
 
-    def initialize(opts)
-      @env = opts.fetch(:env)
-      @path = opts.fetch(:path)
+    def initialize(env:, path:)
+      @env = env
+      @path = path
     end
 
     def run

--- a/lib/gitsh/file_runner.rb
+++ b/lib/gitsh/file_runner.rb
@@ -25,7 +25,7 @@ module Gitsh
     end
 
     def input_strategy
-      InputStrategies::File.new(env: env, path: path)
+      InputStrategies::File.new(path: path)
     end
   end
 end

--- a/lib/gitsh/git_command_list.rb
+++ b/lib/gitsh/git_command_list.rb
@@ -1,8 +1,9 @@
+require 'gitsh/registry'
+
 module Gitsh
   class GitCommandList
-    def initialize(env)
-      @env = env
-    end
+    extend Registry::Client
+    use_registry_for :env
 
     def to_a
       try_using(commands_from_list_cmds) do
@@ -13,8 +14,6 @@ module Gitsh
     end
 
     private
-
-    attr_accessor :env
 
     def try_using(result, default: [])
       if result && result.any?

--- a/lib/gitsh/git_repository.rb
+++ b/lib/gitsh/git_repository.rb
@@ -2,11 +2,14 @@ require 'open3'
 require 'shellwords'
 require 'gitsh/git_repository/status'
 require 'gitsh/git_command_list'
+require 'gitsh/registry'
 
 module Gitsh
   class GitRepository
-    def initialize(env, options={})
-      @env = env
+    extend Registry::Client
+    use_registry_for :env
+
+    def initialize(options={})
       @status_factory = options.fetch(:status_factory, Status)
     end
 
@@ -103,7 +106,7 @@ module Gitsh
 
     private
 
-    attr_reader :env, :status_factory
+    attr_reader :status_factory
 
     def current_branch_name
       branch_name = git_output('symbolic-ref HEAD --short')

--- a/lib/gitsh/git_repository.rb
+++ b/lib/gitsh/git_repository.rb
@@ -9,10 +9,6 @@ module Gitsh
     extend Registry::Client
     use_registry_for :env
 
-    def initialize(options={})
-      @status_factory = options.fetch(:status_factory, Status)
-    end
-
     def git_dir
       git_output('rev-parse --git-dir')
     end
@@ -26,7 +22,7 @@ module Gitsh
     end
 
     def status
-      status_factory.new(git_output('status --porcelain'), git_dir)
+      Status.new(git_output('status --porcelain'), git_dir)
     end
 
     def branches
@@ -105,8 +101,6 @@ module Gitsh
     end
 
     private
-
-    attr_reader :status_factory
 
     def current_branch_name
       branch_name = git_output('symbolic-ref HEAD --short')

--- a/lib/gitsh/git_repository.rb
+++ b/lib/gitsh/git_repository.rb
@@ -44,7 +44,7 @@ module Gitsh
     end
 
     def commands
-      GitCommandList.new(env).to_a
+      GitCommandList.new.to_a
     end
 
     def aliases

--- a/lib/gitsh/history.rb
+++ b/lib/gitsh/history.rb
@@ -1,10 +1,11 @@
+require 'gitsh/registry'
+
 module Gitsh
   class History
     DEFAULT_HISTORY_FILE = "#{Dir.home}/.gitsh_history"
     DEFAULT_HISTORY_SIZE = 500
 
-    def initialize(env, line_editor)
-      @env = env
+    def initialize(line_editor)
       @line_editor = line_editor
     end
 
@@ -25,7 +26,7 @@ module Gitsh
 
     private
 
-    attr_reader :env, :line_editor
+    attr_reader :line_editor
 
     def history_file_exists?
       File.exist?(history_file_path)
@@ -37,6 +38,10 @@ module Gitsh
 
     def history_size
       env.fetch('gitsh.historySize') { DEFAULT_HISTORY_SIZE }.to_i
+    end
+
+    def env
+      Registry.env
     end
   end
 end

--- a/lib/gitsh/history.rb
+++ b/lib/gitsh/history.rb
@@ -8,6 +8,14 @@ module Gitsh
     DEFAULT_HISTORY_FILE = "#{Dir.home}/.gitsh_history"
     DEFAULT_HISTORY_SIZE = 500
 
+    def self.load
+      new.load
+    end
+
+    def self.save
+      new.save
+    end
+
     def load
       File.read(history_file_path).lines.each do |command|
         line_editor::HISTORY << command.chomp

--- a/lib/gitsh/history.rb
+++ b/lib/gitsh/history.rb
@@ -3,14 +3,10 @@ require 'gitsh/registry'
 module Gitsh
   class History
     extend Registry::Client
-    use_registry_for :env
+    use_registry_for :env, :line_editor
 
     DEFAULT_HISTORY_FILE = "#{Dir.home}/.gitsh_history"
     DEFAULT_HISTORY_SIZE = 500
-
-    def initialize(line_editor)
-      @line_editor = line_editor
-    end
 
     def load
       File.read(history_file_path).lines.each do |command|
@@ -28,8 +24,6 @@ module Gitsh
     end
 
     private
-
-    attr_reader :line_editor
 
     def history_file_exists?
       File.exist?(history_file_path)

--- a/lib/gitsh/history.rb
+++ b/lib/gitsh/history.rb
@@ -2,6 +2,9 @@ require 'gitsh/registry'
 
 module Gitsh
   class History
+    extend Registry::Client
+    use_registry_for :env
+
     DEFAULT_HISTORY_FILE = "#{Dir.home}/.gitsh_history"
     DEFAULT_HISTORY_SIZE = 500
 
@@ -38,10 +41,6 @@ module Gitsh
 
     def history_size
       env.fetch('gitsh.historySize') { DEFAULT_HISTORY_SIZE }.to_i
-    end
-
-    def env
-      Registry.env
     end
   end
 end

--- a/lib/gitsh/input_strategies/file.rb
+++ b/lib/gitsh/input_strategies/file.rb
@@ -1,4 +1,5 @@
 require 'gitsh/error'
+require 'gitsh/registry'
 
 module Gitsh
   module InputStrategies
@@ -6,7 +7,6 @@ module Gitsh
       STDIN_PLACEHOLDER = '-'.freeze
 
       def initialize(opts)
-        @env = opts[:env]
         @path = opts.fetch(:path)
       end
 
@@ -40,7 +40,7 @@ module Gitsh
 
       private
 
-      attr_reader :env, :file, :path
+      attr_reader :file, :path
 
       def open_file
         if path == STDIN_PLACEHOLDER
@@ -52,6 +52,10 @@ module Gitsh
 
       def next_line
         file.readline.chomp
+      end
+
+      def env
+        Registry.env
       end
     end
   end

--- a/lib/gitsh/input_strategies/file.rb
+++ b/lib/gitsh/input_strategies/file.rb
@@ -9,8 +9,8 @@ module Gitsh
 
       STDIN_PLACEHOLDER = '-'.freeze
 
-      def initialize(opts)
-        @path = opts.fetch(:path)
+      def initialize(path:)
+        @path = path
       end
 
       def setup

--- a/lib/gitsh/input_strategies/file.rb
+++ b/lib/gitsh/input_strategies/file.rb
@@ -4,6 +4,9 @@ require 'gitsh/registry'
 module Gitsh
   module InputStrategies
     class File
+      extend Registry::Client
+      use_registry_for :env
+
       STDIN_PLACEHOLDER = '-'.freeze
 
       def initialize(opts)
@@ -52,10 +55,6 @@ module Gitsh
 
       def next_line
         file.readline.chomp
-      end
-
-      def env
-        Registry.env
       end
     end
   end

--- a/lib/gitsh/input_strategies/interactive.rb
+++ b/lib/gitsh/input_strategies/interactive.rb
@@ -18,7 +18,7 @@ module Gitsh
         @line_editor = opts.fetch(:line_editor) do
           LineEditorHistoryFilter.new(Gitsh::LineEditor)
         end
-        @history = opts.fetch(:history) { History.new(env, @line_editor) }
+        @history = opts.fetch(:history) { History.new(@line_editor) }
         @terminal = opts.fetch(:terminal) { Terminal.instance }
       end
 

--- a/lib/gitsh/input_strategies/interactive.rb
+++ b/lib/gitsh/input_strategies/interactive.rb
@@ -17,13 +17,8 @@ module Gitsh
       BLANK_LINE_REGEX = /^\s*$/
       CONTINUATION_PROMPT = '> '.freeze
 
-      def initialize(opts = {})
-        @history = opts.fetch(:history) { History.new }
-        @terminal = opts.fetch(:terminal) { Terminal.instance }
-      end
-
       def setup
-        history.load
+        History.load
         setup_line_editor
         handle_window_resize
         greet_user
@@ -32,7 +27,7 @@ module Gitsh
 
       def teardown
         env.print "\n"
-        history.save
+        History.save
       end
 
       def read_command
@@ -67,8 +62,6 @@ module Gitsh
 
       private
 
-      attr_reader :history, :terminal
-
       def setup_line_editor
         line_editor.completion_proc = TabCompletion::Facade.new(line_editor)
         line_editor.completer_quote_characters = %('")
@@ -79,7 +72,7 @@ module Gitsh
       def handle_window_resize
         Signal.trap('WINCH') do
           begin
-            line_editor.set_screen_size(*terminal.size)
+            line_editor.set_screen_size(*Terminal.size)
           rescue Terminal::UnknownSizeError
           end
         end
@@ -111,7 +104,7 @@ module Gitsh
       end
 
       def prompter
-        @prompter ||= Prompter.new(color: terminal.color_support?)
+        @prompter ||= Prompter.new(color: Terminal.color_support?)
       end
     end
   end

--- a/lib/gitsh/input_strategies/interactive.rb
+++ b/lib/gitsh/input_strategies/interactive.rb
@@ -69,10 +69,6 @@ module Gitsh
 
       attr_reader :history, :line_editor, :terminal
 
-      def env
-        Registry.env
-      end
-
       def setup_line_editor
         line_editor.completion_proc = TabCompletion::Facade.new(line_editor, env)
         line_editor.completer_quote_characters = %('")
@@ -116,6 +112,10 @@ module Gitsh
 
       def prompter
         @prompter ||= Prompter.new(env: env, color: terminal.color_support?)
+      end
+
+      def env
+        Registry.env
       end
     end
   end

--- a/lib/gitsh/input_strategies/interactive.rb
+++ b/lib/gitsh/input_strategies/interactive.rb
@@ -111,7 +111,7 @@ module Gitsh
       end
 
       def prompter
-        @prompter ||= Prompter.new(env: env, color: terminal.color_support?)
+        @prompter ||= Prompter.new(color: terminal.color_support?)
       end
 
       def env

--- a/lib/gitsh/input_strategies/interactive.rb
+++ b/lib/gitsh/input_strategies/interactive.rb
@@ -12,16 +12,13 @@ module Gitsh
   module InputStrategies
     class Interactive
       extend Registry::Client
-      use_registry_for :env
+      use_registry_for :env, :line_editor
 
       BLANK_LINE_REGEX = /^\s*$/
       CONTINUATION_PROMPT = '> '.freeze
 
       def initialize(opts = {})
-        @line_editor = opts.fetch(:line_editor) do
-          LineEditorHistoryFilter.new(Gitsh::LineEditor)
-        end
-        @history = opts.fetch(:history) { History.new(@line_editor) }
+        @history = opts.fetch(:history) { History.new }
         @terminal = opts.fetch(:terminal) { Terminal.instance }
       end
 
@@ -70,7 +67,7 @@ module Gitsh
 
       private
 
-      attr_reader :history, :line_editor, :terminal
+      attr_reader :history, :terminal
 
       def setup_line_editor
         line_editor.completion_proc = TabCompletion::Facade.new(line_editor)

--- a/lib/gitsh/input_strategies/interactive.rb
+++ b/lib/gitsh/input_strategies/interactive.rb
@@ -70,7 +70,7 @@ module Gitsh
       attr_reader :history, :line_editor, :terminal
 
       def setup_line_editor
-        line_editor.completion_proc = TabCompletion::Facade.new(line_editor, env)
+        line_editor.completion_proc = TabCompletion::Facade.new(line_editor)
         line_editor.completer_quote_characters = %('")
         line_editor.completer_word_break_characters = ' &|;('
         line_editor.quoting_detection_proc = QuoteDetector.new

--- a/lib/gitsh/input_strategies/interactive.rb
+++ b/lib/gitsh/input_strategies/interactive.rb
@@ -11,6 +11,9 @@ require 'gitsh/terminal'
 module Gitsh
   module InputStrategies
     class Interactive
+      extend Registry::Client
+      use_registry_for :env
+
       BLANK_LINE_REGEX = /^\s*$/
       CONTINUATION_PROMPT = '> '.freeze
 
@@ -112,10 +115,6 @@ module Gitsh
 
       def prompter
         @prompter ||= Prompter.new(color: terminal.color_support?)
-      end
-
-      def env
-        Registry.env
       end
     end
   end

--- a/lib/gitsh/input_strategies/interactive.rb
+++ b/lib/gitsh/input_strategies/interactive.rb
@@ -14,12 +14,11 @@ module Gitsh
       BLANK_LINE_REGEX = /^\s*$/
       CONTINUATION_PROMPT = '> '.freeze
 
-      def initialize(opts)
+      def initialize(opts = {})
         @line_editor = opts.fetch(:line_editor) do
           LineEditorHistoryFilter.new(Gitsh::LineEditor)
         end
-        @env = opts[:env]
-        @history = opts.fetch(:history) { History.new(@env, @line_editor) }
+        @history = opts.fetch(:history) { History.new(env, @line_editor) }
         @terminal = opts.fetch(:terminal) { Terminal.instance }
       end
 
@@ -68,7 +67,11 @@ module Gitsh
 
       private
 
-      attr_reader :history, :line_editor, :env, :terminal
+      attr_reader :history, :line_editor, :terminal
+
+      def env
+        Registry.env
+      end
 
       def setup_line_editor
         line_editor.completion_proc = TabCompletion::Facade.new(line_editor, env)

--- a/lib/gitsh/input_strategies/interactive.rb
+++ b/lib/gitsh/input_strategies/interactive.rb
@@ -63,7 +63,7 @@ module Gitsh
       private
 
       def setup_line_editor
-        line_editor.completion_proc = TabCompletion::Facade.new(line_editor)
+        line_editor.completion_proc = TabCompletion::Facade.new
         line_editor.completer_quote_characters = %('")
         line_editor.completer_word_break_characters = ' &|;('
         line_editor.quoting_detection_proc = QuoteDetector.new

--- a/lib/gitsh/interpreter.rb
+++ b/lib/gitsh/interpreter.rb
@@ -6,11 +6,9 @@ require 'gitsh/parser'
 
 module Gitsh
   class Interpreter
-    def initialize(options)
-      @env = options.fetch(:env)
-      @lexer = options.fetch(:lexer, Lexer)
-      @parser = options.fetch(:parser, Parser)
-      @input_strategy = options.fetch(:input_strategy)
+    def initialize(env:, input_strategy:)
+      @env = env
+      @input_strategy = input_strategy
     end
 
     def run
@@ -24,7 +22,7 @@ module Gitsh
 
     private
 
-    attr_reader :env, :parser, :lexer, :input_strategy
+    attr_reader :env, :input_strategy
 
     def execute(input)
       build_command(input).execute(env)
@@ -33,13 +31,13 @@ module Gitsh
     end
 
     def build_command(input)
-      tokens = lexer.lex(input)
+      tokens = Lexer.lex(input)
 
       if incomplete_command?(tokens)
         continuation = input_strategy.read_continuation
         build_multi_line_command(input, continuation)
       else
-        parser.parse(tokens)
+        Parser.parse(tokens)
       end
     end
 

--- a/lib/gitsh/magic_variables.rb
+++ b/lib/gitsh/magic_variables.rb
@@ -1,8 +1,9 @@
+require 'gitsh/registry'
+
 module Gitsh
   class MagicVariables
-    def initialize(repo)
-      @repo = repo
-    end
+    extend Registry::Client
+    use_registry_for :repo
 
     def fetch(key)
       if available_variables.include?(key)
@@ -17,8 +18,6 @@ module Gitsh
     end
 
     private
-
-    attr_reader :repo
 
     def _prior
       repo.revision_name('@{-1}') ||

--- a/lib/gitsh/prompt_color.rb
+++ b/lib/gitsh/prompt_color.rb
@@ -3,6 +3,9 @@ require 'gitsh/registry'
 
 module Gitsh
   class PromptColor
+    extend Registry::Client
+    use_registry_for :env
+
     def status_color(status)
       if !status.initialized?
         env.repo_config_color('gitsh.color.uninitialized', 'normal red')
@@ -13,12 +16,6 @@ module Gitsh
       else
         env.repo_config_color('gitsh.color.default', 'blue')
       end
-    end
-
-    private
-
-    def env
-      Registry.env
     end
   end
 end

--- a/lib/gitsh/prompt_color.rb
+++ b/lib/gitsh/prompt_color.rb
@@ -4,18 +4,25 @@ require 'gitsh/registry'
 module Gitsh
   class PromptColor
     extend Registry::Client
-    use_registry_for :env
+    use_registry_for :env, :repo
 
     def status_color(status)
       if !status.initialized?
-        env.repo_config_color('gitsh.color.uninitialized', 'normal red')
+        color_setting('gitsh.color.uninitialized', default: 'normal red')
       elsif status.has_untracked_files?
-        env.repo_config_color('gitsh.color.untracked', 'red')
+        color_setting('gitsh.color.untracked', default: 'red')
       elsif status.has_modified_files?
-        env.repo_config_color('gitsh.color.modified', 'yellow')
+        color_setting('gitsh.color.modified', default: 'yellow')
       else
-        env.repo_config_color('gitsh.color.default', 'blue')
+        color_setting('gitsh.color.default', default: 'blue')
       end
+    end
+
+    private
+
+    def color_setting(setting_name, default:)
+      color_name = env.fetch(setting_name) { default }
+      repo.color(color_name)
     end
   end
 end

--- a/lib/gitsh/prompt_color.rb
+++ b/lib/gitsh/prompt_color.rb
@@ -1,11 +1,8 @@
 require 'gitsh/colors'
+require 'gitsh/registry'
 
 module Gitsh
   class PromptColor
-    def initialize(env)
-      @env = env
-    end
-
     def status_color(status)
       if !status.initialized?
         env.repo_config_color('gitsh.color.uninitialized', 'normal red')
@@ -20,6 +17,8 @@ module Gitsh
 
     private
 
-    attr_reader :env
+    def env
+      Registry.env
+    end
   end
 end

--- a/lib/gitsh/prompter.rb
+++ b/lib/gitsh/prompter.rb
@@ -11,7 +11,7 @@ module Gitsh
     def initialize(options={})
       @env = options.fetch(:env)
       @use_color = options.fetch(:color, true)
-      @prompt_color = options.fetch(:prompt_color) { PromptColor.new(@env) }
+      @prompt_color = options.fetch(:prompt_color) { PromptColor.new }
       @options = options
     end
 

--- a/lib/gitsh/prompter.rb
+++ b/lib/gitsh/prompter.rb
@@ -12,7 +12,6 @@ module Gitsh
     def initialize(options={})
       @use_color = options.fetch(:color, true)
       @prompt_color = options.fetch(:prompt_color) { PromptColor.new }
-      @options = options
     end
 
     def prompt
@@ -24,6 +23,9 @@ module Gitsh
     attr_reader :use_color, :prompt_color
 
     class Prompt
+      extend Registry::Client
+      use_registry_for :env
+
       def initialize(use_color, prompt_color)
         @use_color = use_color
         @prompt_color = prompt_color
@@ -119,10 +121,6 @@ module Gitsh
 
       def repo_status
         @repo_status ||= env.repo_status
-      end
-
-      def env
-        Registry.env
       end
     end
   end

--- a/lib/gitsh/prompter.rb
+++ b/lib/gitsh/prompter.rb
@@ -2,6 +2,7 @@
 
 require 'gitsh/colors'
 require 'gitsh/prompt_color'
+require 'gitsh/registry'
 
 module Gitsh
   class Prompter
@@ -9,23 +10,21 @@ module Gitsh
     BRANCH_CHAR_LIMIT = 15
 
     def initialize(options={})
-      @env = options.fetch(:env)
       @use_color = options.fetch(:color, true)
       @prompt_color = options.fetch(:prompt_color) { PromptColor.new }
       @options = options
     end
 
     def prompt
-      Prompt.new(env, use_color, prompt_color).to_s
+      Prompt.new(use_color, prompt_color).to_s
     end
 
     private
 
-    attr_reader :env, :use_color, :prompt_color
+    attr_reader :use_color, :prompt_color
 
     class Prompt
-      def initialize(env, use_color, prompt_color)
-        @env = env
+      def initialize(use_color, prompt_color)
         @use_color = use_color
         @prompt_color = prompt_color
       end
@@ -48,7 +47,7 @@ module Gitsh
 
       private
 
-      attr_reader :env, :prompt_color
+      attr_reader :prompt_color
 
       def working_directory
         Dir.getwd.sub(/\A#{Dir.home}/, '~')
@@ -120,6 +119,10 @@ module Gitsh
 
       def repo_status
         @repo_status ||= env.repo_status
+      end
+
+      def env
+        Registry.env
       end
     end
   end

--- a/lib/gitsh/prompter.rb
+++ b/lib/gitsh/prompter.rb
@@ -24,7 +24,7 @@ module Gitsh
 
     class Prompt
       extend Registry::Client
-      use_registry_for :env
+      use_registry_for :env, :repo
 
       def initialize(use_color, prompt_color)
         @use_color = use_color
@@ -77,7 +77,7 @@ module Gitsh
 
       def branch_name
         @branch_name ||= if repo_status.initialized?
-          env.repo_current_head
+          repo.current_head
         else
           'uninitialized'
         end
@@ -120,7 +120,7 @@ module Gitsh
       end
 
       def repo_status
-        @repo_status ||= env.repo_status
+        @repo_status ||= repo.status
       end
     end
   end

--- a/lib/gitsh/prompter.rb
+++ b/lib/gitsh/prompter.rb
@@ -9,9 +9,8 @@ module Gitsh
     DEFAULT_FORMAT = "%D %c%B%#%w".freeze
     BRANCH_CHAR_LIMIT = 15
 
-    def initialize(options={})
-      @use_color = options.fetch(:color, true)
-      @prompt_color = options.fetch(:prompt_color) { PromptColor.new }
+    def initialize(color: true)
+      @use_color = color
     end
 
     def prompt
@@ -20,7 +19,11 @@ module Gitsh
 
     private
 
-    attr_reader :use_color, :prompt_color
+    attr_reader :use_color
+
+    def prompt_color
+      @prompt_color ||= PromptColor.new
+    end
 
     class Prompt
       extend Registry::Client

--- a/lib/gitsh/registry.rb
+++ b/lib/gitsh/registry.rb
@@ -25,10 +25,6 @@ module Gitsh
       instance.clear
     end
 
-    def self.env
-      instance[:env]
-    end
-
     def initialize
       clear
     end

--- a/lib/gitsh/registry.rb
+++ b/lib/gitsh/registry.rb
@@ -13,6 +13,19 @@ module Gitsh
       end
     end
 
+    def self.populate(conf_dir:)
+      require 'gitsh/environment'
+      require 'gitsh/git_repository'
+      require 'gitsh/line_editor_history_filter'
+      require 'gitsh/line_editor'
+
+      instance[:repo] = Gitsh::GitRepository.new
+      instance[:env] = Gitsh::Environment.new(config_directory: conf_dir)
+      instance[:line_editor] = Gitsh::LineEditorHistoryFilter.new(
+        Gitsh::LineEditor,
+      )
+    end
+
     def self.[]=(name, value)
       instance[name] = value
     end

--- a/lib/gitsh/registry.rb
+++ b/lib/gitsh/registry.rb
@@ -4,6 +4,15 @@ module Gitsh
   class Registry
     include Singleton
 
+    module Client
+      def use_registry_for(*keys)
+        keys.each do |key|
+          define_method(key) { Registry[key] }
+          private(key)
+        end
+      end
+    end
+
     def self.[]=(name, value)
       instance[name] = value
     end

--- a/lib/gitsh/registry.rb
+++ b/lib/gitsh/registry.rb
@@ -1,0 +1,43 @@
+require 'singleton'
+
+module Gitsh
+  class Registry
+    include Singleton
+
+    def self.[]=(name, value)
+      instance[name] = value
+    end
+
+    def self.[](name)
+      instance[name]
+    end
+
+    def self.clear
+      instance.clear
+    end
+
+    def self.env
+      instance[:env]
+    end
+
+    def initialize
+      clear
+    end
+
+    def []=(name, value)
+      objects[name] = value
+    end
+
+    def [](name)
+      objects.fetch(name)
+    end
+
+    def clear
+      @objects = {}
+    end
+
+    private
+
+    attr_reader :objects
+  end
+end

--- a/lib/gitsh/registry.rb
+++ b/lib/gitsh/registry.rb
@@ -7,7 +7,7 @@ module Gitsh
     module Client
       def use_registry_for(*keys)
         keys.each do |key|
-          define_method(key) { Registry[key] }
+          define_method(key) { Registry.instance[key] }
           private(key)
         end
       end
@@ -24,14 +24,6 @@ module Gitsh
       instance[:line_editor] = Gitsh::LineEditorHistoryFilter.new(
         Gitsh::LineEditor,
       )
-    end
-
-    def self.[]=(name, value)
-      instance[name] = value
-    end
-
-    def self.[](name)
-      instance[name]
     end
 
     def self.clear

--- a/lib/gitsh/tab_completion/alias_expander.rb
+++ b/lib/gitsh/tab_completion/alias_expander.rb
@@ -5,6 +5,9 @@ require 'gitsh/tab_completion/tokens_to_words'
 module Gitsh
   module TabCompletion
     class AliasExpander
+      extend Registry::Client
+      use_registry_for :env
+
       def initialize(words)
         @words = words
       end
@@ -39,10 +42,6 @@ module Gitsh
 
       def expanded_alias
         @_expanded_alias ||= env.fetch("alias.#{words.first}")
-      end
-
-      def env
-        Registry.env
       end
     end
   end

--- a/lib/gitsh/tab_completion/alias_expander.rb
+++ b/lib/gitsh/tab_completion/alias_expander.rb
@@ -1,12 +1,12 @@
 require 'gitsh/error'
+require 'gitsh/registry'
 require 'gitsh/tab_completion/tokens_to_words'
 
 module Gitsh
   module TabCompletion
     class AliasExpander
-      def initialize(words, env)
+      def initialize(words)
         @words = words
-        @env = env
       end
 
       def call
@@ -19,7 +19,7 @@ module Gitsh
 
       private
 
-      attr_reader :words, :env
+      attr_reader :words
 
       def expandable?
         !expanded_alias.start_with?('!')
@@ -39,6 +39,10 @@ module Gitsh
 
       def expanded_alias
         @_expanded_alias ||= env.fetch("alias.#{words.first}")
+      end
+
+      def env
+        Registry.env
       end
     end
   end

--- a/lib/gitsh/tab_completion/automaton_factory.rb
+++ b/lib/gitsh/tab_completion/automaton_factory.rb
@@ -12,7 +12,7 @@ module Gitsh
       def build
         start_state = Automaton::State.new('start')
         config_paths.each do |path|
-          DSL.load(path, start_state, env)
+          DSL.load(path, start_state)
         end
         Automaton.new(start_state)
       end

--- a/lib/gitsh/tab_completion/automaton_factory.rb
+++ b/lib/gitsh/tab_completion/automaton_factory.rb
@@ -1,15 +1,12 @@
+require 'gitsh/registry'
 require 'gitsh/tab_completion/automaton'
 require 'gitsh/tab_completion/dsl'
 
 module Gitsh
   module TabCompletion
     class AutomatonFactory
-      def self.build(env)
-        new(env).build
-      end
-
-      def initialize(env)
-        @env = env
+      def self.build
+        new.build
       end
 
       def build
@@ -22,13 +19,15 @@ module Gitsh
 
       private
 
-      attr_reader :env
-
       def config_paths
         [
           File.join(env.config_directory, 'completions'),
           File.join(ENV.fetch('HOME', '/'), '.gitsh_completions'),
         ]
+      end
+
+      def env
+        Registry.env
       end
     end
   end

--- a/lib/gitsh/tab_completion/automaton_factory.rb
+++ b/lib/gitsh/tab_completion/automaton_factory.rb
@@ -5,6 +5,9 @@ require 'gitsh/tab_completion/dsl'
 module Gitsh
   module TabCompletion
     class AutomatonFactory
+      extend Registry::Client
+      use_registry_for :env
+
       def self.build
         new.build
       end
@@ -24,10 +27,6 @@ module Gitsh
           File.join(env.config_directory, 'completions'),
           File.join(ENV.fetch('HOME', '/'), '.gitsh_completions'),
         ]
-      end
-
-      def env
-        Registry.env
       end
     end
   end

--- a/lib/gitsh/tab_completion/command_completer.rb
+++ b/lib/gitsh/tab_completion/command_completer.rb
@@ -1,8 +1,12 @@
+require 'gitsh/registry'
+
 module Gitsh
   module TabCompletion
     class CommandCompleter
-      def initialize(line_editor, prior_words, input, automaton, escaper)
-        @line_editor = line_editor
+      extend Registry::Client
+      use_registry_for :line_editor
+
+      def initialize(prior_words, input, automaton, escaper)
         @prior_words = prior_words
         @input = input
         @automaton = automaton
@@ -18,7 +22,7 @@ module Gitsh
 
       private
 
-      attr_reader :line_editor, :prior_words, :input, :automaton, :escaper
+      attr_reader :prior_words, :input, :automaton, :escaper
 
       def completion_append_character
         if incomplete_path?

--- a/lib/gitsh/tab_completion/dsl.rb
+++ b/lib/gitsh/tab_completion/dsl.rb
@@ -4,10 +4,10 @@ require 'gitsh/tab_completion/dsl/parser'
 module Gitsh
   module TabCompletion
     module DSL
-      def self.load(path, start_state, env)
+      def self.load(path, start_state)
         source = File.read(path)
         tokens = Lexer.lex(source, path)
-        factory = Parser.parse(tokens, gitsh_env: env)
+        factory = Parser.parse(tokens, gitsh_env: Registry.env)
         factory.build(start_state)
       rescue Errno::ENOENT
       end

--- a/lib/gitsh/tab_completion/dsl.rb
+++ b/lib/gitsh/tab_completion/dsl.rb
@@ -7,7 +7,7 @@ module Gitsh
       def self.load(path, start_state)
         source = File.read(path)
         tokens = Lexer.lex(source, path)
-        factory = Parser.parse(tokens, gitsh_env: Registry.env)
+        factory = Parser.parse(tokens)
         factory.build(start_state)
       rescue Errno::ENOENT
       end

--- a/lib/gitsh/tab_completion/dsl/parser.rb
+++ b/lib/gitsh/tab_completion/dsl/parser.rb
@@ -1,5 +1,4 @@
 require 'rltk'
-require 'gitsh/registry'
 require 'gitsh/tab_completion/dsl/choice_factory'
 require 'gitsh/tab_completion/dsl/concatenation_factory'
 require 'gitsh/tab_completion/dsl/fallback_transition_factory'
@@ -60,16 +59,12 @@ module Gitsh
           private
 
           def build_matcher(var_name)
-            VARIABLE_TO_MATCHER_CLASS.fetch(var_name).new(gitsh_env)
+            VARIABLE_TO_MATCHER_CLASS.fetch(var_name).new
           rescue KeyError
             raise ParseError.new(
               'Invalid',
               RLTK::Token.new(:VAR, var_name, pos(0)),
             )
-          end
-
-          def gitsh_env
-            Registry.env
           end
         end
 

--- a/lib/gitsh/tab_completion/escaper.rb
+++ b/lib/gitsh/tab_completion/escaper.rb
@@ -1,17 +1,17 @@
 require 'gitsh/lexer'
+require 'gitsh/registry'
 
 module Gitsh
   module TabCompletion
     class Escaper
+      extend Registry::Client
+      use_registry_for :line_editor
+
       ESCAPABLES = {
         nil => Gitsh::Lexer::UNQUOTED_STRING_ESCAPABLES,
         '"' => Gitsh::Lexer::SOFT_STRING_ESCAPABLES,
         "'" => Gitsh::Lexer::HARD_STRING_ESCAPABLES,
       }.freeze
-
-      def initialize(line_editor)
-        @line_editor = line_editor
-      end
 
       def escape(option)
         option.gsub(escapables) { |char| "\\#{char}" }
@@ -22,8 +22,6 @@ module Gitsh
       end
 
       private
-
-      attr_reader :line_editor
 
       def escapables
         ESCAPABLES[line_editor.completion_quote_character].to_regexp

--- a/lib/gitsh/tab_completion/facade.rb
+++ b/lib/gitsh/tab_completion/facade.rb
@@ -30,7 +30,7 @@ module Gitsh
       def command_completions(context, input)
         CommandCompleter.new(
           line_editor,
-          AliasExpander.new(context.prior_words, env).call,
+          AliasExpander.new(context.prior_words).call,
           input,
           automaton,
           escaper,

--- a/lib/gitsh/tab_completion/facade.rb
+++ b/lib/gitsh/tab_completion/facade.rb
@@ -1,3 +1,4 @@
+require 'gitsh/registry'
 require 'gitsh/tab_completion/alias_expander'
 require 'gitsh/tab_completion/automaton_factory'
 require 'gitsh/tab_completion/command_completer'
@@ -8,8 +9,10 @@ require 'gitsh/tab_completion/variable_completer'
 module Gitsh
   module TabCompletion
     class Facade
-      def initialize(line_editor)
-        @line_editor = line_editor
+      extend Registry::Client
+      use_registry_for :line_editor
+
+      def initialize
         @automaton = AutomatonFactory.build
       end
 
@@ -24,11 +27,10 @@ module Gitsh
 
       private
 
-      attr_reader :line_editor, :automaton
+      attr_reader :automaton
 
       def command_completions(context, input)
         CommandCompleter.new(
-          line_editor,
           AliasExpander.new(context.prior_words).call,
           input,
           automaton,
@@ -37,11 +39,11 @@ module Gitsh
       end
 
       def variable_completions(input)
-        VariableCompleter.new(line_editor, input).call
+        VariableCompleter.new(input).call
       end
 
       def escaper
-        @escaper ||= Escaper.new(line_editor)
+        @escaper ||= Escaper.new
       end
     end
   end

--- a/lib/gitsh/tab_completion/facade.rb
+++ b/lib/gitsh/tab_completion/facade.rb
@@ -4,7 +4,6 @@ require 'gitsh/tab_completion/command_completer'
 require 'gitsh/tab_completion/context'
 require 'gitsh/tab_completion/escaper'
 require 'gitsh/tab_completion/variable_completer'
-require 'gitsh/registry'
 
 module Gitsh
   module TabCompletion
@@ -38,15 +37,11 @@ module Gitsh
       end
 
       def variable_completions(input)
-        VariableCompleter.new(line_editor, input, env).call
+        VariableCompleter.new(line_editor, input).call
       end
 
       def escaper
         @escaper ||= Escaper.new(line_editor)
-      end
-
-      def env
-        Registry.env
       end
     end
   end

--- a/lib/gitsh/tab_completion/facade.rb
+++ b/lib/gitsh/tab_completion/facade.rb
@@ -4,13 +4,13 @@ require 'gitsh/tab_completion/command_completer'
 require 'gitsh/tab_completion/context'
 require 'gitsh/tab_completion/escaper'
 require 'gitsh/tab_completion/variable_completer'
+require 'gitsh/registry'
 
 module Gitsh
   module TabCompletion
     class Facade
-      def initialize(line_editor, env)
+      def initialize(line_editor)
         @line_editor = line_editor
-        @env = env
         @automaton = AutomatonFactory.build(env)
       end
 
@@ -25,7 +25,7 @@ module Gitsh
 
       private
 
-      attr_reader :line_editor, :env, :automaton
+      attr_reader :line_editor, :automaton
 
       def command_completions(context, input)
         CommandCompleter.new(
@@ -43,6 +43,10 @@ module Gitsh
 
       def escaper
         @escaper ||= Escaper.new(line_editor)
+      end
+
+      def env
+        Registry.env
       end
     end
   end

--- a/lib/gitsh/tab_completion/facade.rb
+++ b/lib/gitsh/tab_completion/facade.rb
@@ -11,7 +11,7 @@ module Gitsh
     class Facade
       def initialize(line_editor)
         @line_editor = line_editor
-        @automaton = AutomatonFactory.build(env)
+        @automaton = AutomatonFactory.build
       end
 
       def call(input)

--- a/lib/gitsh/tab_completion/matchers/anything_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/anything_matcher.rb
@@ -4,9 +4,6 @@ module Gitsh
   module TabCompletion
     module Matchers
       class AnythingMatcher < BaseMatcher
-        def initialize(_env)
-        end
-
         def name
           'anything'
         end

--- a/lib/gitsh/tab_completion/matchers/branch_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/branch_matcher.rb
@@ -6,7 +6,7 @@ module Gitsh
     module Matchers
       class BranchMatcher < BaseMatcher
         extend Registry::Client
-        use_registry_for :env
+        use_registry_for :repo
 
         def name
           'branch'
@@ -15,7 +15,7 @@ module Gitsh
         private
 
         def all_completions
-          env.repo_branches
+          repo.branches
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/branch_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/branch_matcher.rb
@@ -1,23 +1,22 @@
+require 'gitsh/registry'
 require 'gitsh/tab_completion/matchers/base_matcher'
 
 module Gitsh
   module TabCompletion
     module Matchers
       class BranchMatcher < BaseMatcher
-        def initialize(env)
-          @env = env
-        end
-
         def name
           'branch'
         end
 
         private
 
-        attr_reader :env
-
         def all_completions
           env.repo_branches
+        end
+
+        def env
+          Registry.env
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/branch_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/branch_matcher.rb
@@ -5,6 +5,9 @@ module Gitsh
   module TabCompletion
     module Matchers
       class BranchMatcher < BaseMatcher
+        extend Registry::Client
+        use_registry_for :env
+
         def name
           'branch'
         end
@@ -13,10 +16,6 @@ module Gitsh
 
         def all_completions
           env.repo_branches
-        end
-
-        def env
-          Registry.env
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/command_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/command_matcher.rb
@@ -9,23 +9,17 @@ module Gitsh
         extend Registry::Client
         use_registry_for :env, :repo
 
-        def initialize(internal_command = Commands::InternalCommand)
-          @internal_command = internal_command
-        end
-
         def name
           'command'
         end
 
         private
 
-        attr_reader :internal_command
-
         def all_completions
           repo.commands + \
             repo.aliases + \
             env.local_aliases + \
-            internal_command.commands
+            Commands::InternalCommand.commands
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/command_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/command_matcher.rb
@@ -1,3 +1,4 @@
+require 'gitsh/registry'
 require 'gitsh/tab_completion/matchers/base_matcher'
 require 'gitsh/commands/internal_command'
 
@@ -5,8 +6,7 @@ module Gitsh
   module TabCompletion
     module Matchers
       class CommandMatcher < BaseMatcher
-        def initialize(env, internal_command = Commands::InternalCommand)
-          @env = env
+        def initialize(internal_command = Commands::InternalCommand)
           @internal_command = internal_command
         end
 
@@ -16,10 +16,14 @@ module Gitsh
 
         private
 
-        attr_reader :env, :internal_command
+        attr_reader :internal_command
 
         def all_completions
           env.git_commands + env.git_aliases + internal_command.commands
+        end
+
+        def env
+          Registry.env
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/command_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/command_matcher.rb
@@ -6,6 +6,9 @@ module Gitsh
   module TabCompletion
     module Matchers
       class CommandMatcher < BaseMatcher
+        extend Registry::Client
+        use_registry_for :env
+
         def initialize(internal_command = Commands::InternalCommand)
           @internal_command = internal_command
         end
@@ -20,10 +23,6 @@ module Gitsh
 
         def all_completions
           env.git_commands + env.git_aliases + internal_command.commands
-        end
-
-        def env
-          Registry.env
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/command_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/command_matcher.rb
@@ -7,7 +7,7 @@ module Gitsh
     module Matchers
       class CommandMatcher < BaseMatcher
         extend Registry::Client
-        use_registry_for :env
+        use_registry_for :env, :repo
 
         def initialize(internal_command = Commands::InternalCommand)
           @internal_command = internal_command
@@ -22,7 +22,10 @@ module Gitsh
         attr_reader :internal_command
 
         def all_completions
-          env.git_commands + env.git_aliases + internal_command.commands
+          repo.commands + \
+            repo.aliases + \
+            env.local_aliases + \
+            internal_command.commands
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/path_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/path_matcher.rb
@@ -4,9 +4,6 @@ module Gitsh
   module TabCompletion
     module Matchers
       class PathMatcher < BaseMatcher
-        def initialize(_env)
-        end
-
         def completions(token)
           prefix = normalize_path(token)
           paths(prefix).map { |option| option.sub(prefix, token) }

--- a/lib/gitsh/tab_completion/matchers/remote_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/remote_matcher.rb
@@ -6,7 +6,7 @@ module Gitsh
     module Matchers
       class RemoteMatcher < BaseMatcher
         extend Registry::Client
-        use_registry_for :env
+        use_registry_for :repo
 
         def name
           'remote'
@@ -15,7 +15,7 @@ module Gitsh
         private
 
         def all_completions
-          env.repo_remotes
+          repo.remotes
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/remote_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/remote_matcher.rb
@@ -1,23 +1,22 @@
+require 'gitsh/registry'
 require 'gitsh/tab_completion/matchers/base_matcher'
 
 module Gitsh
   module TabCompletion
     module Matchers
       class RemoteMatcher < BaseMatcher
-        def initialize(env)
-          @env = env
-        end
-
         def name
           'remote'
         end
 
         private
 
-        attr_reader :env
-
         def all_completions
           env.repo_remotes
+        end
+
+        def env
+          Registry.env
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/remote_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/remote_matcher.rb
@@ -5,6 +5,9 @@ module Gitsh
   module TabCompletion
     module Matchers
       class RemoteMatcher < BaseMatcher
+        extend Registry::Client
+        use_registry_for :env
+
         def name
           'remote'
         end
@@ -13,10 +16,6 @@ module Gitsh
 
         def all_completions
           env.repo_remotes
-        end
-
-        def env
-          Registry.env
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/revision_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/revision_matcher.rb
@@ -6,7 +6,7 @@ module Gitsh
     module Matchers
       class RevisionMatcher < BaseMatcher
         extend Registry::Client
-        use_registry_for :env
+        use_registry_for :repo
 
         SEPARATORS = /(?:\.\.+|[:^~\\])/
 
@@ -22,7 +22,7 @@ module Gitsh
         private
 
         def all_completions
-          env.repo_heads
+          repo.heads
         end
 
         def split(token)

--- a/lib/gitsh/tab_completion/matchers/revision_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/revision_matcher.rb
@@ -5,6 +5,9 @@ module Gitsh
   module TabCompletion
     module Matchers
       class RevisionMatcher < BaseMatcher
+        extend Registry::Client
+        use_registry_for :env
+
         SEPARATORS = /(?:\.\.+|[:^~\\])/
 
         def name
@@ -25,10 +28,6 @@ module Gitsh
         def split(token)
           parts = token.rpartition(SEPARATORS)
           [parts[0...-1].join, parts[-1]]
-        end
-
-        def env
-          Registry.env
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/revision_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/revision_matcher.rb
@@ -1,3 +1,4 @@
+require 'gitsh/registry'
 require 'gitsh/tab_completion/matchers/base_matcher'
 
 module Gitsh
@@ -5,10 +6,6 @@ module Gitsh
     module Matchers
       class RevisionMatcher < BaseMatcher
         SEPARATORS = /(?:\.\.+|[:^~\\])/
-
-        def initialize(env)
-          @env = env
-        end
 
         def name
           'revision'
@@ -21,8 +18,6 @@ module Gitsh
 
         private
 
-        attr_reader :env
-
         def all_completions
           env.repo_heads
         end
@@ -30,6 +25,10 @@ module Gitsh
         def split(token)
           parts = token.rpartition(SEPARATORS)
           [parts[0...-1].join, parts[-1]]
+        end
+
+        def env
+          Registry.env
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/tag_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/tag_matcher.rb
@@ -1,23 +1,22 @@
+require 'gitsh/registry'
 require 'gitsh/tab_completion/matchers/base_matcher'
 
 module Gitsh
   module TabCompletion
     module Matchers
       class TagMatcher < BaseMatcher
-        def initialize(env)
-          @env = env
-        end
-
         def name
           'tag'
         end
 
         private
 
-        attr_reader :env
-
         def all_completions
           env.repo_tags
+        end
+
+        def env
+          Registry.env
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/tag_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/tag_matcher.rb
@@ -5,6 +5,9 @@ module Gitsh
   module TabCompletion
     module Matchers
       class TagMatcher < BaseMatcher
+        extend Registry::Client
+        use_registry_for :env
+
         def name
           'tag'
         end
@@ -13,10 +16,6 @@ module Gitsh
 
         def all_completions
           env.repo_tags
-        end
-
-        def env
-          Registry.env
         end
       end
     end

--- a/lib/gitsh/tab_completion/matchers/tag_matcher.rb
+++ b/lib/gitsh/tab_completion/matchers/tag_matcher.rb
@@ -6,7 +6,7 @@ module Gitsh
     module Matchers
       class TagMatcher < BaseMatcher
         extend Registry::Client
-        use_registry_for :env
+        use_registry_for :repo
 
         def name
           'tag'
@@ -15,7 +15,7 @@ module Gitsh
         private
 
         def all_completions
-          env.repo_tags
+          repo.tags
         end
       end
     end

--- a/lib/gitsh/tab_completion/variable_completer.rb
+++ b/lib/gitsh/tab_completion/variable_completer.rb
@@ -4,10 +4,9 @@ module Gitsh
   module TabCompletion
     class VariableCompleter
       extend Registry::Client
-      use_registry_for :env
+      use_registry_for :env, :line_editor
 
-      def initialize(line_editor, input)
-        @line_editor = line_editor
+      def initialize(input)
         @input = input
       end
 
@@ -20,7 +19,7 @@ module Gitsh
 
       private
 
-      attr_reader :line_editor, :input
+      attr_reader :input
 
       def completion_append_character
         if prefix.end_with?('{')

--- a/lib/gitsh/tab_completion/variable_completer.rb
+++ b/lib/gitsh/tab_completion/variable_completer.rb
@@ -1,10 +1,11 @@
+require 'gitsh/registry'
+
 module Gitsh
   module TabCompletion
     class VariableCompleter
-      def initialize(line_editor, input, env)
+      def initialize(line_editor, input)
         @line_editor = line_editor
         @input = input
-        @env = env
       end
 
       def call
@@ -16,7 +17,7 @@ module Gitsh
 
       private
 
-      attr_reader :line_editor, :input, :env
+      attr_reader :line_editor, :input
 
       def completion_append_character
         if prefix.end_with?('{')
@@ -45,6 +46,10 @@ module Gitsh
           parts = input.rpartition(/\$\{?/)
           [parts[0...-1].join, parts.last]
         )
+      end
+
+      def env
+        Registry.env
       end
     end
   end

--- a/lib/gitsh/tab_completion/variable_completer.rb
+++ b/lib/gitsh/tab_completion/variable_completer.rb
@@ -3,6 +3,9 @@ require 'gitsh/registry'
 module Gitsh
   module TabCompletion
     class VariableCompleter
+      extend Registry::Client
+      use_registry_for :env
+
       def initialize(line_editor, input)
         @line_editor = line_editor
         @input = input
@@ -46,10 +49,6 @@ module Gitsh
           parts = input.rpartition(/\$\{?/)
           [parts[0...-1].join, parts.last]
         )
-      end
-
-      def env
-        Registry.env
       end
     end
   end

--- a/lib/gitsh/terminal.rb
+++ b/lib/gitsh/terminal.rb
@@ -3,9 +3,15 @@ require 'open3'
 
 module Gitsh
   class Terminal
-    include Singleton
-
     class UnknownSizeError < StandardError; end
+
+    def self.color_support?
+      new.color_support?
+    end
+
+    def self.size
+      new.size
+    end
 
     def color_support?
       execute('tput colors').to_i > 0

--- a/lib/gitsh/terminal.rb
+++ b/lib/gitsh/terminal.rb
@@ -1,4 +1,3 @@
-require 'singleton'
 require 'open3'
 
 module Gitsh

--- a/spec/integration/arguments_spec.rb
+++ b/spec/integration/arguments_spec.rb
@@ -49,16 +49,14 @@ describe 'When passed arguments' do
   end
 
   def setup_repo
-    Gitsh::Registry[:repo] = Gitsh::GitRepository.new
+    register(repo: Gitsh::GitRepository.new)
   end
 
   def setup_output_streams
     output = StringIO.new
     error = StringIO.new
-    Gitsh::Registry[:env] = Gitsh::Environment.new(
-      output_stream: output,
-      error_stream: error,
-    )
+    env = Gitsh::Environment.new(output_stream: output, error_stream: error)
+    register(env: env)
     [output, error]
   end
 end

--- a/spec/integration/arguments_spec.rb
+++ b/spec/integration/arguments_spec.rb
@@ -2,32 +2,28 @@ require 'spec_helper'
 require 'gitsh/cli'
 require 'gitsh/environment'
 
-describe '--version' do
-  it 'outputs the version, and then exits' do
-    output = StringIO.new
-    error = StringIO.new
-    env = Gitsh::Environment.new(output_stream: output, error_stream: error)
+describe 'When passed arguments' do
+  describe '--version' do
+    it 'outputs the version, and then exits' do
+      output, error = setup_output_streams
 
-    runner = lambda do
-      Gitsh::CLI.new(args: %w(--version), env: env).run
+      runner = lambda do
+        Gitsh::CLI.new(args: %w(--version)).run
+      end
+
+      expect(runner).to raise_error SystemExit
+      expect(error.string).to be_empty
+      expect(output.string.chomp).to eq Gitsh::VERSION
     end
-
-    expect(runner).to raise_error SystemExit
-    expect(error.string).to be_empty
-    expect(output.string.chomp).to eq Gitsh::VERSION
   end
-end
 
-describe 'Unexpected arguments' do
   %w(--badger -x).each do |argument|
-    context "with the argument #{argument.inspect}" do
+    describe argument do
       it 'outputs a usage message and exits' do
-        output = StringIO.new
-        error = StringIO.new
-        env = Gitsh::Environment.new(output_stream: output, error_stream: error)
+        output, error = setup_output_streams
 
         runner = lambda do
-          Gitsh::CLI.new(args: [argument], env: env).run
+          Gitsh::CLI.new(args: [argument]).run
         end
 
         expect(runner).to raise_error SystemExit
@@ -38,15 +34,25 @@ describe 'Unexpected arguments' do
       end
     end
   end
-end
 
-describe '--git' do
-  it 'uses the requested git binary' do
-    GitshRunner.interactive(args: ['--git', fake_git_path]) do |gitsh|
-      gitsh.type('init')
+  describe '--git' do
+    it 'uses the requested git binary' do
+      GitshRunner.interactive(args: ['--git', fake_git_path]) do |gitsh|
+        gitsh.type('init')
 
-      expect(gitsh).to output_no_errors
-      expect(gitsh).to output(/^Fake git: init$/)
+        expect(gitsh).to output_no_errors
+        expect(gitsh).to output(/^Fake git: init$/)
+      end
     end
+  end
+
+  def setup_output_streams
+    output = StringIO.new
+    error = StringIO.new
+    Gitsh::Registry[:env] = Gitsh::Environment.new(
+      output_stream: output,
+      error_stream: error,
+    )
+    [output, error]
   end
 end

--- a/spec/integration/arguments_spec.rb
+++ b/spec/integration/arguments_spec.rb
@@ -9,7 +9,7 @@ describe 'When passed arguments' do
       output, error = setup_output_streams
 
       runner = lambda do
-        Gitsh::CLI.new(args: %w(--version)).run
+        Gitsh::CLI.new(%w(--version)).run
       end
 
       expect(runner).to raise_error SystemExit
@@ -25,7 +25,7 @@ describe 'When passed arguments' do
         output, error = setup_output_streams
 
         runner = lambda do
-          Gitsh::CLI.new(args: [argument]).run
+          Gitsh::CLI.new([argument]).run
         end
 
         expect(runner).to raise_error SystemExit

--- a/spec/integration/arguments_spec.rb
+++ b/spec/integration/arguments_spec.rb
@@ -5,6 +5,7 @@ require 'gitsh/environment'
 describe 'When passed arguments' do
   describe '--version' do
     it 'outputs the version, and then exits' do
+      setup_repo
       output, error = setup_output_streams
 
       runner = lambda do
@@ -20,6 +21,7 @@ describe 'When passed arguments' do
   %w(--badger -x).each do |argument|
     describe argument do
       it 'outputs a usage message and exits' do
+        setup_repo
         output, error = setup_output_streams
 
         runner = lambda do
@@ -44,6 +46,10 @@ describe 'When passed arguments' do
         expect(gitsh).to output(/^Fake git: init$/)
       end
     end
+  end
+
+  def setup_repo
+    Gitsh::Registry[:repo] = Gitsh::GitRepository.new
   end
 
   def setup_output_streams

--- a/spec/support/gitsh_runner.rb
+++ b/spec/support/gitsh_runner.rb
@@ -4,6 +4,7 @@ require 'tmpdir'
 require 'gitsh/cli'
 require 'gitsh/environment'
 require 'gitsh/line_editor_history_filter'
+require 'gitsh/registry'
 require 'rspec/mocks/test_double'
 require File.expand_path('../file_system', __FILE__)
 
@@ -31,6 +32,7 @@ class GitshRunner
     with_a_temporary_home_directory do
       in_a_temporary_directory do
         setup_unix_env
+        populate_registry
         runner = start_runner_thread
         wait_for_prompt
 
@@ -50,6 +52,7 @@ class GitshRunner
     with_a_temporary_home_directory do
       in_a_temporary_directory do
         setup_unix_env
+        populate_registry
         cli.run
       end
     end
@@ -97,7 +100,6 @@ class GitshRunner
   def cli
     Gitsh::CLI.new(
       args: options.fetch(:args, []),
-      env: env,
       interactive_input_strategy: interactive_input_strategy
     )
   end
@@ -125,6 +127,10 @@ class GitshRunner
 
   def wait_for_prompt
     @prompt = line_editor.prompt
+  end
+
+  def populate_registry
+    Gitsh::Registry[:env] = env
   end
 
   def setup_unix_env

--- a/spec/support/gitsh_runner.rb
+++ b/spec/support/gitsh_runner.rb
@@ -3,6 +3,7 @@ require 'tempfile'
 require 'tmpdir'
 require 'gitsh/cli'
 require 'gitsh/environment'
+require 'gitsh/git_repository'
 require 'gitsh/line_editor_history_filter'
 require 'gitsh/registry'
 require 'rspec/mocks/test_double'
@@ -130,6 +131,7 @@ class GitshRunner
   end
 
   def populate_registry
+    Gitsh::Registry[:repo] = Gitsh::GitRepository.new
     Gitsh::Registry[:env] = env
   end
 

--- a/spec/support/gitsh_runner.rb
+++ b/spec/support/gitsh_runner.rb
@@ -101,13 +101,6 @@ class GitshRunner
   def cli
     Gitsh::CLI.new(
       args: options.fetch(:args, []),
-      interactive_input_strategy: interactive_input_strategy
-    )
-  end
-
-  def interactive_input_strategy
-    Gitsh::InputStrategies::Interactive.new(
-      line_editor: line_editor,
     )
   end
 
@@ -132,6 +125,7 @@ class GitshRunner
   def populate_registry
     Gitsh::Registry[:repo] = Gitsh::GitRepository.new
     Gitsh::Registry[:env] = env
+    Gitsh::Registry[:line_editor] = line_editor
   end
 
   def setup_unix_env

--- a/spec/support/gitsh_runner.rb
+++ b/spec/support/gitsh_runner.rb
@@ -108,7 +108,6 @@ class GitshRunner
   def interactive_input_strategy
     Gitsh::InputStrategies::Interactive.new(
       line_editor: line_editor,
-      env: env
     )
   end
 

--- a/spec/support/gitsh_runner.rb
+++ b/spec/support/gitsh_runner.rb
@@ -121,9 +121,9 @@ class GitshRunner
   end
 
   def populate_registry
-    Gitsh::Registry[:repo] = Gitsh::GitRepository.new
-    Gitsh::Registry[:env] = env
-    Gitsh::Registry[:line_editor] = line_editor
+    Gitsh::Registry.instance[:repo] = Gitsh::GitRepository.new
+    Gitsh::Registry.instance[:env] = env
+    Gitsh::Registry.instance[:line_editor] = line_editor
   end
 
   def setup_unix_env

--- a/spec/support/gitsh_runner.rb
+++ b/spec/support/gitsh_runner.rb
@@ -99,9 +99,7 @@ class GitshRunner
   end
 
   def cli
-    Gitsh::CLI.new(
-      args: options.fetch(:args, []),
-    )
+    Gitsh::CLI.new(options.fetch(:args, []))
   end
 
   def env

--- a/spec/support/registry.rb
+++ b/spec/support/registry.rb
@@ -1,3 +1,4 @@
+require 'gitsh/colors'
 require 'gitsh/environment'
 require 'gitsh/git_repository'
 require 'gitsh/registry'
@@ -20,6 +21,14 @@ module Registry
 
   def register_repo(attrs = {})
     default_attrs = {
+      current_head: 'master',
+      color: Gitsh::Colors::RED_FG,
+      status: instance_double(
+        Gitsh::GitRepository::Status,
+        initialized?: true,
+        has_untracked_files?: false,
+        has_modified_files?: false,
+      ),
     }
     Gitsh::Registry[:repo] = instance_double(
       Gitsh::GitRepository,

--- a/spec/support/registry.rb
+++ b/spec/support/registry.rb
@@ -4,9 +4,12 @@ require 'gitsh/registry'
 module Registry
   def register_env(attrs = {})
     default_atts = {
+      config_directory: File.expand_path('../../etc', __FILE__),
       git_command: fake_git_path,
-      tty?: true,
+      print: nil,
+      puts: nil,
       puts_error: nil,
+      tty?: true,
     }
     Gitsh::Registry[:env] = instance_double(
       Gitsh::Environment,

--- a/spec/support/registry.rb
+++ b/spec/support/registry.rb
@@ -1,9 +1,10 @@
 require 'gitsh/environment'
+require 'gitsh/git_repository'
 require 'gitsh/registry'
 
 module Registry
   def register_env(attrs = {})
-    default_atts = {
+    default_attrs = {
       config_directory: File.expand_path('../../etc', __FILE__),
       git_command: fake_git_path,
       print: nil,
@@ -13,7 +14,16 @@ module Registry
     }
     Gitsh::Registry[:env] = instance_double(
       Gitsh::Environment,
-      default_atts.merge(attrs),
+      default_attrs.merge(attrs),
+    )
+  end
+
+  def register_repo(attrs = {})
+    default_attrs = {
+    }
+    Gitsh::Registry[:repo] = instance_double(
+      Gitsh::GitRepository,
+      default_attrs.merge(attrs),
     )
   end
 end

--- a/spec/support/registry.rb
+++ b/spec/support/registry.rb
@@ -45,10 +45,11 @@ module Registry
 
   def register_line_editor(attrs = {})
     default_attrs = {
-      :'completion_append_character=' => nil,
       :'completer_quote_characters=' => nil,
       :'completer_word_break_characters=' => nil,
+      :'completion_append_character=' => nil,
       :'completion_proc=' => nil,
+      :'completion_suppress_quote=' => nil,
       :'quoting_detection_proc=' => nil,
       readline: nil
     }

--- a/spec/support/registry.rb
+++ b/spec/support/registry.rb
@@ -7,7 +7,7 @@ require 'gitsh/registry'
 module Registry
   def register(entries)
     entries.each do |name, object|
-      Gitsh::Registry[name] = object
+      registry[name] = object
     end
   end
 
@@ -22,15 +22,15 @@ module Registry
     }
     env = instance_double(Gitsh::Environment, default_attrs.merge(attrs))
     allow(env).to receive(:fetch).and_yield
-    Gitsh::Registry[:env] = env
+    registry[:env] = env
   end
 
   def registered_env
-    Gitsh::Registry[:env]
+    registry[:env]
   end
 
   def set_registered_env_value(key, value)
-    allow(Gitsh::Registry[:env]).to receive(:fetch).with(key).and_return(value)
+    allow(registry[:env]).to receive(:fetch).with(key).and_return(value)
   end
 
   def register_repo(attrs = {})
@@ -44,7 +44,7 @@ module Registry
         has_modified_files?: false,
       ),
     }
-    Gitsh::Registry[:repo] = instance_double(
+    registry[:repo] = instance_double(
       Gitsh::GitRepository,
       default_attrs.merge(attrs),
     )
@@ -62,11 +62,15 @@ module Registry
     }
     line_editor = class_double(Gitsh::LineEditor, default_attrs.merge(attrs))
     line_editor.const_set('HISTORY', [])
-    Gitsh::Registry[:line_editor] = line_editor
+    registry[:line_editor] = line_editor
   end
 
   def registered_line_editor
-    Gitsh::Registry[:line_editor]
+    registry[:line_editor]
+  end
+
+  def registry
+    Gitsh::Registry.instance
   end
 end
 

--- a/spec/support/registry.rb
+++ b/spec/support/registry.rb
@@ -1,0 +1,21 @@
+require 'gitsh/environment'
+require 'gitsh/registry'
+
+module Registry
+  def register_env(attrs = {})
+    default_atts = {
+      git_command: fake_git_path,
+      tty?: true,
+      puts_error: nil,
+    }
+    Gitsh::Registry[:env] = instance_double(
+      Gitsh::Environment,
+      default_atts.merge(attrs),
+    )
+  end
+end
+
+RSpec.configure do |config|
+  config.include Registry
+  config.before { Gitsh::Registry.clear }
+end

--- a/spec/support/registry.rb
+++ b/spec/support/registry.rb
@@ -20,10 +20,17 @@ module Registry
       puts_error: nil,
       tty?: true,
     }
-    Gitsh::Registry[:env] = instance_double(
-      Gitsh::Environment,
-      default_attrs.merge(attrs),
-    )
+    env = instance_double(Gitsh::Environment, default_attrs.merge(attrs))
+    allow(env).to receive(:fetch).and_yield
+    Gitsh::Registry[:env] = env
+  end
+
+  def registered_env
+    Gitsh::Registry[:env]
+  end
+
+  def set_registered_env_value(key, value)
+    allow(Gitsh::Registry[:env]).to receive(:fetch).with(key).and_return(value)
   end
 
   def register_repo(attrs = {})
@@ -53,10 +60,13 @@ module Registry
       :'quoting_detection_proc=' => nil,
       readline: nil
     }
-    Gitsh::Registry[:line_editor] = class_double(
-      Gitsh::LineEditor,
-      default_attrs.merge(attrs),
-    )
+    line_editor = class_double(Gitsh::LineEditor, default_attrs.merge(attrs))
+    line_editor.const_set('HISTORY', [])
+    Gitsh::Registry[:line_editor] = line_editor
+  end
+
+  def registered_line_editor
+    Gitsh::Registry[:line_editor]
   end
 end
 

--- a/spec/support/registry.rb
+++ b/spec/support/registry.rb
@@ -1,9 +1,16 @@
 require 'gitsh/colors'
 require 'gitsh/environment'
 require 'gitsh/git_repository'
+require 'gitsh/line_editor'
 require 'gitsh/registry'
 
 module Registry
+  def register(entries)
+    entries.each do |name, object|
+      Gitsh::Registry[name] = object
+    end
+  end
+
   def register_env(attrs = {})
     default_attrs = {
       config_directory: File.expand_path('../../etc', __FILE__),
@@ -32,6 +39,21 @@ module Registry
     }
     Gitsh::Registry[:repo] = instance_double(
       Gitsh::GitRepository,
+      default_attrs.merge(attrs),
+    )
+  end
+
+  def register_line_editor(attrs = {})
+    default_attrs = {
+      :'completion_append_character=' => nil,
+      :'completer_quote_characters=' => nil,
+      :'completer_word_break_characters=' => nil,
+      :'completion_proc=' => nil,
+      :'quoting_detection_proc=' => nil,
+      readline: nil
+    }
+    Gitsh::Registry[:line_editor] = class_double(
+      Gitsh::LineEditor,
       default_attrs.merge(attrs),
     )
   end

--- a/spec/units/cli_spec.rb
+++ b/spec/units/cli_spec.rb
@@ -54,14 +54,14 @@ describe Gitsh::CLI do
 
     context 'with an unreadable script file' do
       it 'exits' do
-        register_env
+        env = register_env
         interpreter = stub_interpreter
         allow(interpreter).to receive(:run).
           and_raise(Gitsh::NoInputError, 'Oh no!')
         cli = Gitsh::CLI.new(['path/to/a/script'])
 
         expect { cli.run }.to raise_exception(SystemExit)
-        expect(Gitsh::Registry.env).
+        expect(env).
           to have_received(:puts_error).with('gitsh: Oh no!')
       end
     end
@@ -77,11 +77,11 @@ describe Gitsh::CLI do
 
     context 'with a non-existent git' do
       it 'exits with a helpful error message' do
-        register_env(git_command: 'nonexistent')
+        env = register_env(git_command: 'nonexistent')
         cli = Gitsh::CLI.new([])
 
         expect { cli.run }.to raise_exception(SystemExit)
-        expect(Gitsh::Registry.env).to have_received(:puts_error).with(
+        expect(env).to have_received(:puts_error).with(
           "gitsh: nonexistent: No such file or directory\nEnsure git is on "\
           'your PATH, or specify the path to git using the --git option',
         )
@@ -93,11 +93,11 @@ describe Gitsh::CLI do
         non_executable = Tempfile.new('git')
         non_executable.close
         begin
-          register_env(git_command: non_executable.path)
+          env = register_env(git_command: non_executable.path)
           cli = Gitsh::CLI.new([])
 
           expect { cli.run }.to raise_exception(SystemExit)
-          expect(Gitsh::Registry.env).to have_received(:puts_error).with(
+          expect(env).to have_received(:puts_error).with(
             "gitsh: #{non_executable.path}: Permission denied\nEnsure git is "\
             'executable',
           )

--- a/spec/units/cli_spec.rb
+++ b/spec/units/cli_spec.rb
@@ -5,6 +5,7 @@ describe Gitsh::CLI do
   describe '#run' do
     context 'with valid arguments and no script file' do
       it 'uses the interactive input strategy' do
+        register_env
         interpreter = stub_interpreter
         interactive_input_strategy = stub_interactive_input_strategy
         cli = Gitsh::CLI.new(args: [])
@@ -19,14 +20,10 @@ describe Gitsh::CLI do
 
     context 'when STDIN is not a TTY' do
       it 'calls the script runner with -' do
+        register_env(tty?: false)
         interpreter = stub_interpreter
         file_input_strategy = stub_file_input_strategy
-        env = double(
-          'Environment',
-          tty?: false,
-          git_command: fake_git_path,
-        )
-        cli = Gitsh::CLI.new(args: [], env: env)
+        cli = Gitsh::CLI.new(args: [])
 
         cli.run
 
@@ -40,6 +37,7 @@ describe Gitsh::CLI do
 
     context 'with a script file' do
       it 'calls the script runner with the script file' do
+        register_env
         interpreter = stub_interpreter
         file_input_strategy = stub_file_input_strategy
         cli = Gitsh::CLI.new(args: ['path/to/a/script'])
@@ -56,21 +54,22 @@ describe Gitsh::CLI do
 
     context 'with an unreadable script file' do
       it 'exits' do
-        env = double('env', puts_error: nil, git_command: fake_git_path)
+        register_env
         interpreter = stub_interpreter
         allow(interpreter).to receive(:run).
           and_raise(Gitsh::NoInputError, 'Oh no!')
-        cli = Gitsh::CLI.new(env: env, args: ['path/to/a/script'])
+        cli = Gitsh::CLI.new(args: ['path/to/a/script'])
 
         expect { cli.run }.to raise_exception(SystemExit)
-        expect(env).to have_received(:puts_error).with('gitsh: Oh no!')
+        expect(Gitsh::Registry.env).
+          to have_received(:puts_error).with('gitsh: Oh no!')
       end
     end
 
     context 'with invalid arguments' do
       it 'exits with a usage message' do
-        env = double('Environment', puts_error: nil)
-        cli = Gitsh::CLI.new(args: %w( --bad-argument ), env: env)
+        register_env
+        cli = Gitsh::CLI.new(args: %w( --bad-argument ))
 
         expect { cli.run }.to raise_exception(SystemExit)
       end
@@ -78,11 +77,11 @@ describe Gitsh::CLI do
 
     context 'with a non-existent git' do
       it 'exits with a helpful error message' do
-        env = double('Environment', puts_error: nil, git_command: 'nonexistent')
-        cli = Gitsh::CLI.new(args: [], env: env)
+        register_env(git_command: 'nonexistent')
+        cli = Gitsh::CLI.new(args: [])
 
         expect { cli.run }.to raise_exception(SystemExit)
-        expect(env).to have_received(:puts_error).with(
+        expect(Gitsh::Registry.env).to have_received(:puts_error).with(
           "gitsh: nonexistent: No such file or directory\nEnsure git is on "\
           'your PATH, or specify the path to git using the --git option',
         )
@@ -94,15 +93,11 @@ describe Gitsh::CLI do
         non_executable = Tempfile.new('git')
         non_executable.close
         begin
-          env = double(
-            'Environment',
-            puts_error: nil,
-            git_command: non_executable.path,
-          )
-          cli = Gitsh::CLI.new(args: [], env: env)
+          register_env(git_command: non_executable.path)
+          cli = Gitsh::CLI.new(args: [])
 
           expect { cli.run }.to raise_exception(SystemExit)
-          expect(env).to have_received(:puts_error).with(
+          expect(Gitsh::Registry.env).to have_received(:puts_error).with(
             "gitsh: #{non_executable.path}: Permission denied\nEnsure git is "\
             'executable',
           )

--- a/spec/units/cli_spec.rb
+++ b/spec/units/cli_spec.rb
@@ -8,7 +8,7 @@ describe Gitsh::CLI do
         register_env
         interpreter = stub_interpreter
         interactive_input_strategy = stub_interactive_input_strategy
-        cli = Gitsh::CLI.new(args: [])
+        cli = Gitsh::CLI.new([])
 
         cli.run
 
@@ -23,7 +23,7 @@ describe Gitsh::CLI do
         register_env(tty?: false)
         interpreter = stub_interpreter
         file_input_strategy = stub_file_input_strategy
-        cli = Gitsh::CLI.new(args: [])
+        cli = Gitsh::CLI.new([])
 
         cli.run
 
@@ -40,7 +40,7 @@ describe Gitsh::CLI do
         register_env
         interpreter = stub_interpreter
         file_input_strategy = stub_file_input_strategy
-        cli = Gitsh::CLI.new(args: ['path/to/a/script'])
+        cli = Gitsh::CLI.new(['path/to/a/script'])
 
         cli.run
 
@@ -58,7 +58,7 @@ describe Gitsh::CLI do
         interpreter = stub_interpreter
         allow(interpreter).to receive(:run).
           and_raise(Gitsh::NoInputError, 'Oh no!')
-        cli = Gitsh::CLI.new(args: ['path/to/a/script'])
+        cli = Gitsh::CLI.new(['path/to/a/script'])
 
         expect { cli.run }.to raise_exception(SystemExit)
         expect(Gitsh::Registry.env).
@@ -69,7 +69,7 @@ describe Gitsh::CLI do
     context 'with invalid arguments' do
       it 'exits with a usage message' do
         register_env
-        cli = Gitsh::CLI.new(args: %w( --bad-argument ))
+        cli = Gitsh::CLI.new(['--bad-argument'])
 
         expect { cli.run }.to raise_exception(SystemExit)
       end
@@ -78,7 +78,7 @@ describe Gitsh::CLI do
     context 'with a non-existent git' do
       it 'exits with a helpful error message' do
         register_env(git_command: 'nonexistent')
-        cli = Gitsh::CLI.new(args: [])
+        cli = Gitsh::CLI.new([])
 
         expect { cli.run }.to raise_exception(SystemExit)
         expect(Gitsh::Registry.env).to have_received(:puts_error).with(
@@ -94,7 +94,7 @@ describe Gitsh::CLI do
         non_executable.close
         begin
           register_env(git_command: non_executable.path)
-          cli = Gitsh::CLI.new(args: [])
+          cli = Gitsh::CLI.new([])
 
           expect { cli.run }.to raise_exception(SystemExit)
           expect(Gitsh::Registry.env).to have_received(:puts_error).with(

--- a/spec/units/environment_spec.rb
+++ b/spec/units/environment_spec.rb
@@ -238,86 +238,13 @@ describe Gitsh::Environment do
     end
   end
 
-  describe '#git_aliases' do
-    it 'combines locally-set aliases with global aliases' do
-      register_repo(aliases: ['foo', 'bar'])
+  describe '#local_aliases' do
+    it 'returns names of aliases defined in the gitsh session' do
       env = described_class.new
-      register(env: env)
       env['aliasish'] = 'not relevant'
       env['alias.baz'] = '!echo baz'
 
-      expect(env.git_aliases).to eq ['foo', 'bar', 'baz'].sort
-    end
-  end
-
-  context 'delegated methods' do
-    let(:repo) { Gitsh::Registry[:repo] }
-    let(:env) { described_class.new }
-
-    describe '#repo_branches' do
-      it 'is delegated to the GitRepository' do
-        expect(env).to delegate(:repo_branches).to(repo, :branches)
-      end
-    end
-
-    describe '#repo_tags' do
-      it 'is delegated to the GitRepository' do
-        expect(env).to delegate(:repo_tags).to(repo, :tags)
-      end
-    end
-
-    describe '#repo_heads' do
-      it 'is delegated to the GitRepository' do
-        expect(env).to delegate(:repo_heads).to(repo, :heads)
-      end
-    end
-
-    describe '#repo_current_head' do
-      it 'is delegated to the GitRepository' do
-        expect(env).to delegate(:repo_current_head).to(repo, :current_head)
-      end
-    end
-
-    describe '#repo_status' do
-      it 'is delegated to the GitRepository' do
-        expect(env).to delegate(:repo_status).to(repo, :status)
-      end
-    end
-
-    describe '#git_commands' do
-      it 'is delegated to the GitRepository' do
-        expect(env).to delegate(:git_commands).to(repo, :commands)
-      end
-    end
-
-    describe '#repo_config_color' do
-      context 'when there is no environment variable set' do
-        it 'gets the color setting from the repo' do
-          expected_color = double('color')
-          register_repo(config_color: expected_color, config: nil)
-          env = described_class.new
-
-          color = env.repo_config_color('test.color.foo', 'red')
-
-          expect(color).to eq expected_color
-          expect(Gitsh::Registry[:repo]).to have_received(:config_color).
-            with('test.color.foo', 'red')
-        end
-      end
-
-      context 'when there is an environment variable set' do
-        it 'gets the repo to convert the color to an ANSI escape sequence' do
-          expected_color = double('color')
-          register_repo(color: expected_color, config: nil)
-          env = described_class.new
-
-          env['test.color.foo'] = 'blue'
-          color = env.repo_config_color('test.color.foo', 'red')
-
-          expect(color).to eq expected_color
-          expect(Gitsh::Registry[:repo]).to have_received(:color).with('blue')
-        end
-      end
+      expect(env.local_aliases).to eq ['baz']
     end
   end
 

--- a/spec/units/environment_spec.rb
+++ b/spec/units/environment_spec.rb
@@ -16,10 +16,10 @@ describe Gitsh::Environment do
   describe '#fetch' do
     context 'for a magic variable' do
       it 'returns the value of the magic variable' do
-        magic_variables = double(:magic_variables)
+        magic_variables = stub_magic_variables
         allow(magic_variables).to receive(:fetch).with(:_prior).
           and_return('a-branch-name')
-        env = described_class.new(magic_variables: magic_variables)
+        env = described_class.new
 
         expect(env.fetch(:_prior)).to eq 'a-branch-name'
         expect(env.fetch('_prior')).to eq 'a-branch-name'
@@ -72,12 +72,10 @@ describe Gitsh::Environment do
   describe '#available_variables' do
     it 'returns the names of all available variables' do
       register_repo(available_config_variables: [:'user.name'])
-      magic_variables = double('MagicVariables')
-      allow(magic_variables).to receive(:available_variables).
-        and_return([:_prior])
-      env = described_class.new(
-        magic_variables: magic_variables,
+      magic_variables = stub_magic_variables(
+        available_variables: [:_prior],
       )
+      env = described_class.new
       env[:foo] = 'bar'
       env['user.name'] = 'Config Override'
 
@@ -252,5 +250,11 @@ describe Gitsh::Environment do
     entries.each do |key, object|
       Gitsh::Registry[key] = object
     end
+  end
+
+  def stub_magic_variables(attrs = {})
+    magic_variables = instance_double(Gitsh::MagicVariables, attrs)
+    allow(Gitsh::MagicVariables).to receive(:new).and_return(magic_variables)
+    magic_variables
   end
 end

--- a/spec/units/environment_spec.rb
+++ b/spec/units/environment_spec.rb
@@ -52,6 +52,7 @@ describe Gitsh::Environment do
     context 'for an unknown variable with a default block given' do
       it 'yields to the block' do
         env = described_class.new
+        register(env)
 
         expect(env.fetch(:unknown) { 'default' }).to eq 'default'
       end
@@ -154,6 +155,7 @@ describe Gitsh::Environment do
     it 'defaults to "/usr/bin/env git"' do
       with_a_temporary_home_directory do
         env = described_class.new
+        register(env)
 
         expect(env.git_command).to eq '/usr/bin/env git'
       end
@@ -318,5 +320,9 @@ describe Gitsh::Environment do
         end
       end
     end
+  end
+
+  def register(env)
+    Gitsh::Registry[:env] = env
   end
 end

--- a/spec/units/environment_spec.rb
+++ b/spec/units/environment_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'gitsh/environment'
 
 describe Gitsh::Environment do
-  before { register_repo }
-
   describe '#[]=' do
     it 'sets a gitsh environment variable' do
       env = described_class.new
@@ -38,7 +36,8 @@ describe Gitsh::Environment do
 
     context 'for a Git configuration variable' do
       it 'returns the value of the Git configuration variable' do
-        allow(Gitsh::Registry[:repo]).to receive(:config).
+        repo = register_repo
+        allow(repo).to receive(:config).
           with('user.name', false).and_return('John Smith')
         env = described_class.new
         register(env: env)
@@ -60,7 +59,8 @@ describe Gitsh::Environment do
 
     context 'for an unknown variable with no default block given' do
       it 'raises an error' do
-        allow(Gitsh::Registry[:repo]).to receive(:config).and_raise(KeyError)
+        repo = register_repo
+        allow(repo).to receive(:config).and_raise(KeyError)
         env = described_class.new
 
         expect { env.fetch(:unknown) }.
@@ -89,7 +89,8 @@ describe Gitsh::Environment do
 
   describe '#clone' do
     it 'creates a copy with an isolated set of variables' do
-      allow(Gitsh::Registry[:repo]).to receive(:config).and_raise(KeyError)
+      repo = register_repo
+      allow(repo).to receive(:config).and_raise(KeyError)
       original = described_class.new
       original['a'] = 'A is set'
 
@@ -243,12 +244,6 @@ describe Gitsh::Environment do
       env['alias.baz'] = '!echo baz'
 
       expect(env.local_aliases).to eq ['baz']
-    end
-  end
-
-  def register(entries)
-    entries.each do |key, object|
-      Gitsh::Registry[key] = object
     end
   end
 

--- a/spec/units/file_runner_spec.rb
+++ b/spec/units/file_runner_spec.rb
@@ -17,7 +17,6 @@ describe Gitsh::FileRunner do
         input_strategy: input_strategy,
       )
       expect(Gitsh::InputStrategies::File).to have_received(:new).with(
-        env: env,
         path: 'my/path',
       )
     end

--- a/spec/units/git_command_list_spec.rb
+++ b/spec/units/git_command_list_spec.rb
@@ -7,9 +7,11 @@ describe Gitsh::GitCommandList do
   MODERN_HELP_COMMAND = "#{GIT_COMMAND} help -a --no-verbose".freeze
   LEGACY_HELP_COMMAND = "#{GIT_COMMAND} help -a".freeze
 
+  before { register_env(git_command: GIT_COMMAND) }
+
   describe '#to_a' do
     it 'produces the list of porcelain commands' do
-      commands = Gitsh::GitCommandList.new(env).to_a
+      commands = Gitsh::GitCommandList.new.to_a
 
       expect(commands).to include %(add)
       expect(commands).to include %(commit)
@@ -23,7 +25,7 @@ describe Gitsh::GitCommandList do
       it 'uses that command list' do
         stub_command(MODERN_LIST_COMMAND, output: "commit\nstatus\nadd\n")
 
-        commands = Gitsh::GitCommandList.new(env).to_a
+        commands = Gitsh::GitCommandList.new.to_a
 
         expect(commands).to eq ['add', 'commit', 'status']
       end
@@ -37,7 +39,7 @@ describe Gitsh::GitCommandList do
           output: "Commands:\n  commit   status\n  add\n",
         )
 
-        commands = Gitsh::GitCommandList.new(env).to_a
+        commands = Gitsh::GitCommandList.new.to_a
 
         expect(commands).to eq ['add', 'commit', 'status']
       end
@@ -52,7 +54,7 @@ describe Gitsh::GitCommandList do
           output: "Commands:\n  commit   status\n  add\n",
         )
 
-        commands = Gitsh::GitCommandList.new(env).to_a
+        commands = Gitsh::GitCommandList.new.to_a
 
         expect(commands).to eq ['add', 'commit', 'status']
       end
@@ -64,15 +66,11 @@ describe Gitsh::GitCommandList do
         stub_command(MODERN_HELP_COMMAND, success: false)
         stub_command(LEGACY_HELP_COMMAND, success: false)
 
-        commands = Gitsh::GitCommandList.new(env).to_a
+        commands = Gitsh::GitCommandList.new.to_a
 
         expect(commands).to eq []
       end
     end
-  end
-
-  def env
-    double(git_command: GIT_COMMAND)
   end
 
   def stub_command(command, success: true, output: '')

--- a/spec/units/git_repository_spec.rb
+++ b/spec/units/git_repository_spec.rb
@@ -5,11 +5,13 @@ require 'gitsh/git_repository'
 describe Gitsh::GitRepository do
   include Color
 
+  before { register_env(git_command: '/usr/bin/env git') }
+
   describe '#git_dir' do
     it 'returns the path to the .git directory' do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
+          repo = Gitsh::GitRepository.new
           run 'git init'
 
           expect(repo.git_dir).to eq '.git'
@@ -23,7 +25,7 @@ describe Gitsh::GitRepository do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
           root_dir = Dir.pwd
-          repo = Gitsh::GitRepository.new(env)
+          repo = Gitsh::GitRepository.new
           run 'git init'
 
           expect(repo.root_dir).to eq(root_dir)
@@ -40,7 +42,7 @@ describe Gitsh::GitRepository do
       it 'returns the empty string' do
         with_a_temporary_home_directory do
           in_a_temporary_directory do
-            repo = Gitsh::GitRepository.new(env)
+            repo = Gitsh::GitRepository.new
 
             expect(repo.root_dir).to eq('')
           end
@@ -53,7 +55,7 @@ describe Gitsh::GitRepository do
     it 'returns the name of the current git branch' do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
+          repo = Gitsh::GitRepository.new
           run 'git init'
           expect(repo.current_head).to eq 'master'
           run 'git checkout -b my-feature'
@@ -65,7 +67,7 @@ describe Gitsh::GitRepository do
     it 'returns the name of the current git branch with a forward slash' do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
+          repo = Gitsh::GitRepository.new
           run 'git init'
           run 'git checkout -b feature/foo'
           expect(repo.current_head).to eq 'feature/foo'
@@ -76,7 +78,7 @@ describe Gitsh::GitRepository do
     it 'returns the name of an annotated tag if there is no branch' do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
+          repo = Gitsh::GitRepository.new
           run 'git init'
           run 'git commit --allow-empty -m "First"'
           run 'git tag -m "Tag pointing to first" first'
@@ -91,7 +93,7 @@ describe Gitsh::GitRepository do
     it 'returns the an abbreviated SHA if there is no branch or tag' do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
+          repo = Gitsh::GitRepository.new
           run 'git init'
           run 'git commit --allow-empty -m "First"'
           run 'git commit --allow-empty -m "Second"'
@@ -104,7 +106,7 @@ describe Gitsh::GitRepository do
 
     it 'returns nil in an uninitialized repository' do
       Dir.chdir('/') do
-        repo = Gitsh::GitRepository.new(env)
+        repo = Gitsh::GitRepository.new
         expect(repo.current_head).to be_nil
       end
     end
@@ -114,7 +116,7 @@ describe Gitsh::GitRepository do
     it 'produces all the branch names' do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
+          repo = Gitsh::GitRepository.new
           run 'git init'
           run 'git commit --allow-empty -m "Something swell"'
 
@@ -133,7 +135,7 @@ describe Gitsh::GitRepository do
     it 'produces all the tag names' do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
+          repo = Gitsh::GitRepository.new
           run 'git init'
           run 'git commit --allow-empty -m "Something swell"'
           run 'git tag v1.0'
@@ -153,7 +155,7 @@ describe Gitsh::GitRepository do
     it 'produces all the branches and tags' do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
+          repo = Gitsh::GitRepository.new
           run 'git init'
           run 'git commit --allow-empty -m "Something swell"'
           expect(repo.heads).to eq %w( master )
@@ -170,7 +172,7 @@ describe Gitsh::GitRepository do
       commands = double(:commands)
       command_list = instance_double(Gitsh::GitCommandList, to_a: commands)
       allow(Gitsh::GitCommandList).to receive(:new).and_return(command_list)
-      repo = Gitsh::GitRepository.new(env)
+      repo = Gitsh::GitRepository.new
 
       expect(repo.commands).to eq(commands)
     end
@@ -180,7 +182,7 @@ describe Gitsh::GitRepository do
     it 'produces the list of aliases' do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
+          repo = Gitsh::GitRepository.new
           run 'git init'
           run 'git config --local alias.zecho "!echo zzz"'
           run 'git config --local alias.zecho-with-newline "!echo z\nzz"'
@@ -199,7 +201,7 @@ describe Gitsh::GitRepository do
       it 'returns a git configuration value' do
         with_a_temporary_home_directory do
           in_a_temporary_directory do
-            repo = Gitsh::GitRepository.new(env)
+            repo = Gitsh::GitRepository.new
             git_alias = '!echo zzz'
             run 'git init'
             run "git config --local alias.zecho '#{git_alias}'"
@@ -214,7 +216,7 @@ describe Gitsh::GitRepository do
       it 'raises a KeyError' do
         with_a_temporary_home_directory do
           in_a_temporary_directory do
-            repo = Gitsh::GitRepository.new(env)
+            repo = Gitsh::GitRepository.new
 
             expect {
               repo.config('not-a.real-variable')
@@ -228,7 +230,7 @@ describe Gitsh::GitRepository do
       it 'yields to the block' do
         with_a_temporary_home_directory do
           in_a_temporary_directory do
-            repo = Gitsh::GitRepository.new(env)
+            repo = Gitsh::GitRepository.new
 
             expect(repo.config('not-a.real-variable') { 'a-default' }).
               to eq 'a-default'
@@ -242,7 +244,7 @@ describe Gitsh::GitRepository do
     it 'returns a list of all Git configuration variables' do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
-          repo = described_class.new(env)
+          repo = described_class.new
           run 'git init'
           run 'git config --local user.name "Grace Hopper"'
 
@@ -257,7 +259,7 @@ describe Gitsh::GitRepository do
       it 'returns a color code for the color described by the setting' do
         with_a_temporary_home_directory do
           in_a_temporary_directory do
-            repo = Gitsh::GitRepository.new(env)
+            repo = Gitsh::GitRepository.new
             run 'git init'
             run 'git config --local example.color red'
 
@@ -273,7 +275,7 @@ describe Gitsh::GitRepository do
       it 'returns a color code for the color described by the default' do
         with_a_temporary_home_directory do
           in_a_temporary_directory do
-            repo = Gitsh::GitRepository.new(env)
+            repo = Gitsh::GitRepository.new
 
             color = repo.config_color('example.color', 'blue')
 
@@ -288,7 +290,7 @@ describe Gitsh::GitRepository do
     it 'returns a color code for the color described by the argument' do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
+          repo = Gitsh::GitRepository.new
 
           color = repo.color('blue')
 
@@ -302,7 +304,7 @@ describe Gitsh::GitRepository do
     it 'returns a human-readable name for a revision' do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
+          repo = Gitsh::GitRepository.new
           run 'git init'
           run 'git commit --allow-empty -m "A commit"'
 
@@ -314,7 +316,7 @@ describe Gitsh::GitRepository do
     it 'returns nil for an unknown revision' do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
+          repo = Gitsh::GitRepository.new
           run 'git init'
           run 'git commit --allow-empty -m "A commit"'
 
@@ -328,7 +330,7 @@ describe Gitsh::GitRepository do
     it 'returns the merge-base of two revisions' do
       with_a_temporary_home_directory do
         in_a_temporary_directory do
-          repo = Gitsh::GitRepository.new(env)
+          repo = Gitsh::GitRepository.new
           run 'git init'
           run 'git commit --allow-empty -m "Base commit"'
           run 'git checkout -b branch-a master'
@@ -351,9 +353,5 @@ describe Gitsh::GitRepository do
 
   def run(command)
     Open3.capture3(command)
-  end
-
-  def env
-    double(git_command: '/usr/bin/env git')
   end
 end

--- a/spec/units/history_spec.rb
+++ b/spec/units/history_spec.rb
@@ -17,21 +17,24 @@ describe Gitsh::History do
     set_env_value('gitsh.historySize', described_class::DEFAULT_HISTORY_SIZE)
   end
 
-  let(:line_editor) {
-    Class.new.tap { |line_editor| line_editor::HISTORY = [] }
+  let!(:line_editor) {
+    Class.new.tap do |line_editor|
+      line_editor::HISTORY = []
+      Gitsh::Registry[:line_editor] = line_editor
+    end
   }
 
   describe '#load' do
     it 'adds the saved history to the line editor' do
       write_history_file ['init', 'add -p', 'commit']
 
-      described_class.new(line_editor).load
+      described_class.new.load
 
       expect(line_editor::HISTORY).to eq ['init', 'add -p', 'commit']
     end
 
     it 'does nothing when the history file does not exist' do
-      history = described_class.new(line_editor)
+      history = described_class.new
       @history_file.close
       @history_file.unlink
 
@@ -45,7 +48,7 @@ describe Gitsh::History do
     it 'saves the history from the line editor to disk' do
       line_editor::HISTORY.concat(['init', 'add .', 'commit -m "Initial"'])
 
-      described_class.new(line_editor).save
+      described_class.new.save
 
       expect(history_file_lines).to eq [
         "init\n", "add .\n", "commit -m \"Initial\"\n"
@@ -56,7 +59,7 @@ describe Gitsh::History do
       line_editor::HISTORY.concat(['init', 'add .', 'commit -m "Initial"'])
       set_env_value('gitsh.historySize', 2)
 
-      described_class.new(line_editor).save
+      described_class.new.save
 
       expect(history_file_lines).to eq [
         "add .\n", "commit -m \"Initial\"\n"

--- a/spec/units/history_spec.rb
+++ b/spec/units/history_spec.rb
@@ -11,7 +11,12 @@ describe Gitsh::History do
     @history_file.unlink
   end
 
-  let(:env) { { 'gitsh.historyFile' => @history_file.path } }
+  before do
+    register_env
+    set_env_value('gitsh.historyFile', @history_file.path)
+    set_env_value('gitsh.historySize', described_class::DEFAULT_HISTORY_SIZE)
+  end
+
   let(:line_editor) {
     Class.new.tap { |line_editor| line_editor::HISTORY = [] }
   }
@@ -20,13 +25,13 @@ describe Gitsh::History do
     it 'adds the saved history to the line editor' do
       write_history_file ['init', 'add -p', 'commit']
 
-      described_class.new(env, line_editor).load
+      described_class.new(line_editor).load
 
       expect(line_editor::HISTORY).to eq ['init', 'add -p', 'commit']
     end
 
     it 'does nothing when the history file does not exist' do
-      history = described_class.new(env, line_editor)
+      history = described_class.new(line_editor)
       @history_file.close
       @history_file.unlink
 
@@ -40,7 +45,7 @@ describe Gitsh::History do
     it 'saves the history from the line editor to disk' do
       line_editor::HISTORY.concat(['init', 'add .', 'commit -m "Initial"'])
 
-      described_class.new(env, line_editor).save
+      described_class.new(line_editor).save
 
       expect(history_file_lines).to eq [
         "init\n", "add .\n", "commit -m \"Initial\"\n"
@@ -49,9 +54,9 @@ describe Gitsh::History do
 
     it 'is limited by the gitsh.historySize setting' do
       line_editor::HISTORY.concat(['init', 'add .', 'commit -m "Initial"'])
-      env['gitsh.historySize'] = 2
+      set_env_value('gitsh.historySize', 2)
 
-      described_class.new(env, line_editor).save
+      described_class.new(line_editor).save
 
       expect(history_file_lines).to eq [
         "add .\n", "commit -m \"Initial\"\n"
@@ -68,5 +73,9 @@ describe Gitsh::History do
 
   def history_file_lines
     @history_file.each_line.to_a
+  end
+
+  def set_env_value(key, value)
+    allow(Gitsh::Registry.env).to receive(:fetch).with(key).and_return(value)
   end
 end

--- a/spec/units/input_strategies/file_spec.rb
+++ b/spec/units/input_strategies/file_spec.rb
@@ -6,9 +6,7 @@ describe Gitsh::InputStrategies::File do
   describe '#setup' do
     context 'with a file that does not exist' do
       it 'raises a NoInputError' do
-        env = double('Environment')
         input_strategy = described_class.new(
-          env: env,
           path: 'no/such/script',
         )
 
@@ -23,11 +21,7 @@ describe Gitsh::InputStrategies::File do
       it 'raises a NoInputError' do
         script = temp_file('script', "commit -m 'Changes'\npush -f")
         allow(File).to receive(:open).and_raise(Errno::EACCES)
-        env = double('Environment')
-        input_strategy = described_class.new(
-          env: env,
-          path: script.path,
-        )
+        input_strategy = described_class.new(path: script.path)
 
         expect { input_strategy.setup }.to raise_exception(
           Gitsh::NoInputError,
@@ -53,9 +47,7 @@ describe Gitsh::InputStrategies::File do
   describe '#read_command' do
     it 'returns each line of the file followed by a nil' do
       script = temp_file('script', "commit -m 'Changes'\npush -f")
-      input_strategy = described_class.new(
-        path: script.path,
-      )
+      input_strategy = described_class.new(path: script.path)
       input_strategy.setup
 
       expect(input_strategy.read_command).to eq 'commit -m \'Changes\''
@@ -66,11 +58,8 @@ describe Gitsh::InputStrategies::File do
     context 'with -' do
       it 'reads each line from STDIN' do
         input_stream = StringIO.new("push\npull\n")
-        env = double('Environment', input_stream: input_stream)
-        input_strategy = described_class.new(
-          env: env,
-          path: '-',
-        )
+        register_env(input_stream: input_stream)
+        input_strategy = described_class.new(path: '-')
         input_strategy.setup
 
         expect(input_strategy.read_command).to eq 'push'

--- a/spec/units/input_strategies/interactive_spec.rb
+++ b/spec/units/input_strategies/interactive_spec.rb
@@ -2,41 +2,40 @@ require 'spec_helper'
 require 'gitsh/input_strategies/interactive'
 
 describe Gitsh::InputStrategies::Interactive do
-  before { stub_file_runner }
-  let!(:line_editor) { register_line_editor }
+  before do
+    register_env(fetch: '')
+    register_line_editor
+
+    stub_file_runner
+    stub_history
+    stub_terminal
+  end
 
   describe '#setup' do
     it 'loads the history' do
-      input_strategy = build_input_strategy
+      described_class.new.setup
 
-      input_strategy.setup
-
-      expect(history).to have_received(:load)
+      expect(Gitsh::History).to have_received(:load)
     end
 
     it 'sets up the line editor' do
-      input_strategy = build_input_strategy
+      described_class.new.setup
 
-      input_strategy.setup
-
-      expect(line_editor).to have_received(:completion_proc=)
+      expect(registered_line_editor).to have_received(:completion_proc=)
     end
 
     it 'loads the ~/.gitshrc file' do
-      input_strategy = build_input_strategy
-
-      input_strategy.setup
+      described_class.new.setup
 
       expect(Gitsh::FileRunner).to have_received(:run).
         with(hash_including(path: "#{ENV['HOME']}/.gitshrc"))
     end
 
     it 'handles parse errors in the ~/.gitshrc file' do
-      input_strategy = build_input_strategy
       allow(Gitsh::FileRunner).
         to receive(:run).and_raise(Gitsh::ParseError, 'my message')
 
-      input_strategy.setup
+      described_class.new.setup
 
       expect(Gitsh::Registry.env).to have_received(:puts_error).with('gitsh: my message')
     end
@@ -44,26 +43,27 @@ describe Gitsh::InputStrategies::Interactive do
 
   describe '#teardown' do
     it 'saves the history' do
-      input_strategy = build_input_strategy
+      register_env(fetch: '')
+      input_strategy = described_class.new
 
       input_strategy.teardown
 
-      expect(history).to have_received(:save)
+      expect(Gitsh::History).to have_received(:save)
     end
   end
 
   describe '#read_command' do
     it 'returns the user input' do
-      input_strategy = build_input_strategy
-      allow(line_editor).to receive(:readline).and_return('user input')
+      input_strategy = described_class.new
+      allow(registered_line_editor).to receive(:readline).and_return('user input')
       input_strategy.setup
 
       expect(input_strategy.read_command).to eq 'user input'
     end
 
     it 'returns the default command when the user input is blank' do
-      input_strategy = build_input_strategy
-      allow(line_editor).to receive(:readline).and_return(' ')
+      input_strategy = described_class.new
+      allow(registered_line_editor).to receive(:readline).and_return(' ')
       allow(Gitsh::Registry.env).to receive(:fetch).with('gitsh.defaultCommand').
         and_return('my default command')
       input_strategy.setup
@@ -72,11 +72,11 @@ describe Gitsh::InputStrategies::Interactive do
     end
 
     it 'handles a SIGINT by retrying' do
-      input_strategy = build_input_strategy
+      input_strategy = described_class.new
       line_editor_results = StubbedMethodResult.new.
         raises(Interrupt).
         returns('user input after interrupt')
-      allow(line_editor).to receive(:readline) { line_editor_results.next_result }
+      allow(registered_line_editor).to receive(:readline) { line_editor_results.next_result }
 
       input_strategy.setup
       expect(input_strategy.read_command).to eq 'user input after interrupt'
@@ -86,7 +86,7 @@ describe Gitsh::InputStrategies::Interactive do
       line_editor = SignallingLineEditor.new('WINCH')
       allow(line_editor).to receive(:set_screen_size)
       register(line_editor: line_editor)
-      input_strategy = build_input_strategy
+      input_strategy = described_class.new
 
       input_strategy.setup
       expect { input_strategy.read_command }.not_to raise_exception
@@ -97,12 +97,11 @@ describe Gitsh::InputStrategies::Interactive do
       line_editor = SignallingLineEditor.new('WINCH')
       allow(line_editor).to receive(:set_screen_size)
       register(line_editor: line_editor)
-      terminal = double('Terminal', color_support?: true)
-      allow(terminal).to receive(:size).and_raise(
+      allow(Gitsh::Terminal).to receive(:size).and_raise(
         Gitsh::Terminal::UnknownSizeError,
         'Unknown terminal size',
       )
-      input_strategy = build_input_strategy(terminal: terminal)
+      input_strategy = described_class.new
 
       input_strategy.setup
       expect { input_strategy.read_command }.not_to raise_exception
@@ -112,18 +111,18 @@ describe Gitsh::InputStrategies::Interactive do
 
   describe '#read_continuation' do
     it 'returns the user input' do
-      input_strategy = build_input_strategy
-      allow(line_editor).to receive(:readline).and_return('user input')
+      input_strategy = described_class.new
+      allow(registered_line_editor).to receive(:readline).and_return('user input')
       input_strategy.setup
 
       expect(input_strategy.read_continuation).to eq 'user input'
-      expect(line_editor).to have_received(:readline).
+      expect(registered_line_editor).to have_received(:readline).
         with(described_class::CONTINUATION_PROMPT, true)
     end
 
     it 'handles a SIGINT by returning nil' do
-      input_strategy = build_input_strategy
-      allow(line_editor).to receive(:readline).and_raise(Interrupt)
+      input_strategy = described_class.new
+      allow(registered_line_editor).to receive(:readline).and_raise(Interrupt)
       input_strategy.setup
 
       expect(input_strategy.read_continuation).to be_nil
@@ -132,7 +131,7 @@ describe Gitsh::InputStrategies::Interactive do
 
   describe '#handle_parse_error' do
     it 'outputs the error' do
-      input_strategy = build_input_strategy
+      input_strategy = described_class.new
 
       input_strategy.handle_parse_error('my message')
 
@@ -140,23 +139,21 @@ describe Gitsh::InputStrategies::Interactive do
     end
   end
 
-  def build_input_strategy(options={})
-    register_env(fetch: '')
-    described_class.new(
-      history: history,
-      terminal: options.fetch(:terminal, terminal),
-    )
-  end
-
   def stub_file_runner
     allow(Gitsh::FileRunner).to receive(:run)
   end
 
-  def history
-    @history ||= spy('history', load: nil, save: nil)
+  def stub_history
+    allow(Gitsh::History).to receive(:load)
+    allow(Gitsh::History).to receive(:save)
   end
 
-  def terminal
-    double('terminal', color_support?: true, size: [24, 80])
+  def stub_terminal
+    allow(Gitsh::Terminal).to receive(:color_support?).and_return(true)
+    allow(Gitsh::Terminal).to receive(:size).and_return([24, 80])
+  end
+
+  def registered_line_editor
+    Gitsh::Registry[:line_editor]
   end
 end

--- a/spec/units/input_strategies/interactive_spec.rb
+++ b/spec/units/input_strategies/interactive_spec.rb
@@ -5,6 +5,7 @@ describe Gitsh::InputStrategies::Interactive do
   before do
     register_env(fetch: '')
     register_line_editor
+    register_repo
 
     stub_file_runner
     stub_history
@@ -37,7 +38,7 @@ describe Gitsh::InputStrategies::Interactive do
 
       described_class.new.setup
 
-      expect(Gitsh::Registry.env).to have_received(:puts_error).with('gitsh: my message')
+      expect(registered_env).to have_received(:puts_error).with('gitsh: my message')
     end
   end
 
@@ -64,8 +65,7 @@ describe Gitsh::InputStrategies::Interactive do
     it 'returns the default command when the user input is blank' do
       input_strategy = described_class.new
       allow(registered_line_editor).to receive(:readline).and_return(' ')
-      allow(Gitsh::Registry.env).to receive(:fetch).with('gitsh.defaultCommand').
-        and_return('my default command')
+      set_registered_env_value('gitsh.defaultCommand', 'my default command')
       input_strategy.setup
 
       expect(input_strategy.read_command).to eq 'my default command'
@@ -135,7 +135,7 @@ describe Gitsh::InputStrategies::Interactive do
 
       input_strategy.handle_parse_error('my message')
 
-      expect(Gitsh::Registry.env).to have_received(:puts_error).with('gitsh: my message')
+      expect(registered_env).to have_received(:puts_error).with('gitsh: my message')
     end
   end
 
@@ -151,9 +151,5 @@ describe Gitsh::InputStrategies::Interactive do
   def stub_terminal
     allow(Gitsh::Terminal).to receive(:color_support?).and_return(true)
     allow(Gitsh::Terminal).to receive(:size).and_return([24, 80])
-  end
-
-  def registered_line_editor
-    Gitsh::Registry[:line_editor]
   end
 end

--- a/spec/units/input_strategies/interactive_spec.rb
+++ b/spec/units/input_strategies/interactive_spec.rb
@@ -37,7 +37,7 @@ describe Gitsh::InputStrategies::Interactive do
 
       input_strategy.setup
 
-      expect(env).to have_received(:puts_error).with('gitsh: my message')
+      expect(Gitsh::Registry.env).to have_received(:puts_error).with('gitsh: my message')
     end
   end
 
@@ -63,7 +63,7 @@ describe Gitsh::InputStrategies::Interactive do
     it 'returns the default command when the user input is blank' do
       input_strategy = build_input_strategy
       allow(line_editor).to receive(:readline).and_return(' ')
-      allow(env).to receive(:fetch).with('gitsh.defaultCommand').
+      allow(Gitsh::Registry.env).to receive(:fetch).with('gitsh.defaultCommand').
         and_return('my default command')
       input_strategy.setup
 
@@ -130,19 +130,18 @@ describe Gitsh::InputStrategies::Interactive do
   describe '#handle_parse_error' do
     it 'outputs the error' do
       input_strategy = build_input_strategy
-      allow(env).to receive(:puts_error)
 
       input_strategy.handle_parse_error('my message')
 
-      expect(env).to have_received(:puts_error).with('gitsh: my message')
+      expect(Gitsh::Registry.env).to have_received(:puts_error).with('gitsh: my message')
     end
   end
 
   def build_input_strategy(options={})
+    register_env(fetch: '')
     described_class.new(
       line_editor: options.fetch(:line_editor, line_editor),
       history: history,
-      env: env,
       terminal: options.fetch(:terminal, terminal),
     )
   end
@@ -160,18 +159,6 @@ describe Gitsh::InputStrategies::Interactive do
       :'completion_append_character=' => nil,
       :'completion_proc=' => nil,
       readline: nil
-    })
-  end
-
-  def env
-    @env ||= double('Environment', {
-      config_directory: '/tmp/gitsh/',
-      fetch: '',
-      print: nil,
-      puts: nil,
-      puts_error: nil,
-      repo_config_color: '',
-      :[] => nil,
     })
   end
 

--- a/spec/units/interpreter_spec.rb
+++ b/spec/units/interpreter_spec.rb
@@ -7,8 +7,8 @@ describe Gitsh::Interpreter do
     it 'reads, parses, and executes each command from the input strategy' do
       env = double
       command = double(:command, execute: nil)
-      parser = double(:parser, parse: command)
-      lexer = double('Lexer', lex: tokens([:WORD, 'commit']))
+      allow(Gitsh::Parser).to receive(:parse).and_return(command)
+      allow(Gitsh::Lexer).to receive(:lex).and_return(tokens([:WORD, 'commit']))
       input_strategy = double(:input_strategy, setup: nil, teardown: nil)
       allow(input_strategy).to receive(:read_command).and_return(
         'first command',
@@ -17,24 +17,21 @@ describe Gitsh::Interpreter do
       )
       interpreter = described_class.new(
         env: env,
-        parser: parser,
-        lexer: lexer,
         input_strategy: input_strategy,
       )
 
       interpreter.run
 
       expect(input_strategy).to have_received(:setup).ordered
-      expect(lexer).to have_received(:lex).with('first command').ordered
-      expect(lexer).to have_received(:lex).with('second command').ordered
+      expect(Gitsh::Lexer).to have_received(:lex).with('first command').ordered
+      expect(Gitsh::Lexer).to have_received(:lex).with('second command').ordered
       expect(input_strategy).to have_received(:teardown).ordered
       expect(command).to have_received(:execute).with(env).twice
     end
 
     it 'handles parse errors' do
       env = double(:env, puts_error: nil)
-      parser = double(:parser)
-      allow(parser).to receive(:parse).
+      allow(Gitsh::Parser).to receive(:parse).
         and_raise(RLTK::NotInLanguage.new([], double(:token), []))
       input_strategy = double(
         :input_strategy,
@@ -48,7 +45,6 @@ describe Gitsh::Interpreter do
       )
       interpreter = described_class.new(
         env: env,
-        parser: parser,
         input_strategy: input_strategy,
       )
 
@@ -61,11 +57,10 @@ describe Gitsh::Interpreter do
     it 'handles incomplete input by requesting a completion' do
       env = double
       command = double(:command, execute: nil)
-      parser = double(:parser, parse: command)
-      lexer = double('Lexer')
-      allow(lexer).to receive(:lex).with('(commit').
+      allow(Gitsh::Parser).to receive(:parse).and_return(command)
+      allow(Gitsh::Lexer).to receive(:lex).with('(commit').
         and_return(tokens([:LEFT_PAREN], [:WORD, 'commit'], [:INCOMPLETE, ')']))
-      allow(lexer).to receive(:lex).with("(commit\n)").
+      allow(Gitsh::Lexer).to receive(:lex).with("(commit\n)").
         and_return(tokens([:LEFT_PAREN], [:WORD, 'commit'], [:RIGHT_PAREN]))
       input_strategy = double(
         :input_strategy,
@@ -79,27 +74,24 @@ describe Gitsh::Interpreter do
       )
       interpreter = described_class.new(
         env: env,
-        parser: parser,
         input_strategy: input_strategy,
-        lexer: lexer,
       )
 
       interpreter.run
 
-      expect(lexer).to have_received(:lex).
+      expect(Gitsh::Lexer).to have_received(:lex).
         with('(commit').ordered
-      expect(lexer).to have_received(:lex).
+      expect(Gitsh::Lexer).to have_received(:lex).
         with("(commit\n)").ordered
-      expect(parser).to have_received(:parse).once
+      expect(Gitsh::Parser).to have_received(:parse).once
       expect(command).to have_received(:execute)
     end
 
     it 'drops the command if the completion is nil' do
       env = double
-      parser = double(:parser, parse: nil)
-      lexer = double(
-        'Lexer',
-        lex: tokens([:LEFT_PAREN], [:WORD, 'commit'], [:INCOMPLETE, ')']),
+      allow(Gitsh::Parser).to receive(:parse)
+      allow(Gitsh::Lexer).to receive(:lex).and_return(
+        tokens([:LEFT_PAREN], [:WORD, 'commit'], [:INCOMPLETE, ')']),
       )
       input_strategy = double(
         :input_strategy,
@@ -113,15 +105,13 @@ describe Gitsh::Interpreter do
       )
       interpreter = described_class.new(
         env: env,
-        parser: parser,
         input_strategy: input_strategy,
-        lexer: lexer,
       )
 
       interpreter.run
 
-      expect(lexer).to have_received(:lex).once
-      expect(parser).not_to have_received(:parse)
+      expect(Gitsh::Lexer).to have_received(:lex).once
+      expect(Gitsh::Parser).not_to have_received(:parse)
     end
   end
 end

--- a/spec/units/magic_variables_spec.rb
+++ b/spec/units/magic_variables_spec.rb
@@ -6,8 +6,8 @@ describe Gitsh::MagicVariables do
   describe '#fetch' do
     context 'with an unknown variable name and a block' do
       it 'yields to the block' do
-        repo = double('GitRepository')
-        magic_variables = described_class.new(repo)
+        register_repo
+        magic_variables = described_class.new
 
         result = magic_variables.fetch(:_not_a_real_variable) { 'default' }
 
@@ -17,16 +17,16 @@ describe Gitsh::MagicVariables do
 
     context 'with _prior' do
       it 'returns the name of the previous branch' do
-        repo = double('GitRepository', revision_name: 'a-branch-name')
-        magic_variables = described_class.new(repo)
+        repo = register_repo(revision_name: 'a-branch-name')
+        magic_variables = described_class.new
 
         expect(magic_variables.fetch(:_prior)).to eq 'a-branch-name'
         expect(repo).to have_received(:revision_name).with('@{-1}')
       end
 
       it 'raises when there is no prior branch' do
-        repo = double('GitRepository', revision_name: nil)
-        magic_variables = described_class.new(repo)
+        register_repo(revision_name: nil)
+        magic_variables = described_class.new
 
         expect { magic_variables.fetch(:_prior) }.to raise_exception(
           Gitsh::UnsetVariableError,
@@ -36,16 +36,16 @@ describe Gitsh::MagicVariables do
 
     context 'with _merge_base' do
       it 'returns the SHA of the base commit for an in-progress merge' do
-        repo = double('GitRepository', merge_base: 'abc124567890')
-        magic_variables = described_class.new(repo)
+        repo = register_repo(merge_base: 'abc124567890')
+        magic_variables = described_class.new
 
         expect(magic_variables.fetch(:_merge_base)).to eq 'abc124567890'
         expect(repo).to have_received(:merge_base).with('HEAD', 'MERGE_HEAD')
       end
 
       it 'raises when there is no merge in progress' do
-        repo = double('GitRepository', merge_base: '')
-        magic_variables = described_class.new(repo)
+        register_repo(merge_base: '')
+        magic_variables = described_class.new
 
         expect { magic_variables.fetch(:_merge_base) }.to raise_exception(
           Gitsh::UnsetVariableError,
@@ -60,8 +60,8 @@ describe Gitsh::MagicVariables do
             rebase_path = Pathname.new(tmpdir_path).join('rebase-apply')
             rebase_path.mkpath
             write_file(rebase_path.join('onto'), 'abc123')
-            repo = double('GitRepository', git_dir: tmpdir_path)
-            magic_variables = described_class.new(repo)
+            register_repo(git_dir: tmpdir_path)
+            magic_variables = described_class.new
 
             expect(magic_variables.fetch(:_rebase_base)).to eq 'abc123'
           end
@@ -74,8 +74,8 @@ describe Gitsh::MagicVariables do
             rebase_path = Pathname.new(tmpdir_path).join('rebase-merge')
             rebase_path.mkpath
             write_file(rebase_path.join('onto'), 'def456')
-            repo = double('GitRepository', git_dir: tmpdir_path)
-            magic_variables = described_class.new(repo)
+            register_repo(git_dir: tmpdir_path)
+            magic_variables = described_class.new
 
             expect(magic_variables.fetch(:_rebase_base)).to eq 'def456'
           end
@@ -85,8 +85,8 @@ describe Gitsh::MagicVariables do
       context 'when there is no rebase in progress' do
         it 'raises an exception' do
           Dir.mktmpdir do |tmpdir_path|
-            repo = double('GitRepository', git_dir: tmpdir_path)
-            magic_variables = described_class.new(repo)
+            register_repo(git_dir: tmpdir_path)
+            magic_variables = described_class.new
 
             expect { magic_variables.fetch(:_rebase_base) }.to raise_exception(
               Gitsh::UnsetVariableError,
@@ -97,16 +97,16 @@ describe Gitsh::MagicVariables do
 
       context 'with _root' do
         it 'returns the root directory of the repository' do
-          repo = double('GitRepository', root_dir: '/tmp/example')
-          magic_variables = described_class.new(repo)
+          register_repo(root_dir: '/tmp/example')
+          magic_variables = described_class.new
 
           expect(magic_variables.fetch(:_root)).to eq '/tmp/example'
         end
 
         context 'when used outside a repository' do
           it 'raises an exception' do
-            repo = double('GitRepository', root_dir: '')
-            magic_variables = described_class.new(repo)
+            register_repo(root_dir: '')
+            magic_variables = described_class.new
 
             expect { magic_variables.fetch(:_root) }.to raise_exception(
               Gitsh::UnsetVariableError,
@@ -119,8 +119,8 @@ describe Gitsh::MagicVariables do
 
   describe '#available_variables' do
     it 'returns an array of variable names' do
-      repo = double('GitRepository')
-      magic_variables = described_class.new(repo)
+      register_repo
+      magic_variables = described_class.new
 
       expect(magic_variables.available_variables).to match_array [
         :_prior,

--- a/spec/units/prompt_color_spec.rb
+++ b/spec/units/prompt_color_spec.rb
@@ -8,12 +8,12 @@ describe Gitsh::PromptColor do
     context 'with an uninitialized repo' do
       it 'uses the gitsh.color.uninitialized setting' do
         color = double('color')
-        env = double('env', repo_config_color: color)
-        prompt_color = described_class.new(env)
+        register_env(repo_config_color: color)
+        prompt_color = described_class.new
         status = double('status', initialized?: false)
 
         expect(prompt_color.status_color(status)).to eq color
-        expect(env).to have_received(:repo_config_color).
+        expect(Gitsh::Registry.env).to have_received(:repo_config_color).
           with('gitsh.color.uninitialized', 'normal red')
       end
     end
@@ -21,16 +21,16 @@ describe Gitsh::PromptColor do
     context 'with untracked files' do
       it 'uses the gitsh.color.untracked setting' do
         color = double('color')
-        env = double('env', repo_config_color: color)
+        register_env(repo_config_color: color)
         status = double(
           'status',
           initialized?: true,
           has_untracked_files?: true,
         )
-        prompt_color = described_class.new(env)
+        prompt_color = described_class.new
 
         expect(prompt_color.status_color(status)).to eq color
-        expect(env).to have_received(:repo_config_color).
+        expect(Gitsh::Registry.env).to have_received(:repo_config_color).
           with('gitsh.color.untracked', 'red')
       end
     end
@@ -38,17 +38,17 @@ describe Gitsh::PromptColor do
     context 'with modified files' do
       it 'uses the gitsh.color.modified setting' do
         color = double('color')
-        env = double('env', repo_config_color: color)
+        register_env(repo_config_color: color)
         status = double(
           'status',
           initialized?: true,
           has_untracked_files?: false,
           has_modified_files?: true,
         )
-        prompt_color = described_class.new(env)
+        prompt_color = described_class.new
 
         expect(prompt_color.status_color(status)).to eq color
-        expect(env).to have_received(:repo_config_color).
+        expect(Gitsh::Registry.env).to have_received(:repo_config_color).
           with('gitsh.color.modified', 'yellow')
       end
     end
@@ -56,17 +56,17 @@ describe Gitsh::PromptColor do
     context 'with a clean repo' do
       it 'uses the gitsh.color.default setting' do
         color = double('color')
-        env = double('env', repo_config_color: color)
+        register_env(repo_config_color: color)
         status = double(
           'status',
           initialized?: true,
           has_untracked_files?: false,
           has_modified_files?: false,
         )
-        prompt_color = described_class.new(env)
+        prompt_color = described_class.new
 
         expect(prompt_color.status_color(status)).to eq color
-        expect(env).to have_received(:repo_config_color).
+        expect(Gitsh::Registry.env).to have_received(:repo_config_color).
           with('gitsh.color.default', 'blue')
       end
     end

--- a/spec/units/prompt_color_spec.rb
+++ b/spec/units/prompt_color_spec.rb
@@ -7,68 +7,115 @@ describe Gitsh::PromptColor do
   describe '#status_color' do
     context 'with an uninitialized repo' do
       it 'uses the gitsh.color.uninitialized setting' do
+        setup_env('gitsh.color.uninitialized' => 'normal blue')
         color = double('color')
-        register_env(repo_config_color: color)
+        repo = register_repo(color: color)
         prompt_color = described_class.new
-        status = double('status', initialized?: false)
+        status = stub_status(initialized?: false)
 
         expect(prompt_color.status_color(status)).to eq color
-        expect(Gitsh::Registry.env).to have_received(:repo_config_color).
-          with('gitsh.color.uninitialized', 'normal red')
+        expect(repo).to have_received(:color).with('normal blue')
+      end
+
+      it 'uses a default when the setting is not present' do
+        setup_env
+        color = double('color')
+        repo = register_repo(color: color)
+        prompt_color = described_class.new
+        status = stub_status(initialized?: false)
+
+        expect(prompt_color.status_color(status)).to eq color
+        expect(repo).to have_received(:color).with('normal red')
       end
     end
 
     context 'with untracked files' do
       it 'uses the gitsh.color.untracked setting' do
+        setup_env('gitsh.color.untracked' => 'normal blue')
         color = double('color')
-        register_env(repo_config_color: color)
-        status = double(
-          'status',
-          initialized?: true,
-          has_untracked_files?: true,
-        )
+        repo = register_repo(color: color)
         prompt_color = described_class.new
+        status = stub_status(has_untracked_files?: true)
 
         expect(prompt_color.status_color(status)).to eq color
-        expect(Gitsh::Registry.env).to have_received(:repo_config_color).
-          with('gitsh.color.untracked', 'red')
+        expect(repo).to have_received(:color).with('normal blue')
+      end
+
+      it 'uses a default when the setting is not present' do
+        setup_env
+        color = double('color')
+        repo = register_repo(color: color)
+        prompt_color = described_class.new
+        status = stub_status(has_untracked_files?: true)
+
+        expect(prompt_color.status_color(status)).to eq color
+        expect(repo).to have_received(:color).with('red')
       end
     end
 
     context 'with modified files' do
       it 'uses the gitsh.color.modified setting' do
+        setup_env('gitsh.color.modified' => 'normal blue')
         color = double('color')
-        register_env(repo_config_color: color)
-        status = double(
-          'status',
-          initialized?: true,
-          has_untracked_files?: false,
-          has_modified_files?: true,
-        )
+        repo = register_repo(color: color)
         prompt_color = described_class.new
+        status = stub_status(has_modified_files?: true)
 
         expect(prompt_color.status_color(status)).to eq color
-        expect(Gitsh::Registry.env).to have_received(:repo_config_color).
-          with('gitsh.color.modified', 'yellow')
+        expect(repo).to have_received(:color).with('normal blue')
+      end
+
+      it 'uses a default when the setting is not present' do
+        setup_env
+        color = double('color')
+        repo = register_repo(color: color)
+        prompt_color = described_class.new
+        status = stub_status(has_modified_files?: true)
+
+        expect(prompt_color.status_color(status)).to eq color
+        expect(repo).to have_received(:color).with('yellow')
       end
     end
 
     context 'with a clean repo' do
       it 'uses the gitsh.color.default setting' do
+        setup_env('gitsh.color.default' => 'normal yellow')
         color = double('color')
-        register_env(repo_config_color: color)
-        status = double(
-          'status',
-          initialized?: true,
-          has_untracked_files?: false,
-          has_modified_files?: false,
-        )
+        repo = register_repo(color: color)
         prompt_color = described_class.new
+        status = stub_status
 
         expect(prompt_color.status_color(status)).to eq color
-        expect(Gitsh::Registry.env).to have_received(:repo_config_color).
-          with('gitsh.color.default', 'blue')
+        expect(repo).to have_received(:color).with('normal yellow')
+      end
+
+      it 'uses a default when the setting is not present' do
+        setup_env
+        color = double('color')
+        repo = register_repo(color: color)
+        prompt_color = described_class.new
+        status = stub_status
+
+        expect(prompt_color.status_color(status)).to eq color
+        expect(repo).to have_received(:color).with('blue')
       end
     end
+  end
+
+  def setup_env(vars = {})
+    env = register_env
+    allow(env).to receive(:fetch).and_yield
+    vars.each do |name, value|
+      allow(env).to receive(:fetch).with(name).and_return(value)
+    end
+  end
+
+  def stub_status(attrs = {})
+    default_attrs = {
+      initialized?: true,
+      has_untracked_files?: false,
+      has_modified_files?: false,
+    }
+    instance_double(Gitsh::GitRepository::Status, default_attrs.merge(attrs))
   end
 end

--- a/spec/units/prompter_spec.rb
+++ b/spec/units/prompter_spec.rb
@@ -10,10 +10,10 @@ describe Gitsh::Prompter do
     context 'with the default prompt format' do
       context 'an un-initialized git repository' do
         it 'displays an uninitialized prompt' do
-          env = env_double(
+          register_env(
             repo_status: double("Status", initialized?: false),
           )
-          prompter = Gitsh::Prompter.new(env: env)
+          prompter = Gitsh::Prompter.new
 
           expect(prompter.prompt).to eq(
             "#{cwd_basename} #{red}uninitialized!!#{clear} "
@@ -23,8 +23,8 @@ describe Gitsh::Prompter do
 
       context 'a clean repository' do
         it 'displays the branch name and a clean symbol' do
-          env = env_double(repo_current_head: 'my-feature')
-          prompter = Gitsh::Prompter.new(env: env)
+          register_env(repo_current_head: 'my-feature')
+          prompter = Gitsh::Prompter.new
 
           expect(prompter.prompt).to eq(
             "#{cwd_basename} #{red}my-feature@#{clear} "
@@ -34,14 +34,14 @@ describe Gitsh::Prompter do
 
       context 'a repository with untracked files' do
         it 'displays the branch name and an untracked symbol' do
-          env = env_double(
+          register_env(
             repo_status: double(
               "Status",
               initialized?: true,
               has_untracked_files?: true,
             ),
           )
-          prompter = Gitsh::Prompter.new(env: env)
+          prompter = Gitsh::Prompter.new
 
           expect(prompter.prompt).to eq(
             "#{cwd_basename} #{red}master!#{clear} "
@@ -51,7 +51,7 @@ describe Gitsh::Prompter do
 
       context 'a repository with uncommitted changes' do
         it 'displays the branch name an a modified symbol' do
-          env = env_double(
+          register_env(
             repo_status: double(
               "Status",
               initialized?: true,
@@ -59,7 +59,7 @@ describe Gitsh::Prompter do
               has_untracked_files?: false,
             ),
           )
-          prompter = Gitsh::Prompter.new(env: env)
+          prompter = Gitsh::Prompter.new
 
           expect(prompter.prompt).to eq(
             "#{cwd_basename} #{red}master&#{clear} "
@@ -69,7 +69,7 @@ describe Gitsh::Prompter do
 
       context 'with color disabled' do
         it 'displays the prompt without colors' do
-          env = env_double(
+          register_env(
             repo_status: double(
               "Status",
               initialized?: true,
@@ -77,7 +77,7 @@ describe Gitsh::Prompter do
               has_untracked_files?: false,
             ),
           )
-          prompter = Gitsh::Prompter.new(color: false, env: env)
+          prompter = Gitsh::Prompter.new(color: false)
 
           expect(prompter.prompt).to eq "#{cwd_basename} master& "
         end
@@ -85,8 +85,8 @@ describe Gitsh::Prompter do
 
       context 'with a long branch name' do
         it 'displays the shortened branch name' do
-          env = env_double(repo_current_head: "best-branch-name-ever-forever")
-          prompter = Gitsh::Prompter.new(env: env)
+          register_env(repo_current_head: "best-branch-name-ever-forever")
+          prompter = Gitsh::Prompter.new
 
           expect(prompter.prompt).to eq "#{cwd_basename} #{red}best-branch-nam…@#{clear} "
         end
@@ -95,7 +95,7 @@ describe Gitsh::Prompter do
 
     context 'with a custom prompt format' do
       it 'replaces %# with the prompt terminator' do
-        env = env_double(
+        register_env(
           repo_status: double(
             "Status",
             initialized?: true,
@@ -104,13 +104,13 @@ describe Gitsh::Prompter do
           ),
           format: "%#",
         )
-        prompter = Gitsh::Prompter.new(env: env)
+        prompter = Gitsh::Prompter.new
 
         expect(prompter.prompt).to eq "& "
       end
 
       it 'replaces %c with a color code based on the status' do
-        env = env_double(
+        register_env(
           repo_status: double(
             "Status",
             initialized?: true,
@@ -119,48 +119,48 @@ describe Gitsh::Prompter do
           ),
           format: "%c",
         )
-        prompter = Gitsh::Prompter.new(env: env)
+        prompter = Gitsh::Prompter.new
 
         expect(prompter.prompt).to eq "#{red} "
       end
 
       it 'replaces %w with the code to restore the default color' do
-        env = env_double(format: '%w')
-        prompter = Gitsh::Prompter.new(env: env)
+        register_env(format: '%w')
+        prompter = Gitsh::Prompter.new
 
         expect(prompter.prompt).to eq "#{clear} "
       end
 
       it 'replaces %b with the full current HEAD name' do
-        env = env_double(
+        register_env(
           repo_current_head: 'a-really-long-branch-name',
           format: '%b',
         )
-        prompter = Gitsh::Prompter.new(env: env)
+        prompter = Gitsh::Prompter.new
 
         expect(prompter.prompt).to eq 'a-really-long-branch-name '
       end
 
       it 'replaces %B with the abbreviated current HEAD name' do
-        env = env_double(
+        register_env(
           repo_current_head: 'a-really-long-branch-name',
           format: '%B',
         )
-        prompter = Gitsh::Prompter.new(env: env)
+        prompter = Gitsh::Prompter.new
 
         expect(prompter.prompt).to eq 'a-really-long-b… '
       end
 
       it 'replaces %d with the absolute path of the current directory' do
-        env = env_double(format: '%d')
-        prompter = Gitsh::Prompter.new(env: env)
+        register_env(format: '%d')
+        prompter = Gitsh::Prompter.new
 
         expect(prompter.prompt).to eq "#{Dir.getwd.sub(/\A#{Dir.home}/, '~')} "
       end
 
       it 'replaces %D with the basename of the current directory' do
-        env = env_double(format: '%D')
-        prompter = Gitsh::Prompter.new(env: env)
+        register_env(format: '%D')
+        prompter = Gitsh::Prompter.new
 
         expect(prompter.prompt).to eq(
           "#{File.basename(Dir.getwd.sub(/\A#{Dir.home}/, '~'))} "
@@ -168,27 +168,27 @@ describe Gitsh::Prompter do
       end
 
       it 'replaces %g with the absolute path of the current git binary' do
-        env = env_double(
+        register_env(
           format: '%g',
           git_command: '/usr/local/bin/my-custom-git',
         )
-        prompter = Gitsh::Prompter.new(env: env)
+        prompter = Gitsh::Prompter.new
 
         expect(prompter.prompt).to eq '/usr/local/bin/my-custom-git '
       end
 
       it 'replaces %G with the basename of the current git binary' do
-        env = env_double(
+        register_env(
           format: '%G',
           git_command: '/usr/local/bin/my-custom-git',
         )
-        prompter = Gitsh::Prompter.new(env: env)
+        prompter = Gitsh::Prompter.new
 
         expect(prompter.prompt).to eq 'my-custom-git '
       end
     end
 
-    def env_double(attrs={})
+    def register_env(attrs={})
       format = attrs.delete(:format)
       default_attrs = {
         repo_status: double(
@@ -201,12 +201,10 @@ describe Gitsh::Prompter do
         repo_config_color: red,
         git_command: '/usr/local/bin/my-custom-git',
       }
-      double('Environment', default_attrs.merge(attrs)).tap do |env|
-        allow(env).to receive(:[]).with('gitsh.prompt').and_return(format)
-        allow(env).to receive(:fetch).with('gitsh.prompt').and_return(
-          format || Gitsh::Prompter::DEFAULT_FORMAT
-        )
-      end
+      super(default_attrs.merge(attrs))
+      allow(Gitsh::Registry.env).to receive(:fetch).with('gitsh.prompt').and_return(
+        format || Gitsh::Prompter::DEFAULT_FORMAT
+      )
     end
   end
 end

--- a/spec/units/registry_spec.rb
+++ b/spec/units/registry_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'gitsh/registry'
+
+describe Gitsh::Registry do
+  describe 'setting and getting objects' do
+    it 'allows retreival of previously set objects' do
+      test_object = double(:test_object)
+      Gitsh::Registry[:test] = test_object
+
+      expect(Gitsh::Registry[:test]).to eq(test_object)
+    end
+  end
+
+  describe '.env' do
+    it 'allows convenient access to the Environment instance' do
+      env = double(:env)
+      Gitsh::Registry[:env] = env
+
+      expect(Gitsh::Registry.env).to eq(env)
+    end
+  end
+
+  describe '.clear' do
+    it 'removes everything from the registry' do
+      Gitsh::Registry[:env] = double(:env)
+      Gitsh::Registry.clear
+
+      expect { Gitsh::Registry[:env] }.to raise_exception(KeyError)
+    end
+  end
+end

--- a/spec/units/registry_spec.rb
+++ b/spec/units/registry_spec.rb
@@ -5,18 +5,18 @@ describe Gitsh::Registry do
   describe 'setting and getting objects' do
     it 'allows retreival of previously set objects' do
       test_object = double(:test_object)
-      Gitsh::Registry[:test] = test_object
+      Gitsh::Registry.instance[:test] = test_object
 
-      expect(Gitsh::Registry[:test]).to eq(test_object)
+      expect(Gitsh::Registry.instance[:test]).to eq(test_object)
     end
   end
 
   describe '.clear' do
     it 'removes everything from the registry' do
-      Gitsh::Registry[:env] = double(:env)
+      Gitsh::Registry.instance[:env] = double(:env)
       Gitsh::Registry.clear
 
-      expect { Gitsh::Registry[:env] }.to raise_exception(KeyError)
+      expect { Gitsh::Registry.instance[:env] }.to raise_exception(KeyError)
     end
   end
 end

--- a/spec/units/registry_spec.rb
+++ b/spec/units/registry_spec.rb
@@ -11,15 +11,6 @@ describe Gitsh::Registry do
     end
   end
 
-  describe '.env' do
-    it 'allows convenient access to the Environment instance' do
-      env = double(:env)
-      Gitsh::Registry[:env] = env
-
-      expect(Gitsh::Registry.env).to eq(env)
-    end
-  end
-
   describe '.clear' do
     it 'removes everything from the registry' do
       Gitsh::Registry[:env] = double(:env)

--- a/spec/units/tab_completion/alias_expander_spec.rb
+++ b/spec/units/tab_completion/alias_expander_spec.rb
@@ -6,8 +6,7 @@ describe Gitsh::TabCompletion::AliasExpander do
     context 'when the first word is an alias for a Git command' do
       it 'expands the alias' do
         register_env
-        allow(Gitsh::Registry.env).to receive(:fetch).with('alias.alias').
-          and_return('expanded command')
+        set_registered_env_value('alias.alias', 'expanded command')
 
         expect(expand(['alias', 'argument'])).
           to eq ['expanded', 'command', 'argument']
@@ -16,8 +15,8 @@ describe Gitsh::TabCompletion::AliasExpander do
 
     context 'when the first word is an alias for a shell command' do
       it 'does not expand the alias' do
-        register_env
-        allow(Gitsh::Registry.env).to receive(:fetch).with('alias.alias').
+        env = register_env
+        allow(env).to receive(:fetch).with('alias.alias').
           and_return('!shell command')
 
         expect(expand(['alias', 'argument'])).
@@ -28,7 +27,7 @@ describe Gitsh::TabCompletion::AliasExpander do
     context 'when the first word is not an alias' do
       it 'returns the words' do
         register_env
-        allow(Gitsh::Registry.env).to receive(:fetch).with('alias.foo').
+        allow(registered_env).to receive(:fetch).with('alias.foo').
           and_raise(Gitsh::UnsetVariableError)
         words = ['foo', 'bar']
 

--- a/spec/units/tab_completion/alias_expander_spec.rb
+++ b/spec/units/tab_completion/alias_expander_spec.rb
@@ -5,39 +5,39 @@ describe Gitsh::TabCompletion::AliasExpander do
   describe '#call' do
     context 'when the first word is an alias for a Git command' do
       it 'expands the alias' do
-        env = double(:env)
-        allow(env).to receive(:fetch).with('alias.alias').
+        register_env
+        allow(Gitsh::Registry.env).to receive(:fetch).with('alias.alias').
           and_return('expanded command')
 
-        expect(expand(['alias', 'argument'], env)).
+        expect(expand(['alias', 'argument'])).
           to eq ['expanded', 'command', 'argument']
       end
     end
 
     context 'when the first word is an alias for a shell command' do
       it 'does not expand the alias' do
-        env = double(:env)
-        allow(env).to receive(:fetch).with('alias.alias').
+        register_env
+        allow(Gitsh::Registry.env).to receive(:fetch).with('alias.alias').
           and_return('!shell command')
 
-        expect(expand(['alias', 'argument'], env)).
+        expect(expand(['alias', 'argument'])).
           to eq ['alias', 'argument']
       end
     end
 
     context 'when the first word is not an alias' do
       it 'returns the words' do
-        env = double(:env)
-        allow(env).to receive(:fetch).with('alias.foo').
+        register_env
+        allow(Gitsh::Registry.env).to receive(:fetch).with('alias.foo').
           and_raise(Gitsh::UnsetVariableError)
         words = ['foo', 'bar']
 
-        expect(expand(words, env)).to eq(words)
+        expect(expand(words)).to eq(words)
       end
     end
   end
 
-  def expand(words, env)
-    Gitsh::TabCompletion::AliasExpander.new(words, env).call
+  def expand(words)
+    Gitsh::TabCompletion::AliasExpander.new(words).call
   end
 end

--- a/spec/units/tab_completion/automaton_factory_spec.rb
+++ b/spec/units/tab_completion/automaton_factory_spec.rb
@@ -5,19 +5,22 @@ describe Gitsh::TabCompletion::AutomatonFactory do
   describe '.build' do
     it 'loads the tab completion DSL file' do
       config_directory = '/tmp/etc/gitsh'
-      env = double(:env, config_directory: config_directory)
+      register_env(config_directory: config_directory)
       start_state = stub_automaton_state
       automaton = stub_automaton
       stub_dsl_loading
       config_path = File.join(config_directory, 'completions')
 
-      result = described_class.build(env)
+      result = described_class.build
 
       expect(result).to eq(automaton)
       expect(Gitsh::TabCompletion::Automaton).
         to have_received(:new).with(start_state)
-      expect(Gitsh::TabCompletion::DSL).
-        to have_received(:load).with(config_path, start_state, env)
+      expect(Gitsh::TabCompletion::DSL).to have_received(:load).with(
+        config_path,
+        start_state,
+        Gitsh::Registry.env,
+      )
     end
   end
 

--- a/spec/units/tab_completion/automaton_factory_spec.rb
+++ b/spec/units/tab_completion/automaton_factory_spec.rb
@@ -19,7 +19,6 @@ describe Gitsh::TabCompletion::AutomatonFactory do
       expect(Gitsh::TabCompletion::DSL).to have_received(:load).with(
         config_path,
         start_state,
-        Gitsh::Registry.env,
       )
     end
   end

--- a/spec/units/tab_completion/command_completer_spec.rb
+++ b/spec/units/tab_completion/command_completer_spec.rb
@@ -4,9 +4,9 @@ require 'gitsh/tab_completion/command_completer'
 describe Gitsh::TabCompletion::CommandCompleter do
   describe '#call' do
     it 'produces completions using an Automaton' do
+      register_line_editor
       automaton = build_automaton(completions: ['my-stash'])
       completer = described_class.new(
-        build_line_editor,
         ['stash', 'drop'],
         'my-',
         automaton,
@@ -22,9 +22,9 @@ describe Gitsh::TabCompletion::CommandCompleter do
     end
 
     it 'unescapes input and escapes output' do
+      register_line_editor
       automaton = build_automaton(completions: ['my stash'])
       completer = described_class.new(
-        build_line_editor,
         ['stash', 'drop'],
         'my\ s',
         automaton,
@@ -39,9 +39,8 @@ describe Gitsh::TabCompletion::CommandCompleter do
 
     context 'with multiple matching options' do
       it 'configures the line editor to append quotes and spaces' do
-        line_editor = build_line_editor
+        line_editor = register_line_editor
         completer = described_class.new(
-          line_editor,
           ['add'],
           'some',
           build_automaton(completions: ['somedir/', 'somefile.txt']),
@@ -59,9 +58,8 @@ describe Gitsh::TabCompletion::CommandCompleter do
 
     context 'with a single matching option that is not a directory path' do
       it 'configures the line editor to append quotes and spaces' do
-        line_editor = build_line_editor
+        line_editor = register_line_editor
         completer = described_class.new(
-          line_editor,
           ['add'],
           'some',
           build_automaton(completions: ['somefile.txt']),
@@ -79,9 +77,8 @@ describe Gitsh::TabCompletion::CommandCompleter do
 
     context 'with a single matching option that is a directory path' do
       it 'configures the line editor not to append quotes or spaces' do
-        line_editor = build_line_editor
+        line_editor = register_line_editor
         completer = described_class.new(
-          line_editor,
           ['add'],
           'some',
           build_automaton(completions: ['somedir/']),
@@ -96,14 +93,6 @@ describe Gitsh::TabCompletion::CommandCompleter do
           to have_received(:completion_suppress_quote=).with(true)
       end
     end
-  end
-
-  def build_line_editor
-    double(
-      'LineEditor',
-      :completion_append_character= => nil,
-      :completion_suppress_quote= => nil,
-    )
   end
 
   def build_automaton(methods)

--- a/spec/units/tab_completion/dsl/parser_spec.rb
+++ b/spec/units/tab_completion/dsl/parser_spec.rb
@@ -107,13 +107,14 @@ describe Gitsh::TabCompletion::DSL::Parser do
     end
 
     it 'parses rules with options' do
+      register_env
       result = described_class.parse(tokens(
         [:WORD, 'push'], [:OPT_VAR],
         [:INDENT], [:OPTION, '--force'],
         [:INDENT], [:OPTION, '--remote'], [:VAR, 'remote'],
         [:INDENT], [:OPTION, '--multiple'], [:WORD, '1'], [:WORD, '2'],
         [:EOS],
-      ), gitsh_env: double(:env))
+      ))
 
       rule_factory = result.rules.first
       expect(rule_factory.options).to be_a_choice
@@ -134,11 +135,12 @@ describe Gitsh::TabCompletion::DSL::Parser do
     end
 
     it 'parses multiple rules in the same input' do
+      register_env
       result = described_class.parse(tokens(
         [:WORD, 'push'], [:BLANK],
         [:WORD, 'pull'], [:BLANK], [:BLANK],
         [:WORD, 'fetch'], [:EOS],
-      ), gitsh_env: double(:env))
+      ))
 
       expect(result).to be_a_rule_set_factory
       expect(result.rules.length).to eq(3)
@@ -147,10 +149,8 @@ describe Gitsh::TabCompletion::DSL::Parser do
     end
 
     it 'parses empty input' do
-      result = described_class.parse(
-        tokens([:EOS]),
-        gitsh_env: double(:env),
-      )
+      register_env
+      result = described_class.parse(tokens([:EOS]))
 
       expect(result).to be_a_rule_set_factory
       expect(result.rules).to be_empty
@@ -201,8 +201,8 @@ describe Gitsh::TabCompletion::DSL::Parser do
   end
 
   def parse_single_rule(tokens)
-    env = double(:env)
-    result = described_class.parse(tokens, gitsh_env: env)
+    register_env
+    result = described_class.parse(tokens)
     expect(result).to be_a_rule_set_factory
     result.rules.first.root
   end

--- a/spec/units/tab_completion/dsl/parser_spec.rb
+++ b/spec/units/tab_completion/dsl/parser_spec.rb
@@ -107,7 +107,6 @@ describe Gitsh::TabCompletion::DSL::Parser do
     end
 
     it 'parses rules with options' do
-      register_env
       result = described_class.parse(tokens(
         [:WORD, 'push'], [:OPT_VAR],
         [:INDENT], [:OPTION, '--force'],
@@ -135,7 +134,6 @@ describe Gitsh::TabCompletion::DSL::Parser do
     end
 
     it 'parses multiple rules in the same input' do
-      register_env
       result = described_class.parse(tokens(
         [:WORD, 'push'], [:BLANK],
         [:WORD, 'pull'], [:BLANK], [:BLANK],
@@ -149,7 +147,6 @@ describe Gitsh::TabCompletion::DSL::Parser do
     end
 
     it 'parses empty input' do
-      register_env
       result = described_class.parse(tokens([:EOS]))
 
       expect(result).to be_a_rule_set_factory
@@ -201,7 +198,6 @@ describe Gitsh::TabCompletion::DSL::Parser do
   end
 
   def parse_single_rule(tokens)
-    register_env
     result = described_class.parse(tokens)
     expect(result).to be_a_rule_set_factory
     result.rules.first.root

--- a/spec/units/tab_completion/dsl_spec.rb
+++ b/spec/units/tab_completion/dsl_spec.rb
@@ -8,9 +8,9 @@ describe Gitsh::TabCompletion::DSL do
         'stash (apply|drop|pop|show)',
       ].join("\n"))
       start_state = Gitsh::TabCompletion::Automaton::State.new('start')
-      env = Gitsh::Environment.new
+      register_env
 
-      described_class.load(path, start_state, env)
+      described_class.load(path, start_state)
 
       automaton = Gitsh::TabCompletion::Automaton.new(start_state)
       expect(automaton.completions([], '')).
@@ -23,9 +23,9 @@ describe Gitsh::TabCompletion::DSL do
       it 'does not explode' do
         path = '/not/a/real/path'
         start_state = Gitsh::TabCompletion::Automaton::State.new('start')
-        env = Gitsh::Environment.new
+        register_env
 
-        expect { described_class.load(path, start_state, env) }.
+        expect { described_class.load(path, start_state) }.
           not_to raise_exception
       end
     end

--- a/spec/units/tab_completion/dsl_spec.rb
+++ b/spec/units/tab_completion/dsl_spec.rb
@@ -8,7 +8,6 @@ describe Gitsh::TabCompletion::DSL do
         'stash (apply|drop|pop|show)',
       ].join("\n"))
       start_state = Gitsh::TabCompletion::Automaton::State.new('start')
-      register_env
 
       described_class.load(path, start_state)
 
@@ -23,7 +22,6 @@ describe Gitsh::TabCompletion::DSL do
       it 'does not explode' do
         path = '/not/a/real/path'
         start_state = Gitsh::TabCompletion::Automaton::State.new('start')
-        register_env
 
         expect { described_class.load(path, start_state) }.
           not_to raise_exception

--- a/spec/units/tab_completion/escaper_spec.rb
+++ b/spec/units/tab_completion/escaper_spec.rb
@@ -5,8 +5,8 @@ describe Gitsh::TabCompletion::Escaper do
   describe '#escape' do
     context 'without any quote characters' do
       it 'escapes spaces, slashes, quotes, operators, etc.' do
-        line_editor = double(:line_editor, completion_quote_character: nil)
-        escaper = described_class.new(line_editor)
+        register_line_editor(completion_quote_character: nil)
+        escaper = described_class.new
 
         expect(escaper.escape(%q(option))).to eq %q(option)
         expect(escaper.escape(%q(with space))).to eq %q(with\ space)
@@ -23,8 +23,8 @@ describe Gitsh::TabCompletion::Escaper do
 
     context 'with an unclosed single quote' do
       it 'escapes slashes and single quotes' do
-        line_editor = double(:line_editor, completion_quote_character: '\'')
-        escaper = described_class.new(line_editor)
+        register_line_editor(completion_quote_character: '\'')
+        escaper = described_class.new
 
         expect(escaper.escape(%q(option))).to eq %q(option)
         expect(escaper.escape(%q(with space))).to eq %q(with space)
@@ -41,8 +41,8 @@ describe Gitsh::TabCompletion::Escaper do
 
     context 'with an unclosed double quote' do
       it 'escapes slashes, double quotes, and $' do
-        line_editor = double(:line_editor, completion_quote_character: '"')
-        escaper = described_class.new(line_editor)
+        register_line_editor(completion_quote_character: '"')
+        escaper = described_class.new
 
         expect(escaper.escape(%q(option))).to eq %q(option)
         expect(escaper.escape(%q(with space))).to eq %q(with space)
@@ -61,8 +61,8 @@ describe Gitsh::TabCompletion::Escaper do
   describe '#unescape' do
     context 'without any quote characters' do
       it 'unescapes spaces, slashes, quotes, operators, etc.' do
-        line_editor = double(:line_editor, completion_quote_character: nil)
-        escaper = described_class.new(line_editor)
+        register_line_editor(completion_quote_character: nil)
+        escaper = described_class.new
 
         expect(escaper.unescape(%q(option))).to eq %q(option)
         expect(escaper.unescape(%q(with\ space))).to eq %q(with space)
@@ -79,8 +79,8 @@ describe Gitsh::TabCompletion::Escaper do
 
     context 'with an unclosed single quote' do
       it 'unescapes slashes and single quotes' do
-        line_editor = double(:line_editor, completion_quote_character: '\'')
-        escaper = described_class.new(line_editor)
+        register_line_editor(completion_quote_character: '\'')
+        escaper = described_class.new
 
         expect(escaper.unescape(%q(option))).to eq %q(option)
         expect(escaper.unescape(%q(with\ space))).to eq %q(with\ space)
@@ -97,8 +97,8 @@ describe Gitsh::TabCompletion::Escaper do
 
     context 'with an unclosed double quote' do
       it 'unescapes slashes, double quotes, and $' do
-        line_editor = double(:line_editor, completion_quote_character: '"')
-        escaper = described_class.new(line_editor)
+        register_line_editor(completion_quote_character: '"')
+        escaper = described_class.new
 
         expect(escaper.unescape(%q(option))).to eq %q(option)
         expect(escaper.unescape(%q(with\ space))).to eq %q(with\ space)

--- a/spec/units/tab_completion/facade_spec.rb
+++ b/spec/units/tab_completion/facade_spec.rb
@@ -46,7 +46,6 @@ describe Gitsh::TabCompletion::Facade do
         expect(Gitsh::TabCompletion::VariableCompleter).to have_received(:new).with(
           line_editor,
           'name=$g',
-          Gitsh::Registry.env,
         )
         expect(variable_completer).to have_received(:call)
         expect(Gitsh::TabCompletion::CommandCompleter).

--- a/spec/units/tab_completion/facade_spec.rb
+++ b/spec/units/tab_completion/facade_spec.rb
@@ -9,18 +9,16 @@ describe Gitsh::TabCompletion::Facade do
         register_env
         allow(Gitsh::Registry.env).
           to receive(:fetch).and_raise(Gitsh::UnsetVariableError)
-        input = 'add -p $path lib/'
-        line_editor = double(:line_editor, line_buffer: input)
+        register_line_editor(line_buffer: 'add -p $path lib/')
         command_completer = stub_command_completer
         stub_variable_completer
         automaton = stub_automaton_factory
         escaper = stub_escaper
-        facade = described_class.new(line_editor)
+        facade = described_class.new
 
         facade.call('lib/')
 
         expect(Gitsh::TabCompletion::CommandCompleter).to have_received(:new).with(
-          line_editor,
           ['add', '-p', '${path}'],
           'lib/',
           automaton,
@@ -35,16 +33,14 @@ describe Gitsh::TabCompletion::Facade do
     context 'given input ending with a variable' do
       it 'invokes the VariableCompleter' do
         register_env(config_directory: '/tmp/gitsh/')
-        input = ':echo "name=$g'
-        line_editor = double(:line_editor, line_buffer: input)
+        register_line_editor(line_buffer: ':echo "name=$g')
         stub_command_completer
         variable_completer = stub_variable_completer
-        facade = described_class.new(line_editor)
+        facade = described_class.new
 
         facade.call('name=$g')
 
         expect(Gitsh::TabCompletion::VariableCompleter).to have_received(:new).with(
-          line_editor,
           'name=$g',
         )
         expect(variable_completer).to have_received(:call)

--- a/spec/units/tab_completion/facade_spec.rb
+++ b/spec/units/tab_completion/facade_spec.rb
@@ -6,8 +6,8 @@ describe Gitsh::TabCompletion::Facade do
   describe '#call' do
     context 'given input not ending with a variable' do
       it 'invokes the CommandCompleter' do
-        register_env
-        allow(Gitsh::Registry.env).
+        env = register_env
+        allow(env).
           to receive(:fetch).and_raise(Gitsh::UnsetVariableError)
         register_line_editor(line_buffer: 'add -p $path lib/')
         command_completer = stub_command_completer

--- a/spec/units/tab_completion/matchers/anything_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/anything_matcher_spec.rb
@@ -4,7 +4,7 @@ require 'gitsh/tab_completion/matchers/anything_matcher'
 describe Gitsh::TabCompletion::Matchers::AnythingMatcher do
   describe '#match?' do
     it 'returns true for all input' do
-      matcher = described_class.new(double(:env))
+      matcher = described_class.new
 
       expect(matcher.match?('foo')).to be_truthy
       expect(matcher.match?('--all')).to be_truthy
@@ -14,7 +14,7 @@ describe Gitsh::TabCompletion::Matchers::AnythingMatcher do
 
   describe '#completions' do
     it 'returns an empty array' do
-      matcher = described_class.new(double(:env))
+      matcher = described_class.new
 
       expect(matcher.completions('foo')).to eq([])
       expect(matcher.completions('--all')).to eq([])
@@ -24,14 +24,14 @@ describe Gitsh::TabCompletion::Matchers::AnythingMatcher do
 
   describe '#eql?' do
     it 'returns true when given another instance of the same class' do
-      matcher1 = described_class.new(double(:env))
-      matcher2 = described_class.new(double(:env))
+      matcher1 = described_class.new
+      matcher2 = described_class.new
 
       expect(matcher1).to eql(matcher2)
     end
 
     it 'returns false when given an instance of any other class' do
-      matcher = described_class.new(double(:env))
+      matcher = described_class.new
       other = double(:not_a_matcher)
 
       expect(matcher).not_to eql(other)
@@ -40,8 +40,8 @@ describe Gitsh::TabCompletion::Matchers::AnythingMatcher do
 
   describe '#hash' do
     it 'returns the same value for all instances of the class' do
-      matcher1 = described_class.new(double(:env))
-      matcher2 = described_class.new(double(:env))
+      matcher1 = described_class.new
+      matcher2 = described_class.new
 
       expect(matcher1.hash).to eq(matcher2.hash)
     end

--- a/spec/units/tab_completion/matchers/branch_matchers_spec.rb
+++ b/spec/units/tab_completion/matchers/branch_matchers_spec.rb
@@ -4,7 +4,7 @@ require 'gitsh/tab_completion/matchers/branch_matcher'
 describe Gitsh::TabCompletion::Matchers::BranchMatcher do
   describe '#match?' do
     it 'always returns true' do
-      register_env
+      register_repo
       matcher = described_class.new
 
       expect(matcher.match?('foo')).to be_truthy
@@ -15,7 +15,7 @@ describe Gitsh::TabCompletion::Matchers::BranchMatcher do
   describe '#completions' do
     context 'given blank input' do
       it 'returns the names of all branches' do
-        register_env(repo_branches: ['master', 'my-feature'])
+        register_repo(branches: ['master', 'my-feature'])
         matcher = described_class.new
 
         expect(matcher.completions('')).to match_array ['master', 'my-feature']
@@ -24,7 +24,7 @@ describe Gitsh::TabCompletion::Matchers::BranchMatcher do
 
     context 'given a partial branch name' do
       it 'returns all branch names matching the input' do
-        register_env(repo_branches: ['master', 'my-feature'])
+        register_repo(branches: ['master', 'my-feature'])
         matcher = described_class.new
 
         expect(matcher.completions('m')).
@@ -39,7 +39,7 @@ describe Gitsh::TabCompletion::Matchers::BranchMatcher do
 
   describe '#eql?' do
     it 'returns true when given another instance of the same class' do
-      register_env
+      register_repo
       matcher1 = described_class.new
       matcher2 = described_class.new
 
@@ -47,7 +47,7 @@ describe Gitsh::TabCompletion::Matchers::BranchMatcher do
     end
 
     it 'returns false when given an instance of any other class' do
-      register_env
+      register_repo
       matcher = described_class.new
       other = double(:not_a_matcher)
 
@@ -57,7 +57,7 @@ describe Gitsh::TabCompletion::Matchers::BranchMatcher do
 
   describe '#hash' do
     it 'returns the same value for all instances of the class' do
-      register_env
+      register_repo
       matcher1 = described_class.new
       matcher2 = described_class.new
 

--- a/spec/units/tab_completion/matchers/branch_matchers_spec.rb
+++ b/spec/units/tab_completion/matchers/branch_matchers_spec.rb
@@ -4,7 +4,8 @@ require 'gitsh/tab_completion/matchers/branch_matcher'
 describe Gitsh::TabCompletion::Matchers::BranchMatcher do
   describe '#match?' do
     it 'always returns true' do
-      matcher = described_class.new(double(:env))
+      register_env
+      matcher = described_class.new
 
       expect(matcher.match?('foo')).to be_truthy
       expect(matcher.match?('')).to be_truthy
@@ -14,8 +15,8 @@ describe Gitsh::TabCompletion::Matchers::BranchMatcher do
   describe '#completions' do
     context 'given blank input' do
       it 'returns the names of all branches' do
-        env = double(:env, repo_branches: ['master', 'my-feature'])
-        matcher = described_class.new(env)
+        register_env(repo_branches: ['master', 'my-feature'])
+        matcher = described_class.new
 
         expect(matcher.completions('')).to match_array ['master', 'my-feature']
       end
@@ -23,8 +24,8 @@ describe Gitsh::TabCompletion::Matchers::BranchMatcher do
 
     context 'given a partial branch name' do
       it 'returns all branch names matching the input' do
-        env = double(:env, repo_branches: ['master', 'my-feature'])
-        matcher = described_class.new(env)
+        register_env(repo_branches: ['master', 'my-feature'])
+        matcher = described_class.new
 
         expect(matcher.completions('m')).
           to match_array ['master', 'my-feature']
@@ -38,15 +39,16 @@ describe Gitsh::TabCompletion::Matchers::BranchMatcher do
 
   describe '#eql?' do
     it 'returns true when given another instance of the same class' do
-      env = double(:env)
-      matcher1 = described_class.new(env)
-      matcher2 = described_class.new(env)
+      register_env
+      matcher1 = described_class.new
+      matcher2 = described_class.new
 
       expect(matcher1).to eql(matcher2)
     end
 
     it 'returns false when given an instance of any other class' do
-      matcher = described_class.new(double(:env))
+      register_env
+      matcher = described_class.new
       other = double(:not_a_matcher)
 
       expect(matcher).not_to eql(other)
@@ -55,9 +57,9 @@ describe Gitsh::TabCompletion::Matchers::BranchMatcher do
 
   describe '#hash' do
     it 'returns the same value for all instances of the class' do
-      env = double(:env)
-      matcher1 = described_class.new(env)
-      matcher2 = described_class.new(env)
+      register_env
+      matcher1 = described_class.new
+      matcher2 = described_class.new
 
       expect(matcher1.hash).to eq(matcher2.hash)
     end

--- a/spec/units/tab_completion/matchers/command_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/command_matcher_spec.rb
@@ -4,7 +4,7 @@ require 'gitsh/tab_completion/matchers/command_matcher'
 describe Gitsh::TabCompletion::Matchers::CommandMatcher do
   describe '#match?' do
     it 'always returns true' do
-      matcher = described_class.new(double(:internal_command))
+      matcher = described_class.new
 
       expect(matcher.match?('foo')).to be_truthy
       expect(matcher.match?('')).to be_truthy
@@ -20,11 +20,10 @@ describe Gitsh::TabCompletion::Matchers::CommandMatcher do
       register_env(
         local_aliases: ['force'],
       )
-      internal_command = double(
-        :internal_command,
-        commands: [':echo', ':help'],
+      allow(Gitsh::Commands::InternalCommand).to receive(:commands).and_return(
+        [':echo', ':help'],
       )
-      matcher = described_class.new(internal_command)
+      matcher = described_class.new
 
       expect(matcher.completions('')).to match_array [
         'add', 'commit',
@@ -41,11 +40,10 @@ describe Gitsh::TabCompletion::Matchers::CommandMatcher do
       register_env(
         local_aliases: ['force'],
       )
-      internal_command = double(
-        :internal_command,
-        commands: [':echo', ':help'],
+      allow(Gitsh::Commands::InternalCommand).to receive(:commands).and_return(
+        [':echo', ':help'],
       )
-      matcher = described_class.new(internal_command)
+      matcher = described_class.new
 
       expect(matcher.completions('gr')).to match_array [
         'graph', 'grep',
@@ -55,15 +53,14 @@ describe Gitsh::TabCompletion::Matchers::CommandMatcher do
 
   describe '#eql?' do
     it 'returns true when given another instance of the same class' do
-      internal_command = double(:internal_command)
-      matcher1 = described_class.new(internal_command)
-      matcher2 = described_class.new(internal_command)
+      matcher1 = described_class.new
+      matcher2 = described_class.new
 
       expect(matcher1).to eql(matcher2)
     end
 
     it 'returns false when given an instance of any other class' do
-      matcher = described_class.new(double(:internal_command))
+      matcher = described_class.new
       other = double(:not_a_matcher)
 
       expect(matcher).not_to eql(other)
@@ -72,9 +69,8 @@ describe Gitsh::TabCompletion::Matchers::CommandMatcher do
 
   describe '#hash' do
     it 'returns the same value for all instances of the class' do
-      internal_command = double(:internal_command)
-      matcher1 = described_class.new(internal_command)
-      matcher2 = described_class.new(internal_command)
+      matcher1 = described_class.new
+      matcher2 = described_class.new
 
       expect(matcher1.hash).to eq(matcher2.hash)
     end

--- a/spec/units/tab_completion/matchers/command_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/command_matcher_spec.rb
@@ -13,9 +13,12 @@ describe Gitsh::TabCompletion::Matchers::CommandMatcher do
 
   describe '#completions' do
     it 'returns the available commands (Git, internal, and aliases)' do
+      register_repo(
+        commands: ['add', 'commit'],
+        aliases: ['graph'],
+      )
       register_env(
-        git_commands: ['add', 'commit'],
-        git_aliases: ['graph', 'force'],
+        local_aliases: ['force'],
       )
       internal_command = double(
         :internal_command,
@@ -31,9 +34,12 @@ describe Gitsh::TabCompletion::Matchers::CommandMatcher do
     end
 
     it 'filters the results based on the input' do
+      register_repo(
+        commands: ['add', 'grep'],
+        aliases: ['graph'],
+      )
       register_env(
-        git_commands: ['add', 'grep'],
-        git_aliases: ['graph', 'force'],
+        local_aliases: ['force'],
       )
       internal_command = double(
         :internal_command,

--- a/spec/units/tab_completion/matchers/command_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/command_matcher_spec.rb
@@ -4,7 +4,7 @@ require 'gitsh/tab_completion/matchers/command_matcher'
 describe Gitsh::TabCompletion::Matchers::CommandMatcher do
   describe '#match?' do
     it 'always returns true' do
-      matcher = described_class.new(double(:env), double(:internal_command))
+      matcher = described_class.new(double(:internal_command))
 
       expect(matcher.match?('foo')).to be_truthy
       expect(matcher.match?('')).to be_truthy
@@ -13,8 +13,7 @@ describe Gitsh::TabCompletion::Matchers::CommandMatcher do
 
   describe '#completions' do
     it 'returns the available commands (Git, internal, and aliases)' do
-      env = double(
-        :env,
+      register_env(
         git_commands: ['add', 'commit'],
         git_aliases: ['graph', 'force'],
       )
@@ -22,7 +21,7 @@ describe Gitsh::TabCompletion::Matchers::CommandMatcher do
         :internal_command,
         commands: [':echo', ':help'],
       )
-      matcher = described_class.new(env, internal_command)
+      matcher = described_class.new(internal_command)
 
       expect(matcher.completions('')).to match_array [
         'add', 'commit',
@@ -32,8 +31,7 @@ describe Gitsh::TabCompletion::Matchers::CommandMatcher do
     end
 
     it 'filters the results based on the input' do
-      env = double(
-        :env,
+      register_env(
         git_commands: ['add', 'grep'],
         git_aliases: ['graph', 'force'],
       )
@@ -41,7 +39,7 @@ describe Gitsh::TabCompletion::Matchers::CommandMatcher do
         :internal_command,
         commands: [':echo', ':help'],
       )
-      matcher = described_class.new(env, internal_command)
+      matcher = described_class.new(internal_command)
 
       expect(matcher.completions('gr')).to match_array [
         'graph', 'grep',
@@ -51,16 +49,15 @@ describe Gitsh::TabCompletion::Matchers::CommandMatcher do
 
   describe '#eql?' do
     it 'returns true when given another instance of the same class' do
-      env = double(:env)
       internal_command = double(:internal_command)
-      matcher1 = described_class.new(env, internal_command)
-      matcher2 = described_class.new(env, internal_command)
+      matcher1 = described_class.new(internal_command)
+      matcher2 = described_class.new(internal_command)
 
       expect(matcher1).to eql(matcher2)
     end
 
     it 'returns false when given an instance of any other class' do
-      matcher = described_class.new(double(:env), double(:internal_command))
+      matcher = described_class.new(double(:internal_command))
       other = double(:not_a_matcher)
 
       expect(matcher).not_to eql(other)
@@ -69,10 +66,9 @@ describe Gitsh::TabCompletion::Matchers::CommandMatcher do
 
   describe '#hash' do
     it 'returns the same value for all instances of the class' do
-      env = double(:env)
       internal_command = double(:internal_command)
-      matcher1 = described_class.new(env, internal_command)
-      matcher2 = described_class.new(env, internal_command)
+      matcher1 = described_class.new(internal_command)
+      matcher2 = described_class.new(internal_command)
 
       expect(matcher1.hash).to eq(matcher2.hash)
     end

--- a/spec/units/tab_completion/matchers/path_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/path_matcher_spec.rb
@@ -4,7 +4,7 @@ require 'gitsh/tab_completion/matchers/path_matcher'
 describe Gitsh::TabCompletion::Matchers::PathMatcher do
   describe '#match?' do
     it 'always returns true' do
-      matcher = described_class.new(double(:env))
+      matcher = described_class.new
 
       expect(matcher.match?('foo')).to be_truthy
       expect(matcher.match?('')).to be_truthy
@@ -18,7 +18,7 @@ describe Gitsh::TabCompletion::Matchers::PathMatcher do
         write_file('foo/first.txt')
         write_file('foo/second.txt')
         write_file('first.txt')
-        matcher = described_class.new(double(:env))
+        matcher = described_class.new
 
         expect(matcher.completions('')).to match_array ['foo/', 'first.txt']
         expect(matcher.completions('f')).to match_array ['foo/', 'first.txt']
@@ -31,14 +31,14 @@ describe Gitsh::TabCompletion::Matchers::PathMatcher do
 
   describe '#eql?' do
     it 'returns true when given another instance of the same class' do
-      matcher1 = described_class.new(double(:env))
-      matcher2 = described_class.new(double(:env))
+      matcher1 = described_class.new
+      matcher2 = described_class.new
 
       expect(matcher1).to eql(matcher2)
     end
 
     it 'returns false when given an instance of any other class' do
-      matcher = described_class.new(double(:env))
+      matcher = described_class.new
       other = double(:not_a_matcher)
 
       expect(matcher).not_to eql(other)
@@ -47,8 +47,8 @@ describe Gitsh::TabCompletion::Matchers::PathMatcher do
 
   describe '#hash' do
     it 'returns the same value for all instances of the class' do
-      matcher1 = described_class.new(double(:env))
-      matcher2 = described_class.new(double(:env))
+      matcher1 = described_class.new
+      matcher2 = described_class.new
 
       expect(matcher1.hash).to eq(matcher2.hash)
     end

--- a/spec/units/tab_completion/matchers/remote_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/remote_matcher_spec.rb
@@ -4,7 +4,7 @@ require 'gitsh/tab_completion/matchers/remote_matcher'
 describe Gitsh::TabCompletion::Matchers::RemoteMatcher do
   describe '#match?' do
     it 'always returns true' do
-      matcher = described_class.new(double(:env))
+      matcher = described_class.new
 
       expect(matcher.match?('foo')).to be_truthy
       expect(matcher.match?('')).to be_truthy
@@ -13,16 +13,16 @@ describe Gitsh::TabCompletion::Matchers::RemoteMatcher do
 
   describe '#completions' do
     it 'returns the available Git remotes' do
-      env = double(:env, repo_remotes: ['origin', 'github'])
-      matcher = described_class.new(env)
+      register_env(repo_remotes: ['origin', 'github'])
+      matcher = described_class.new
 
       expect(matcher.completions('')).
         to match_array ['origin', 'github']
     end
 
     it 'filters the results based on the input' do
-      env = double(:env, repo_remotes: ['origin', 'github'])
-      matcher = described_class.new(env)
+      register_env(repo_remotes: ['origin', 'github'])
+      matcher = described_class.new
 
       expect(matcher.completions('g')).to match_array ['github']
     end
@@ -30,15 +30,14 @@ describe Gitsh::TabCompletion::Matchers::RemoteMatcher do
 
   describe '#eql?' do
     it 'returns true when given another instance of the same class' do
-      env = double(:env)
-      matcher1 = described_class.new(env)
-      matcher2 = described_class.new(env)
+      matcher1 = described_class.new
+      matcher2 = described_class.new
 
       expect(matcher1).to eql(matcher2)
     end
 
     it 'returns false when given an instance of any other class' do
-      matcher = described_class.new(double(:env))
+      matcher = described_class.new
       other = double(:not_a_matcher)
 
       expect(matcher).not_to eql(other)
@@ -47,9 +46,8 @@ describe Gitsh::TabCompletion::Matchers::RemoteMatcher do
 
   describe '#hash' do
     it 'returns the same value for all instances of the class' do
-      env = double(:env)
-      matcher1 = described_class.new(env)
-      matcher2 = described_class.new(env)
+      matcher1 = described_class.new
+      matcher2 = described_class.new
 
       expect(matcher1.hash).to eq(matcher2.hash)
     end

--- a/spec/units/tab_completion/matchers/remote_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/remote_matcher_spec.rb
@@ -13,7 +13,7 @@ describe Gitsh::TabCompletion::Matchers::RemoteMatcher do
 
   describe '#completions' do
     it 'returns the available Git remotes' do
-      register_env(repo_remotes: ['origin', 'github'])
+      register_repo(remotes: ['origin', 'github'])
       matcher = described_class.new
 
       expect(matcher.completions('')).
@@ -21,7 +21,7 @@ describe Gitsh::TabCompletion::Matchers::RemoteMatcher do
     end
 
     it 'filters the results based on the input' do
-      register_env(repo_remotes: ['origin', 'github'])
+      register_repo(remotes: ['origin', 'github'])
       matcher = described_class.new
 
       expect(matcher.completions('g')).to match_array ['github']

--- a/spec/units/tab_completion/matchers/revision_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/revision_matcher_spec.rb
@@ -4,7 +4,7 @@ require 'gitsh/tab_completion/matchers/revision_matcher'
 describe Gitsh::TabCompletion::Matchers::RevisionMatcher do
   describe '#match?' do
     it 'always returns true' do
-      matcher = described_class.new(double(:env))
+      matcher = described_class.new
 
       expect(matcher.match?('foo')).to be_truthy
       expect(matcher.match?('')).to be_truthy
@@ -14,8 +14,8 @@ describe Gitsh::TabCompletion::Matchers::RevisionMatcher do
   describe '#completions' do
     context 'given blank input' do
       it 'returns the names of all heads' do
-        env = double(:env, repo_heads: ['master', 'my-feature'])
-        matcher = described_class.new(env)
+        register_env(repo_heads: ['master', 'my-feature'])
+        matcher = described_class.new
 
         expect(matcher.completions('')).to match_array ['master', 'my-feature']
       end
@@ -23,8 +23,8 @@ describe Gitsh::TabCompletion::Matchers::RevisionMatcher do
 
     context 'given input containing a prefix' do
       it 'returns the name of all heads with the prefix added' do
-        env = double(:env, repo_heads: ['master', 'my-feature'])
-        matcher = described_class.new(env)
+        register_env(repo_heads: ['master', 'my-feature'])
+        matcher = described_class.new
 
         expect(matcher.completions('master..')).
           to match_array ['master..master', 'master..my-feature']
@@ -35,8 +35,8 @@ describe Gitsh::TabCompletion::Matchers::RevisionMatcher do
 
     context 'given a partial revision name' do
       it 'returns all heads matching the input' do
-        env = double(:env, repo_heads: ['master', 'my-feature'])
-        matcher = described_class.new(env)
+        register_env(repo_heads: ['master', 'my-feature'])
+        matcher = described_class.new
 
         expect(matcher.completions('m')).
           to match_array ['master', 'my-feature']
@@ -54,15 +54,14 @@ describe Gitsh::TabCompletion::Matchers::RevisionMatcher do
 
   describe '#eql?' do
     it 'returns true when given another instance of the same class' do
-      env = double(:env)
-      matcher1 = described_class.new(env)
-      matcher2 = described_class.new(env)
+      matcher1 = described_class.new
+      matcher2 = described_class.new
 
       expect(matcher1).to eql(matcher2)
     end
 
     it 'returns false when given an instance of any other class' do
-      matcher = described_class.new(double(:env))
+      matcher = described_class.new
       other = double(:not_a_matcher)
 
       expect(matcher).not_to eql(other)
@@ -71,9 +70,8 @@ describe Gitsh::TabCompletion::Matchers::RevisionMatcher do
 
   describe '#hash' do
     it 'returns the same value for all instances of the class' do
-      env = double(:env)
-      matcher1 = described_class.new(env)
-      matcher2 = described_class.new(env)
+      matcher1 = described_class.new
+      matcher2 = described_class.new
 
       expect(matcher1.hash).to eq(matcher2.hash)
     end

--- a/spec/units/tab_completion/matchers/revision_matcher_spec.rb
+++ b/spec/units/tab_completion/matchers/revision_matcher_spec.rb
@@ -14,7 +14,7 @@ describe Gitsh::TabCompletion::Matchers::RevisionMatcher do
   describe '#completions' do
     context 'given blank input' do
       it 'returns the names of all heads' do
-        register_env(repo_heads: ['master', 'my-feature'])
+        register_repo(heads: ['master', 'my-feature'])
         matcher = described_class.new
 
         expect(matcher.completions('')).to match_array ['master', 'my-feature']
@@ -23,7 +23,7 @@ describe Gitsh::TabCompletion::Matchers::RevisionMatcher do
 
     context 'given input containing a prefix' do
       it 'returns the name of all heads with the prefix added' do
-        register_env(repo_heads: ['master', 'my-feature'])
+        register_repo(heads: ['master', 'my-feature'])
         matcher = described_class.new
 
         expect(matcher.completions('master..')).
@@ -35,7 +35,7 @@ describe Gitsh::TabCompletion::Matchers::RevisionMatcher do
 
     context 'given a partial revision name' do
       it 'returns all heads matching the input' do
-        register_env(repo_heads: ['master', 'my-feature'])
+        register_repo(heads: ['master', 'my-feature'])
         matcher = described_class.new
 
         expect(matcher.completions('m')).

--- a/spec/units/tab_completion/matchers/tag_matchers_spec.rb
+++ b/spec/units/tab_completion/matchers/tag_matchers_spec.rb
@@ -4,7 +4,7 @@ require 'gitsh/tab_completion/matchers/tag_matcher'
 describe Gitsh::TabCompletion::Matchers::TagMatcher do
   describe '#match?' do
     it 'always returns true' do
-      matcher = described_class.new(double(:env))
+      matcher = described_class.new
 
       expect(matcher.match?('foo')).to be_truthy
       expect(matcher.match?('')).to be_truthy
@@ -14,8 +14,8 @@ describe Gitsh::TabCompletion::Matchers::TagMatcher do
   describe '#completions' do
     context 'given blank input' do
       it 'returns the names of all tags' do
-        env = double(:env, repo_tags: ['v1.0', 'v1.1'])
-        matcher = described_class.new(env)
+        register_env(repo_tags: ['v1.0', 'v1.1'])
+        matcher = described_class.new
 
         expect(matcher.completions('')).to match_array ['v1.0', 'v1.1']
       end
@@ -23,8 +23,8 @@ describe Gitsh::TabCompletion::Matchers::TagMatcher do
 
     context 'given a partial tag name' do
       it 'returns all tag names matching the input' do
-        env = double(:env, repo_tags: ['v1.0', 'v2.0'])
-        matcher = described_class.new(env)
+        register_env(repo_tags: ['v1.0', 'v2.0'])
+        matcher = described_class.new
 
         expect(matcher.completions('v')).
           to match_array ['v1.0', 'v2.0']
@@ -38,15 +38,14 @@ describe Gitsh::TabCompletion::Matchers::TagMatcher do
 
   describe '#eql?' do
     it 'returns true when given another instance of the same class' do
-      env = double(:env)
-      matcher1 = described_class.new(env)
-      matcher2 = described_class.new(env)
+      matcher1 = described_class.new
+      matcher2 = described_class.new
 
       expect(matcher1).to eql(matcher2)
     end
 
     it 'returns false when given an instance of any other class' do
-      matcher = described_class.new(double(:env))
+      matcher = described_class.new
       other = double(:not_a_matcher)
 
       expect(matcher).not_to eql(other)
@@ -55,9 +54,8 @@ describe Gitsh::TabCompletion::Matchers::TagMatcher do
 
   describe '#hash' do
     it 'returns the same value for all instances of the class' do
-      env = double(:env)
-      matcher1 = described_class.new(env)
-      matcher2 = described_class.new(env)
+      matcher1 = described_class.new
+      matcher2 = described_class.new
 
       expect(matcher1.hash).to eq(matcher2.hash)
     end

--- a/spec/units/tab_completion/matchers/tag_matchers_spec.rb
+++ b/spec/units/tab_completion/matchers/tag_matchers_spec.rb
@@ -14,7 +14,7 @@ describe Gitsh::TabCompletion::Matchers::TagMatcher do
   describe '#completions' do
     context 'given blank input' do
       it 'returns the names of all tags' do
-        register_env(repo_tags: ['v1.0', 'v1.1'])
+        register_repo(tags: ['v1.0', 'v1.1'])
         matcher = described_class.new
 
         expect(matcher.completions('')).to match_array ['v1.0', 'v1.1']
@@ -23,7 +23,7 @@ describe Gitsh::TabCompletion::Matchers::TagMatcher do
 
     context 'given a partial tag name' do
       it 'returns all tag names matching the input' do
-        register_env(repo_tags: ['v1.0', 'v2.0'])
+        register_repo(tags: ['v1.0', 'v2.0'])
         matcher = described_class.new
 
         expect(matcher.completions('v')).

--- a/spec/units/tab_completion/variable_completer_spec.rb
+++ b/spec/units/tab_completion/variable_completer_spec.rb
@@ -5,19 +5,21 @@ describe Gitsh::TabCompletion::VariableCompleter do
   describe '#call' do
     context 'with a variable not wrapped in braces' do
       it 'produces variable completions that match the input' do
+        register_line_editor
         register_env(
           available_variables: [:'user.name', :'user.email', :'greeting'],
         )
-        completer = described_class.new(build_line_editor, '$us')
+        completer = described_class.new('$us')
 
         expect(completer.call).to match_array ['$user.name', '$user.email']
       end
 
       it 'prefixes the completions with the prefix, if there is one' do
+        register_line_editor
         register_env(
           available_variables: [:'user.name', :'user.email', :'greeting'],
         )
-        completer = described_class.new(build_line_editor, 'name=$us')
+        completer = described_class.new('name=$us')
 
         expect(completer.call).
           to match_array ['name=$user.name', 'name=$user.email']
@@ -25,8 +27,8 @@ describe Gitsh::TabCompletion::VariableCompleter do
 
       it 'configures the line editor to append a space and not close quotes' do
         register_env(available_variables: [])
-        line_editor = build_line_editor
-        completer = described_class.new(line_editor, '$us')
+        line_editor = register_line_editor
+        completer = described_class.new('$us')
 
         completer.call
 
@@ -39,21 +41,19 @@ describe Gitsh::TabCompletion::VariableCompleter do
 
     context 'with a variable wrapped in braces' do
       it 'produces variable completions that match the input' do
+        register_line_editor
         register_env(
           available_variables: [:'user.name', :'user.email', :'greeting'],
         )
-        completer = described_class.new(
-          build_line_editor,
-          '${us',
-        )
+        completer = described_class.new('${us')
 
         expect(completer.call).to match_array ['${user.name', '${user.email']
       end
 
       it 'configures the line editor to append a closing brace and not close quotes' do
         register_env(available_variables: [])
-        line_editor = build_line_editor
-        completer = described_class.new(line_editor, '${us')
+        line_editor = register_line_editor
+        completer = described_class.new('${us')
 
         completer.call
 
@@ -63,14 +63,6 @@ describe Gitsh::TabCompletion::VariableCompleter do
           to have_received(:completion_suppress_quote=).with(true)
       end
     end
-  end
-
-  def build_line_editor
-    double(
-      'LineEditor',
-      :completion_append_character= => nil,
-      :completion_suppress_quote= => nil,
-    )
   end
 
   def build_env(variables: [])

--- a/spec/units/tab_completion/variable_completer_spec.rb
+++ b/spec/units/tab_completion/variable_completer_spec.rb
@@ -5,29 +5,28 @@ describe Gitsh::TabCompletion::VariableCompleter do
   describe '#call' do
     context 'with a variable not wrapped in braces' do
       it 'produces variable completions that match the input' do
-        completer = described_class.new(
-          build_line_editor,
-          '$us',
-          build_env(variables: ['user.name', 'user.email', 'greeting']),
+        register_env(
+          available_variables: [:'user.name', :'user.email', :'greeting'],
         )
+        completer = described_class.new(build_line_editor, '$us')
 
         expect(completer.call).to match_array ['$user.name', '$user.email']
       end
 
       it 'prefixes the completions with the prefix, if there is one' do
-        completer = described_class.new(
-          build_line_editor,
-          'name=$us',
-          build_env(variables: ['user.name', 'user.email', 'greeting']),
+        register_env(
+          available_variables: [:'user.name', :'user.email', :'greeting'],
         )
+        completer = described_class.new(build_line_editor, 'name=$us')
 
         expect(completer.call).
           to match_array ['name=$user.name', 'name=$user.email']
       end
 
       it 'configures the line editor to append a space and not close quotes' do
+        register_env(available_variables: [])
         line_editor = build_line_editor
-        completer = described_class.new(line_editor, '$us', build_env)
+        completer = described_class.new(line_editor, '$us')
 
         completer.call
 
@@ -40,18 +39,21 @@ describe Gitsh::TabCompletion::VariableCompleter do
 
     context 'with a variable wrapped in braces' do
       it 'produces variable completions that match the input' do
+        register_env(
+          available_variables: [:'user.name', :'user.email', :'greeting'],
+        )
         completer = described_class.new(
           build_line_editor,
           '${us',
-          build_env(variables: ['user.name', 'user.email', 'greeting']),
         )
 
         expect(completer.call).to match_array ['${user.name', '${user.email']
       end
 
       it 'configures the line editor to append a closing brace and not close quotes' do
+        register_env(available_variables: [])
         line_editor = build_line_editor
-        completer = described_class.new(line_editor, '${us', build_env)
+        completer = described_class.new(line_editor, '${us')
 
         completer.call
 

--- a/spec/units/terminal_spec.rb
+++ b/spec/units/terminal_spec.rb
@@ -8,7 +8,7 @@ describe Gitsh::Terminal do
       it 'returns true' do
         stub_command 'tput colors', output: "256\n"
 
-        result = Gitsh::Terminal.instance.color_support?
+        result = Gitsh::Terminal.new.color_support?
 
         expect(result).to be_truthy
       end
@@ -18,7 +18,7 @@ describe Gitsh::Terminal do
       it 'returns false' do
         stub_command 'tput colors', output: "-1\n"
 
-        result = Gitsh::Terminal.instance.color_support?
+        result = Gitsh::Terminal.new.color_support?
 
         expect(result).to be_falsey
       end
@@ -28,7 +28,7 @@ describe Gitsh::Terminal do
       it 'returns false' do
         stub_command 'tput colors', success: false
 
-        result = Gitsh::Terminal.instance.color_support?
+        result = Gitsh::Terminal.new.color_support?
 
         expect(result).to be_falsey
       end
@@ -39,7 +39,7 @@ describe Gitsh::Terminal do
     it 'returns an array containing the number of lines and columns the terminal has' do
       stub_command 'stty size', output: "24 80\n"
 
-      result = Gitsh::Terminal.instance.size
+      result = Gitsh::Terminal.new.size
 
       expect(result).to eq [24, 80]
     end
@@ -50,7 +50,7 @@ describe Gitsh::Terminal do
         stub_command 'env LINES="" tput lines', output: "24\n"
         stub_command 'env COLUMNS="" tput cols', output: "80\n"
 
-        result = Gitsh::Terminal.instance.size
+        result = Gitsh::Terminal.new.size
 
         expect(result).to eq [24, 80]
       end
@@ -64,7 +64,7 @@ describe Gitsh::Terminal do
         stub_command 'tput lines', output: "24\n"
         stub_command 'tput cols', output: "80\n"
 
-        result = Gitsh::Terminal.instance.size
+        result = Gitsh::Terminal.new.size
 
         expect(result).to eq [24, 80]
       end
@@ -74,7 +74,7 @@ describe Gitsh::Terminal do
       it 'raises' do
         stub_command anything, success: false
 
-        expect { Gitsh::Terminal.instance.size }.
+        expect { Gitsh::Terminal.new.size }.
           to raise_error(Gitsh::Terminal::UnknownSizeError)
       end
     end

--- a/src/gitsh.rb.in
+++ b/src/gitsh.rb.in
@@ -7,10 +7,10 @@ require 'gitsh/git_repository'
 require 'gitsh/registry'
 
 begin
+  Gitsh::Registry[:repo] = Gitsh::GitRepository.new
   Gitsh::Registry[:env] = Gitsh::Environment.new(
     config_directory: '@pkgsysconfdir@',
   )
-  Gitsh::Registry[:repo] = Gitsh::GitRepository.new
   Gitsh::CLI.new.run
 rescue => e
   $stderr.puts "gitsh: Error: #{e.message}"

--- a/src/gitsh.rb.in
+++ b/src/gitsh.rb.in
@@ -4,12 +4,17 @@ require '@gemsetuppath@'
 require 'gitsh/cli'
 require 'gitsh/environment'
 require 'gitsh/git_repository'
+require 'gitsh/line_editor_history_filter'
+require 'gitsh/line_editor'
 require 'gitsh/registry'
 
 begin
   Gitsh::Registry[:repo] = Gitsh::GitRepository.new
   Gitsh::Registry[:env] = Gitsh::Environment.new(
     config_directory: '@pkgsysconfdir@',
+  )
+  Gitsh::Registry[:line_editor] = Gitsh::LineEditorHistoryFilter.new(
+    Gitsh::LineEditor,
   )
   Gitsh::CLI.new.run
 rescue => e

--- a/src/gitsh.rb.in
+++ b/src/gitsh.rb.in
@@ -3,12 +3,14 @@ $LOAD_PATH.unshift('@rubylibdir@')
 require '@gemsetuppath@'
 require 'gitsh/cli'
 require 'gitsh/environment'
+require 'gitsh/git_repository'
 require 'gitsh/registry'
 
 begin
   Gitsh::Registry[:env] = Gitsh::Environment.new(
     config_directory: '@pkgsysconfdir@',
   )
+  Gitsh::Registry[:repo] = Gitsh::GitRepository.new
   Gitsh::CLI.new.run
 rescue => e
   $stderr.puts "gitsh: Error: #{e.message}"

--- a/src/gitsh.rb.in
+++ b/src/gitsh.rb.in
@@ -2,20 +2,10 @@ $LOAD_PATH.unshift('@rubylibdir@')
 
 require '@gemsetuppath@'
 require 'gitsh/cli'
-require 'gitsh/environment'
-require 'gitsh/git_repository'
-require 'gitsh/line_editor_history_filter'
-require 'gitsh/line_editor'
 require 'gitsh/registry'
 
 begin
-  Gitsh::Registry[:repo] = Gitsh::GitRepository.new
-  Gitsh::Registry[:env] = Gitsh::Environment.new(
-    config_directory: '@pkgsysconfdir@',
-  )
-  Gitsh::Registry[:line_editor] = Gitsh::LineEditorHistoryFilter.new(
-    Gitsh::LineEditor,
-  )
+  Gitsh::Registry.populate(conf_dir: '@pkgsysconfdir@')
   Gitsh::CLI.new(ARGV).run
 rescue => e
   $stderr.puts "gitsh: Error: #{e.message}"

--- a/src/gitsh.rb.in
+++ b/src/gitsh.rb.in
@@ -1,12 +1,15 @@
 $LOAD_PATH.unshift('@rubylibdir@')
 
 require '@gemsetuppath@'
-require 'gitsh/environment'
 require 'gitsh/cli'
+require 'gitsh/environment'
+require 'gitsh/registry'
 
 begin
-  env = Gitsh::Environment.new(config_directory: '@pkgsysconfdir@')
-  Gitsh::CLI.new(env: env).run
+  Gitsh::Registry[:env] = Gitsh::Environment.new(
+    config_directory: '@pkgsysconfdir@',
+  )
+  Gitsh::CLI.new.run
 rescue => e
   $stderr.puts "gitsh: Error: #{e.message}"
   exit 1

--- a/src/gitsh.rb.in
+++ b/src/gitsh.rb.in
@@ -16,7 +16,7 @@ begin
   Gitsh::Registry[:line_editor] = Gitsh::LineEditorHistoryFilter.new(
     Gitsh::LineEditor,
   )
-  Gitsh::CLI.new.run
+  Gitsh::CLI.new(ARGV).run
 rescue => e
   $stderr.puts "gitsh: Error: #{e.message}"
   exit 1


### PR DESCRIPTION
## What?

This PR is a large refactor which replaces dependency injection with the [registry pattern][1] for shared instances, or direct references to class names that were previously passed as constructor arguments. 

Previously we had a lot of classes that looked like this:

```ruby
class Foo
  def initialize(env, bar_factory = Gitsh::Bar)
    @bar = bar_factory.new(env)
    @env = env
  end

  private

  attr_reader :bar, :env
end
```

Now, those same classes look like this:

```ruby
class Foo
  extend Registry::Client
  use_registry_for :env

  def initialize
    @bar = Gitsh::Bar.new
  end

  private

  attr_reader :bar
end
```

The objects moved to the registry are the shared instances of:

- `Gitsh::Environment`
- `Gitsh::GitRepository`
- `Gitsh::LineEditorHistoryFilter` (decorating `Gitsh::LineEditor`)

[1]: https://mattbrictson.com/registry-pattern

## Why?

The nature of gitsh means that some amount of long-lasting, global state is inevitable. Unlike a Web application, which needs to handle multiple concurrent requests from different users, a gitsh process only runs a single command at any given time, and does so for a single user in a single session.

We get a lot of benefits from this approach, which include:

- **Fewer redundant arguments**

    There were several classes which held a reference to the shared `Gitsh::Environment` instance only because they needed to pass it along to some other object that needed to use it.

- **Easier to break up `Gitsh::Environment`**

    The `Gitsh::Environment` has become a bit of a junk drawer. The main reason is that it was the one object that was available everywhere, so access to any shared state was easiest if it went through this object.

    Introducing the registry means we are able to drop all of the `Gitsh::Environment#repo_*` methods (which delegated directly to a `Gitsh::GitRepository` instance) and instead share both the `Gitsh::Environment` and `Gitsh::GitRepository` via the registry.

   The remaining responsibilities of `Gitsh::Environment` (I/O, variable access, and access to some global config) can be broken out in future PRs.

- **Easier to share other instances**

    The final straw in doing this refactor was starting work on globbing patterns (#145), and realising we will need to access the tab completion automaton while evaluating variable values. Adding yet another thing to the environment was not appealing, nor was passing another instance around through the whole system, or building multiple instances of a pretty large tab completion graph.

    After this refactor, we'll be able to use the registry to share the tab completion automaton instance, and easily access it directly from where it's needed.

### Code review

This diff is very large (~1,000 changed lines), but many of the changes are very similar and reviewers should probably focus on:

- The `Gitsh::Registry` implementation in `lib/gitsh/registry.rb`
- The new test helpers in ` spec/support/registry.rb`