### PR TITLE
Update READLINE_ARCH

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,4 +158,4 @@ When updating Rubygems for gitsh, there are a few things to consider:
 - Use the minimum supported Ruby version when updating gems to avoid
   installing versions that are incompatible with older Rubies.
 
-[style-guide]: https://github.com/thoughtbot/guides/tree/master/style#ruby
+[style-guide]: https://github.com/thoughtbot/guides/tree/master/ruby

--- a/homebrew/gitsh.rb.in
+++ b/homebrew/gitsh.rb.in
@@ -44,6 +44,6 @@ class Gitsh < Formula
   end
 
   def set_architecture
-    ENV['READLINE_ARCH'] = "-arch #{MacOS.preferred_arch}"
+    ENV['READLINE_ARCH'] = "-arch #{Hardware::CPU.arch}"
   end
 end


### PR DESCRIPTION
Submitting here because the [thoughtbot/homebrew-formulae](https://github.com/thoughtbot/homebrew-formulae) README says to submit pull requests against the respective repos.

Calling `MacOS.preferred_arch` triggers the following warning during installation:
```
Warning: Calling MacOS.preferred_arch is deprecated! Use Hardware::CPU.arch (or ideally let the compiler handle it) instead.Please report this issue to the thoughtbot/formulae tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:  /usr/local/Homebrew/Library/Taps/thoughtbot/homebrew-formulae/Formula/gitsh.rb:47
```

I also updated the link to thoughtbot's Ruby style guide in `CONTRIBUTING`.