### PR TITLE
Fix failing specs due to default branch name hint

### DIFF
--- a/spec/integration/chaining_spec.rb
+++ b/spec/integration/chaining_spec.rb
@@ -70,7 +70,9 @@ describe 'Chaining methods' do
     end
 
     it 'allows the right hand side to be blank' do
-      GitshRunner.interactive do |gitsh|
+      GitshRunner.interactive(
+        settings: { "init.defaultBranch" => "master" }
+      ) do |gitsh|
         gitsh.type('init;')
         expect(gitsh).to output_no_errors
         expect(gitsh).to output(/Initialized/)

--- a/spec/integration/correction_spec.rb
+++ b/spec/integration/correction_spec.rb
@@ -3,7 +3,9 @@ require 'spec_helper'
 describe 'Correcting input' do
   context 'when help.autocorrect is enabled' do
     it 'removes the git prefix from a command' do
-      GitshRunner.interactive do |gitsh|
+      GitshRunner.interactive(
+        settings: { "init.defaultBranch" => "master" }
+      ) do |gitsh|
         gitsh.type ':set help.autocorrect 1'
         gitsh.type 'git init'
 

--- a/spec/integration/create_repository_spec.rb
+++ b/spec/integration/create_repository_spec.rb
@@ -3,7 +3,9 @@ require 'gitsh/cli'
 
 describe 'Creating a repository' do
   it 'is possible through the gish CLI' do
-    GitshRunner.interactive do |gitsh|
+    GitshRunner.interactive(
+      settings: { "init.defaultBranch" => "master" }
+    ) do |gitsh|
       expect(gitsh).to prompt_with "#{cwd_basename} uninitialized!! "
 
       gitsh.type('init')

--- a/spec/integration/tab_completion_spec.rb
+++ b/spec/integration/tab_completion_spec.rb
@@ -55,7 +55,9 @@ describe 'Completing things with tab' do
   end
 
   it 'completes commands after operators' do
-    GitshRunner.interactive do |gitsh|
+    GitshRunner.interactive(
+      settings: { "init.defaultBranch" => "master" }
+    ) do |gitsh|
       gitsh.type("init && :ec\t Hello")
 
       expect(gitsh).to output_no_errors


### PR DESCRIPTION
Some specs including 'init' command are failing due to default branch name hint.

(There is still one more spec failing, however, it has nothing to do with the `hint`.)