### PR TITLE
fix build for recent... macos? readline? ruby?

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     coderay (1.1.2)
     diff-lcs (1.3)
-    ffi (1.10.0)
+    ffi (1.17.0)
     filigree (0.3.3)
     method_source (0.9.2)
     pry (0.12.2)
@@ -33,3 +33,6 @@ DEPENDENCIES
   pry
   rltk
   rspec
+
+BUNDLED WITH
+   2.5.23

--- a/ext/gitsh/src/line_editor.c
+++ b/ext/gitsh/src/line_editor.c
@@ -1164,7 +1164,7 @@ readline_s_set_completer_word_break_characters(VALUE self, VALUE str)
  * Raises NotImplementedError if the using readline library does not support.
  */
 static VALUE
-readline_s_get_completer_word_break_characters(VALUE self, VALUE str)
+readline_s_get_completer_word_break_characters(VALUE str)
 {
     if (rl_completer_word_break_characters == NULL)
         return Qnil;
@@ -1282,7 +1282,7 @@ readline_s_set_completer_quote_characters(VALUE self, VALUE str)
  * Raises NotImplementedError if the using readline library does not support.
  */
 static VALUE
-readline_s_get_completer_quote_characters(VALUE self, VALUE str)
+readline_s_get_completer_quote_characters(VALUE str)
 {
     if (rl_completer_quote_characters == NULL)
         return Qnil;


### PR DESCRIPTION
got these errors on macos 14 with ruby 3.2 and 3.3 and readline 8.2, not sure which one is the culprit, my C skills are almost nonexistent but i powered through!

```
src/line_editor.c:1622:5: error: incompatible function pointer types passing 'VALUE (VALUE, VALUE)' (aka 'unsigned long (unsigned long, unsigned long)') to parameter of type 'VALUE (*)(VALUE)' (aka 'unsigned long (*)(unsigned long)') [-Wincompatible-function-pointer-types]
    rb_define_singleton_method(mLineEditor, "completer_word_break_characters",
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/line_editor.c:1626:5: error: incompatible function pointer types passing 'VALUE (VALUE, VALUE)' (aka 'unsigned long (unsigned long, unsigned long)') to parameter of type 'VALUE (*)(VALUE)' (aka 'unsigned long (*)(unsigned long)') [-Wincompatible-function-pointer-types]
    rb_define_singleton_method(mLineEditor, "completer_quote_characters",
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```